### PR TITLE
fix: stop truncating in-depth responses, check length at send time

### DIFF
--- a/smarter_dev/bot/agents/mention_agent.py
+++ b/smarter_dev/bot/agents/mention_agent.py
@@ -59,6 +59,8 @@ class ConversationalMentionSignature(dspy.Signature):
     **3. Special tool behaviors to know:**
 
     `generate_in_depth_response()`: Only GENERATES text - you MUST call `send_message(result['response'])` after!
+    - Pass along user preferences in your prompt: if they asked for "brief", "detailed", "eli5", etc., include that
+    - If send_message() returns MESSAGE_TOO_LONG error, you need to write a shorter response yourself
     `generate_engagement_plan()`: Use when context is unclear or conversation is complex (3+ people, confusing flow)
 
     ## HOW TO COMMUNICATE


### PR DESCRIPTION
Instead of automatically truncating long messages from the in-depth
response tool, we now:

1. Removed excessive length warnings from InDepthResponseSignature that
   were making the LLM overly cautious about message length
2. Removed automatic truncation from generate_in_depth_response()
3. Added length checking to send_message() and reply_to_message() that
   returns a clear error with instructions to retry with a shorter message
4. Updated mention agent to pass user length/detail preferences to the
   in-depth response tool

This allows the agent to naturally generate appropriately-sized responses
while still enforcing Discord's 2000 character limit at the send layer.