### PR TITLE
Add voice message TTS to bot

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,17 @@ REDIS_URL=redis://:smarter_dev_redis_password@localhost:6380/0
 DISCORD_BOT_TOKEN=your_bot_token_here
 DISCORD_APPLICATION_ID=your_application_id_here
 
+# Discord Voice Message Configuration
+VOICE_TTS_MODEL=gemini-2.5-flash-preview-tts
+VOICE_TTS_VOICE=Kore
+VOICE_TTS_SAMPLE_RATE=24000
+VOICE_TTS_CHANNELS=1
+VOICE_TTS_SAMPLE_WIDTH=2
+VOICE_MAX_INPUT_CHARS=800
+VOICE_WORDS_PER_MINUTE=150
+VOICE_MAX_DURATION_SECONDS=30
+VOICE_OPUS_BITRATE=48k
+
 # API Configuration
 API_SECRET_KEY=your_secret_api_key_here
 API_BASE_URL=http://localhost:8000/api

--- a/Dockerfile.bot
+++ b/Dockerfile.bot
@@ -9,6 +9,7 @@ RUN apt-get update && apt-get install -y \
     libpng-dev \
     libfreetype6-dev \
     curl \
+    ffmpeg \
     procps \
     && rm -rf /var/lib/apt/lists/*
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ These only matter when you exercise the feature:
 | Var | Feature |
 |---|---|
 | `DISCORD_BOT_TOKEN` + `DISCORD_APPLICATION_ID` | The bot connecting to Discord. Without these the bot logs an error and exits cleanly. |
-| `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `GEMINI_API_KEY` | LLM-backed features (mod agent, help, mention, scan synthesis). |
+| `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `GEMINI_API_KEY` | LLM-backed features (mod agent, help, mention, scan synthesis). `GEMINI_API_KEY` is also used for Discord voice message TTS. |
 | `BRAVE_SEARCH_API_KEY` / `JINA_API_KEY` / `YOUTUBE_API_KEY` | Scan tools (search, page reader, YouTube). |
 | `RESEND_API_KEY` | Outbound email (e.g. signup confirmations). Logs a warning and skips if absent. |
 | `SPACES_ACCESS_KEY` / `SPACES_SECRET_KEY` | DigitalOcean Spaces / S3-compatible asset storage. |

--- a/docs/LLM_CONFIG.md
+++ b/docs/LLM_CONFIG.md
@@ -12,6 +12,17 @@ The project uses three model types for different purposes:
 | `medium` | `LLM_MEDIUM_MODEL` | `claude-haiku-4-5-20251001` | Higher quality reasoning (forum agent) |
 | `judge` | `LLM_JUDGE_MODEL` | `gemini/gemini-3.1-flash-lite-preview` | Evaluation/testing |
 
+Discord voice messages use Gemini TTS directly rather than DSPy:
+
+| Environment Variable | Default | Purpose |
+|----------------------|---------|---------|
+| `VOICE_TTS_MODEL` | `gemini-2.5-flash-preview-tts` | Gemini TTS model for voice messages |
+| `VOICE_TTS_VOICE` | `Kore` | Gemini prebuilt TTS voice |
+| `VOICE_MAX_INPUT_CHARS` | `800` | Maximum response text sent to TTS |
+| `VOICE_WORDS_PER_MINUTE` | `150` | Estimated speaking rate for voice response word budget |
+| `VOICE_MAX_DURATION_SECONDS` | `30` | Target maximum spoken duration for voice responses |
+| `VOICE_OPUS_BITRATE` | `48k` | Opus bitrate for the Discord voice attachment |
+
 ## API Keys Required
 
 Add the appropriate API key to your `.env` file:
@@ -73,6 +84,10 @@ Or create a `.env` file:
 LLM_FAST_MODEL=gemini/gemini-3.1-flash-lite-preview
 LLM_MEDIUM_MODEL=claude-haiku-4-5-20251001
 LLM_JUDGE_MODEL=gemini/gemini-3.1-flash-lite-preview
+VOICE_TTS_MODEL=gemini-2.5-flash-preview-tts
+VOICE_TTS_VOICE=Kore
+VOICE_WORDS_PER_MINUTE=150
+VOICE_MAX_DURATION_SECONDS=30
 GEMINI_API_KEY=your_gemini_key_here
 ANTHROPIC_API_KEY=your_anthropic_key_here
 ```

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -34,3 +34,14 @@ data:
   LLM_FAST_MODEL: "gemini/gemini-3.1-flash-lite-preview"
   LLM_MEDIUM_MODEL: "claude-haiku-4-5-20251001"
   LLM_JUDGE_MODEL: "gemini/gemini-3.1-flash-lite-preview"
+
+  # Discord voice message configuration
+  VOICE_TTS_MODEL: "gemini-2.5-flash-preview-tts"
+  VOICE_TTS_VOICE: "Kore"
+  VOICE_TTS_SAMPLE_RATE: "24000"
+  VOICE_TTS_CHANNELS: "1"
+  VOICE_TTS_SAMPLE_WIDTH: "2"
+  VOICE_MAX_INPUT_CHARS: "800"
+  VOICE_WORDS_PER_MINUTE: "150"
+  VOICE_MAX_DURATION_SECONDS: "30"
+  VOICE_OPUS_BITRATE: "48k"

--- a/smarter_dev/bot/agents/response_agent.py
+++ b/smarter_dev/bot/agents/response_agent.py
@@ -159,7 +159,8 @@ class ResponseAgent(BaseAgent):
         users: list[dict],
         me_info: dict,
         request_id: str = "unknown",
-        personality_hint: str = ""
+        personality_hint: str = "",
+        voice_mode: bool = False,
     ) -> tuple[bool, ResponseAgentOutput]:
         """Generate a response using ReAct with tools.
 
@@ -175,6 +176,7 @@ class ResponseAgent(BaseAgent):
             me_info: Bot info dict
             request_id: Request ID for tracing
             personality_hint: Suggested personality/tone for casual conversations
+            voice_mode: Capture response text for voice synthesis instead of sending text
 
         Returns:
             Tuple of (success, ResponseAgentOutput)
@@ -189,12 +191,31 @@ class ResponseAgent(BaseAgent):
         )
 
         try:
+            if voice_mode:
+                from smarter_dev.shared.config import get_settings
+
+                settings = get_settings()
+                max_words = max(
+                    1,
+                    int(
+                        settings.voice_words_per_minute
+                        * settings.voice_max_duration_seconds
+                        / 60
+                    ),
+                )
+                personality_hint = (
+                    f"{personality_hint or 'friendly and helpful'} "
+                    f"For voice mode, keep the final response under {max_words} words."
+                )
+
             # Create context-bound tools for this response
             logger.debug(f"[{request_id}] Creating response tools...")
+            voice_response_parts: list[str] | None = [] if voice_mode else None
             tools, _channel_queries = create_response_tools(
                 bot=bot,
                 channel_id=str(channel_id),
-                guild_id=str(guild_id)
+                guild_id=str(guild_id),
+                voice_response_parts=voice_response_parts,
             )
             logger.debug(f"[{request_id}] Created {len(tools)} tools")
 
@@ -223,6 +244,8 @@ class ResponseAgent(BaseAgent):
 
             # Parse structured output
             output = ResponseAgentOutput.from_agent_result(result)
+            if voice_response_parts:
+                output.response_text = "\n\n".join(voice_response_parts).strip()
 
             # Extract token usage
             tokens_used = self._extract_token_usage(result)

--- a/smarter_dev/bot/agents/tools.py
+++ b/smarter_dev/bot/agents/tools.py
@@ -700,7 +700,13 @@ def with_failure_tracking(tool_name: str, tool_func: Callable, critical: bool = 
     return wrapped
 
 
-def create_mention_tools(bot, channel_id: str, guild_id: str, trigger_message_id: str) -> tuple[list[Callable], list[str]]:
+def create_mention_tools(
+    bot,
+    channel_id: str,
+    guild_id: str,
+    trigger_message_id: str,
+    voice_response_parts: list[str] | None = None,
+) -> tuple[list[Callable], list[str]]:
     """Create context-bound Discord interaction tools for a mention agent.
 
     All returned tools are bound to the specific channel and guild where the
@@ -711,6 +717,8 @@ def create_mention_tools(bot, channel_id: str, guild_id: str, trigger_message_id
         channel_id: Channel where the mention occurred (string)
         guild_id: Guild where the mention occurred (string)
         trigger_message_id: ID of the message that triggered the mention
+        voice_response_parts: Optional sink for voice-mode responses. When set,
+            response send tools capture text instead of posting it to Discord.
 
     Returns:
         Tuple of (List of callable async functions, List of recent search queries in this channel)
@@ -769,6 +777,14 @@ def create_mention_tools(bot, channel_id: str, guild_id: str, trigger_message_id
 
             # Stop typing indicator before sending
             channel_state.typing_active = False
+            if voice_response_parts is not None:
+                voice_response_parts.append(content)
+                channel_state.add_recent_message(content)
+                return {
+                    "success": True,
+                    "result": "Message captured for voice response. Typing indicator stopped.",
+                }
+
             message = await bot.rest.create_message(int(channel_id), content)
 
             # Track the message to prevent duplicates
@@ -840,6 +856,14 @@ def create_mention_tools(bot, channel_id: str, guild_id: str, trigger_message_id
 
             # Stop typing indicator before sending
             channel_state.typing_active = False
+            if voice_response_parts is not None:
+                voice_response_parts.append(content)
+                channel_state.add_recent_message(content)
+                return {
+                    "success": True,
+                    "result": "Reply captured for voice response. Typing indicator stopped.",
+                }
+
             message = await bot.rest.create_message(
                 int(channel_id),
                 content,
@@ -1908,11 +1932,11 @@ def create_mention_tools(bot, channel_id: str, guild_id: str, trigger_message_id
             # Track the planning call for this invocation
             invocation_searches[plan_key] = current_time
 
-            # Send status message to channel
-            try:
-                await bot.rest.create_message(int(channel_id), "> -# Planning my response")
-            except Exception as e:
-                logger.warning(f"[Tool] Failed to send planning status message: {e}")
+            if voice_response_parts is None:
+                try:
+                    await bot.rest.create_message(int(channel_id), "> -# Planning my response")
+                except Exception as e:
+                    logger.warning(f"[Tool] Failed to send planning status message: {e}")
 
             # Build FULL context (20 messages) for strategic planning
             context_builder = ConversationContextBuilder(
@@ -2035,11 +2059,11 @@ def create_mention_tools(bot, channel_id: str, guild_id: str, trigger_message_id
                     "cooldown_remaining": int(remaining)
                 }
 
-            # Send status message to channel with the provided summary
-            try:
-                await bot.rest.create_message(int(channel_id), f'> -# Writing a response for "{prompt_summary}"')
-            except Exception as e:
-                logger.warning(f"[Tool] Failed to send in-depth response status message: {e}")
+            if voice_response_parts is None:
+                try:
+                    await bot.rest.create_message(int(channel_id), f'> -# Writing a response for "{prompt_summary}"')
+                except Exception as e:
+                    logger.warning(f"[Tool] Failed to send in-depth response status message: {e}")
 
             # Get fast model for in-depth response generation
             claude_lm = get_llm_model("fast")
@@ -2101,12 +2125,12 @@ def create_mention_tools(bot, channel_id: str, guild_id: str, trigger_message_id
         try:
             logger.debug(f"[Tool] report_behavior called in channel {channel_id}: {classification}")
 
-            # Send thought message to channel
-            thought_message = f"> -# Ignoring {classification}"
-            try:
-                await bot.rest.create_message(int(channel_id), thought_message)
-            except Exception as e:
-                logger.warning(f"[Tool] Failed to send behavior report message: {e}")
+            if voice_response_parts is None:
+                thought_message = f"> -# Ignoring {classification}"
+                try:
+                    await bot.rest.create_message(int(channel_id), thought_message)
+                except Exception as e:
+                    logger.warning(f"[Tool] Failed to send behavior report message: {e}")
 
             return {
                 "success": True,
@@ -2154,7 +2178,12 @@ def create_mention_tools(bot, channel_id: str, guild_id: str, trigger_message_id
     return tools, channel_queries
 
 
-def create_response_tools(bot, channel_id: str, guild_id: str) -> tuple[list[Callable], list[str]]:
+def create_response_tools(
+    bot,
+    channel_id: str,
+    guild_id: str,
+    voice_response_parts: list[str] | None = None,
+) -> tuple[list[Callable], list[str]]:
     """Create context-bound Discord interaction tools for a response agent.
 
     This returns a subset of tools suitable for the response agent in the
@@ -2166,6 +2195,7 @@ def create_response_tools(bot, channel_id: str, guild_id: str) -> tuple[list[Cal
         bot: Discord bot instance (lightbulb.BotApp)
         channel_id: Channel where the mention occurred (string)
         guild_id: Guild where the mention occurred (string)
+        voice_response_parts: Optional sink for voice-mode responses.
 
     Returns:
         Tuple of (List of callable async functions, List of recent search queries in this channel)
@@ -2176,7 +2206,8 @@ def create_response_tools(bot, channel_id: str, guild_id: str) -> tuple[list[Cal
         bot=bot,
         channel_id=channel_id,
         guild_id=guild_id,
-        trigger_message_id=""
+        trigger_message_id="",
+        voice_response_parts=voice_response_parts,
     )
 
     # Tools to exclude (flow control tools)

--- a/smarter_dev/bot/agents/watcher.py
+++ b/smarter_dev/bot/agents/watcher.py
@@ -126,6 +126,9 @@ class ResponseAgentOutput:
     tokens_used: int
     """Number of tokens consumed by the agent."""
 
+    response_text: str = ""
+    """Text response produced by the agent, used by voice message mode."""
+
     @classmethod
     def from_agent_result(cls, result: Any) -> "ResponseAgentOutput":
         """Parse response agent output from DSPy result.
@@ -168,5 +171,6 @@ class ResponseAgentOutput:
             watching_for=watching_for,
             wait_duration=wait_duration,
             update_frequency=update_frequency,
-            tokens_used=0  # Will be set by caller
+            tokens_used=0,  # Will be set by caller
+            response_text=str(getattr(result, "response", "")).strip(),
         )

--- a/smarter_dev/bot/client.py
+++ b/smarter_dev/bot/client.py
@@ -522,6 +522,7 @@ async def setup_bot_services(bot: lightbulb.BotApp) -> None:
         from smarter_dev.bot.services.advent_of_code_service import (
             AdventOfCodeService,
         )
+        from smarter_dev.bot.services.discord_voice import VoiceService
 
         bytes_service = BytesService(api_client, cache_manager)
         squads_service = SquadsService(api_client, cache_manager)
@@ -535,6 +536,7 @@ async def setup_bot_services(bot: lightbulb.BotApp) -> None:
             api_client, cache_manager, bot
         )
         advent_of_code_service = AdventOfCodeService(api_client, cache_manager, bot)
+        voice_service = VoiceService(api_client, cache_manager, settings)
 
         # Initialize conversation participation services
         channel_state_manager = initialize_channel_state_manager()
@@ -572,6 +574,10 @@ async def setup_bot_services(bot: lightbulb.BotApp) -> None:
         await advent_of_code_service.initialize()
         logger.info("✓ Advent of Code service initialized")
 
+        logger.info("Initializing voice service...")
+        await voice_service.initialize()
+        logger.info("✓ Voice service initialized")
+
         # Verify service health
         logger.info("Verifying service health...")
         try:
@@ -583,6 +589,7 @@ async def setup_bot_services(bot: lightbulb.BotApp) -> None:
             scheduled_message_health = await scheduled_message_service.health_check()
             repeating_message_health = await repeating_message_service.health_check()
             advent_of_code_health = await advent_of_code_service.health_check()
+            voice_health = await voice_service.health_check()
 
             logger.info(
                 f"Bytes service health: {'healthy' if bytes_health.is_healthy else 'unhealthy'}"
@@ -607,6 +614,10 @@ async def setup_bot_services(bot: lightbulb.BotApp) -> None:
             )
             logger.info(
                 f"Advent of Code service health: {'healthy' if advent_of_code_health.is_healthy else 'unhealthy'}"
+            )
+
+            logger.info(
+                f"Voice service health: {'healthy' if voice_health.is_healthy else 'unhealthy'}"
             )
 
             if not bytes_health.is_healthy:
@@ -639,6 +650,10 @@ async def setup_bot_services(bot: lightbulb.BotApp) -> None:
                 logger.warning(
                     f"Advent of Code service not healthy: {advent_of_code_health.details}"
                 )
+            if not voice_health.is_healthy:
+                logger.warning(
+                    f"Voice service not healthy: {voice_health.details}"
+                )
 
         except Exception as e:
             logger.error(f"Failed to check service health: {e}")
@@ -658,6 +673,7 @@ async def setup_bot_services(bot: lightbulb.BotApp) -> None:
         bot.d["repeating_message_service"] = repeating_message_service
         bot.d["advent_of_code_service"] = advent_of_code_service
         bot.d["channel_state_manager"] = channel_state_manager
+        bot.d["voice_service"] = voice_service
 
         # Store services in d for plugin access (primary)
         bot.d["_services"] = {
@@ -670,6 +686,7 @@ async def setup_bot_services(bot: lightbulb.BotApp) -> None:
             "repeating_message_service": repeating_message_service,
             "advent_of_code_service": advent_of_code_service,
             "channel_state_manager": channel_state_manager,
+            "voice_service": voice_service,
         }
 
         logger.info("✓ Bot services setup complete")

--- a/smarter_dev/bot/plugins/mention.py
+++ b/smarter_dev/bot/plugins/mention.py
@@ -152,6 +152,10 @@ async def handle_mention(event: hikari.MessageCreateEvent) -> None:
             user_question = user_question.replace(f"<@{user_id}>", "").replace(f"<@!{user_id}>", "")
     user_question = user_question.strip()
 
+    is_voice = "VOICE" in user_question
+    if is_voice:
+        user_question = user_question.replace("VOICE", "").strip()
+
     # Check for stop/dismissal request before anything else (zero LLM cost)
     if is_stop_request(event.content or ""):
         killed = await kill_channel_watchers(event.channel_id)
@@ -189,6 +193,11 @@ async def handle_mention(event: hikari.MessageCreateEvent) -> None:
             trigger_message_id=event.message.id,
             limit=CONTEXT_MESSAGE_LIMIT
         )
+        if is_voice:
+            context["conversation_timeline"] = context["conversation_timeline"].replace(
+                "VOICE",
+                "",
+            )
         logger.debug(f"[{request_id}] Context built: {len(context['conversation_timeline'])} chars timeline")
 
         # Step 1: Run classification agent
@@ -236,7 +245,8 @@ async def handle_mention(event: hikari.MessageCreateEvent) -> None:
                 event.guild_id,
                 classification.matched_watcher_id,
                 event.message.id,
-                classification
+                classification,
+                voice_requested=is_voice,
             )
             return
 
@@ -261,7 +271,8 @@ async def handle_mention(event: hikari.MessageCreateEvent) -> None:
             channel_info=context["channel"],
             users=context["users"],
             me_info=context["me"],
-            request_id=request_id
+            request_id=request_id,
+            voice_mode=is_voice,
         )
 
         # Cleanup: Ensure typing indicator is stopped after response agent completes
@@ -282,6 +293,35 @@ async def handle_mention(event: hikari.MessageCreateEvent) -> None:
         if not success:
             logger.warning(f"[{request_id}] Response agent failed - exiting pipeline")
             return
+
+        if is_voice:
+            voice_service = getattr(plugin.bot, "d", {}).get("voice_service")
+            if not voice_service:
+                voice_service = (
+                    getattr(plugin.bot, "d", {}).get("_services", {}).get("voice_service")
+                )
+            if not voice_service:
+                logger.error(f"[{request_id}] Voice service unavailable")
+                await plugin.bot.rest.create_message(
+                    event.channel_id,
+                    "Voice messages are not available right now.",
+                    reply=event.message,
+                )
+                return
+            try:
+                await voice_service.synthesize_and_send(
+                    bot=plugin.bot,
+                    channel_id=event.channel_id,
+                    text=output.response_text,
+                    reply_to_message_id=event.message.id,
+                )
+            except Exception:
+                logger.exception(f"[{request_id}] Voice synthesis failed")
+                await plugin.bot.rest.create_message(
+                    event.channel_id,
+                    output.response_text[:2000],
+                    reply=event.message,
+                )
 
         # Step 3: Create watcher if continuing
         if output.continue_watching:
@@ -358,7 +398,8 @@ async def trigger_watcher_immediately(
     guild_id: int,
     watcher_id: str,
     message_id: int,
-    classification
+    classification,
+    voice_requested: bool = False,
 ) -> None:
     """Trigger an existing watcher immediately with a new mention.
 
@@ -393,7 +434,8 @@ async def trigger_watcher_immediately(
         "author_id": "",  # Will be filled from context
         "content": classification.intent,
         "timestamp": datetime.now(UTC),
-        "is_mention": True
+        "is_mention": True,
+        "voice_requested": voice_requested,
     })
 
     logger.info(f"Triggered watcher {watcher_id} immediately with message {message_id}")

--- a/smarter_dev/bot/services/discord_voice.py
+++ b/smarter_dev/bot/services/discord_voice.py
@@ -1,0 +1,383 @@
+"""Discord voice message service."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import math
+import re
+import shutil
+import struct
+import subprocess
+import tempfile
+import wave
+from datetime import UTC
+from datetime import datetime
+from pathlib import Path
+
+import aiohttp
+from google.genai import types
+
+from smarter_dev.bot.services.base import APIClientProtocol
+from smarter_dev.bot.services.base import BaseService
+from smarter_dev.bot.services.base import CacheManagerProtocol
+from smarter_dev.bot.services.models import ServiceHealth
+from smarter_dev.llm_config import get_gemini_client_for_tts
+from smarter_dev.shared.config import Settings
+from smarter_dev.shared.config import get_settings
+
+DISCORD_API_BASE = "https://discord.com/api/v10"
+VOICE_MESSAGE_FLAG = 8192
+MARKDOWN_RE = re.compile(r"[*_`>#]")
+
+
+async def discord_request(
+    session: aiohttp.ClientSession,
+    method: str,
+    url: str,
+    token: str,
+    *,
+    json: dict | None = None,
+) -> dict:
+    async with session.request(
+        method,
+        url,
+        json=json,
+        headers={
+            "Authorization": f"Bot {token}",
+            "Content-Type": "application/json",
+        },
+    ) as resp:
+        text = await resp.text()
+        if resp.status < 200 or resp.status >= 300:
+            raise RuntimeError(f"Discord error {resp.status}: {text}")
+        return await resp.json()
+
+
+async def send_voice_message(
+    token: str,
+    channel_id: int,
+    ogg_bytes: bytes,
+    duration: float,
+    waveform: str,
+    reply_to_message_id: int | None = None,
+) -> None:
+    file_size = len(ogg_bytes)
+
+    async with aiohttp.ClientSession() as session:
+        res = await discord_request(
+            session,
+            "POST",
+            f"{DISCORD_API_BASE}/channels/{channel_id}/attachments",
+            token,
+            json={
+                "files": [{
+                    "filename": "voice-message.ogg",
+                    "file_size": file_size,
+                    "id": "0",
+                }]
+            },
+        )
+        attachment = res["attachments"][0]
+
+        async with session.put(
+            attachment["upload_url"],
+            data=ogg_bytes,
+            headers={"Content-Type": "audio/ogg"},
+        ) as up:
+            if up.status < 200 or up.status >= 300:
+                raise RuntimeError(await up.text())
+
+        message_payload = {
+            "flags": VOICE_MESSAGE_FLAG,
+            "attachments": [{
+                "id": "0",
+                "filename": "voice-message.ogg",
+                "uploaded_filename": attachment["upload_filename"],
+                "duration_secs": duration,
+                "waveform": waveform,
+            }],
+        }
+        if reply_to_message_id:
+            message_payload["message_reference"] = {
+                "channel_id": str(channel_id),
+                "message_id": str(reply_to_message_id),
+            }
+
+        await discord_request(
+            session,
+            "POST",
+            f"{DISCORD_API_BASE}/channels/{channel_id}/messages",
+            token,
+            json=message_payload,
+        )
+
+
+def write_wave_file(
+    filename: Path,
+    pcm: bytes,
+    sample_rate: int,
+    channels: int,
+    sample_width: int,
+) -> None:
+    with wave.open(str(filename), "wb") as wf:
+        wf.setnchannels(channels)
+        wf.setsampwidth(sample_width)
+        wf.setframerate(sample_rate)
+        wf.writeframes(pcm)
+
+
+def pcm_duration_secs(
+    pcm: bytes,
+    sample_rate: int,
+    channels: int,
+    sample_width: int,
+) -> float:
+    bytes_per_second = sample_rate * channels * sample_width
+    return len(pcm) / bytes_per_second
+
+
+async def convert_wav_to_opus_ogg(
+    wav_path: Path,
+    ogg_path: Path,
+    bitrate: str,
+) -> None:
+    ffmpeg = get_ffmpeg_exe()
+    process = await asyncio.create_subprocess_exec(
+        ffmpeg,
+        "-y",
+        "-i",
+        str(wav_path),
+        "-c:a",
+        "libopus",
+        "-b:a",
+        bitrate,
+        "-vbr",
+        "on",
+        str(ogg_path),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    _, stderr = await process.communicate()
+    if process.returncode != 0:
+        error = stderr.decode("utf-8", errors="replace")
+        raise RuntimeError(f"ffmpeg failed: {error}")
+
+
+def get_ffmpeg_exe() -> str:
+    ffmpeg = shutil.which("ffmpeg")
+    if ffmpeg:
+        return ffmpeg
+
+    try:
+        import imageio_ffmpeg
+    except ImportError as e:
+        raise RuntimeError(
+            "ffmpeg is required for Discord voice messages. Install ffmpeg or "
+            "the imageio-ffmpeg package."
+        ) from e
+
+    return imageio_ffmpeg.get_ffmpeg_exe()
+
+
+def waveform_from_pcm(
+    pcm: bytes,
+    sample_width: int,
+    samples: int = 128,
+) -> str:
+    if not pcm:
+        return base64.b64encode(bytes([0] * samples)).decode("ascii")
+
+    frame_count = len(pcm) // sample_width
+    amplitudes = struct.unpack(
+        f"<{frame_count}h",
+        pcm[: frame_count * sample_width],
+    )
+    bucket_size = max(1, math.ceil(frame_count / samples))
+    waveform = []
+
+    for offset in range(0, frame_count, bucket_size):
+        bucket = amplitudes[offset : offset + bucket_size]
+        if bucket:
+            peak = max(abs(sample) for sample in bucket)
+            waveform.append(min(255, round((peak / 32767) * 255)))
+
+    waveform = waveform[:samples]
+    if len(waveform) < samples:
+        waveform.extend([0] * (samples - len(waveform)))
+
+    return base64.b64encode(bytes(waveform)).decode("ascii")
+
+
+def generate_tts_pcm(
+    transcript: str,
+    model_name: str,
+    voice_name: str,
+) -> bytes:
+    client, model = get_gemini_client_for_tts(model_name)
+    prompt = f"Synthesize speech:\n{transcript}"
+    response = client.models.generate_content(
+        model=model,
+        contents=prompt,
+        config=types.GenerateContentConfig(
+            response_modalities=["AUDIO"],
+            speech_config=types.SpeechConfig(
+                voice_config=types.VoiceConfig(
+                    prebuilt_voice_config=types.PrebuiltVoiceConfig(
+                        voice_name=voice_name,
+                    )
+                )
+            ),
+        ),
+    )
+
+    part = response.candidates[0].content.parts[0]
+
+    if not part.inline_data:
+        raise ValueError(f"No audio returned: {response}")
+
+    data = part.inline_data.data
+    if isinstance(data, bytes):
+        return data
+
+    data += "=" * (-len(data) % 4)
+    return base64.b64decode(data)
+
+
+def clean_transcript_for_tts(text: str) -> str:
+    text = MARKDOWN_RE.sub("", text)
+    text = text.replace("–", "-").replace("—", "-")
+    text = text.replace("$", " dollars ").replace("%", " percent ")
+    lines = [line.strip(" -•\t") for line in text.splitlines()]
+    return " ".join(line for line in lines if line).strip()
+
+
+class VoiceService(BaseService):
+    def __init__(
+        self,
+        api_client: APIClientProtocol,
+        cache_manager: CacheManagerProtocol | None = None,
+        settings: Settings | None = None,
+    ):
+        super().__init__(api_client, cache_manager, service_name="VoiceService")
+        self._settings = settings or get_settings()
+
+    async def synthesize_and_send(
+        self,
+        bot,
+        channel_id: int,
+        text: str,
+        reply_to_message_id: int | None = None,
+    ) -> None:
+        self._log_operation("synthesize_and_send", channel_id=channel_id)
+
+        text = text.strip()
+        if not text:
+            raise ValueError("Cannot synthesize an empty voice response")
+        text = clean_transcript_for_tts(text)[: self._settings.voice_max_input_chars]
+        token = getattr(bot, "_token", None) or getattr(bot, "token", None)
+        if not token:
+            token = self._settings.discord_bot_token
+
+        try:
+            pcm = await asyncio.to_thread(
+                generate_tts_pcm,
+                text,
+                self._settings.voice_tts_model,
+                self._settings.voice_tts_voice,
+            )
+        except Exception:
+            self._logger.warning("TTS generation failed, retrying shorter text", exc_info=True)
+            pcm = await asyncio.to_thread(
+                generate_tts_pcm,
+                text[:400],
+                self._settings.voice_tts_model,
+                self._settings.voice_tts_voice,
+            )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            wav = Path(tmp) / "voice.wav"
+            ogg = Path(tmp) / "voice.ogg"
+
+            await asyncio.to_thread(
+                write_wave_file,
+                wav,
+                pcm,
+                self._settings.voice_tts_sample_rate,
+                self._settings.voice_tts_channels,
+                self._settings.voice_tts_sample_width,
+            )
+            await convert_wav_to_opus_ogg(
+                wav,
+                ogg,
+                self._settings.voice_opus_bitrate,
+            )
+
+            await send_voice_message(
+                token=str(token),
+                channel_id=channel_id,
+                ogg_bytes=ogg.read_bytes(),
+                duration=pcm_duration_secs(
+                    pcm,
+                    self._settings.voice_tts_sample_rate,
+                    self._settings.voice_tts_channels,
+                    self._settings.voice_tts_sample_width,
+                ),
+                waveform=waveform_from_pcm(
+                    pcm,
+                    self._settings.voice_tts_sample_width,
+                ),
+                reply_to_message_id=reply_to_message_id,
+            )
+
+    async def health_check(self) -> ServiceHealth:
+        try:
+            _, model = get_gemini_client_for_tts(self._settings.voice_tts_model)
+            get_ffmpeg_exe()
+            return ServiceHealth(
+                service_name=self.service_name,
+                is_healthy=True,
+                last_check=datetime.now(UTC),
+                details={
+                    "tts_model": model,
+                    "tts_voice": self._settings.voice_tts_voice,
+                    "max_input_chars": self._settings.voice_max_input_chars,
+                },
+            )
+        except Exception as e:
+            return ServiceHealth(
+                service_name=self.service_name,
+                is_healthy=False,
+                last_check=datetime.now(UTC),
+                details={"error": str(e)},
+            )
+
+
+_voice_service: VoiceService | None = None
+
+
+def initialize_voice_service() -> VoiceService:
+    global _voice_service
+
+    from smarter_dev.bot.services.api_client import APIClient
+
+    settings = get_settings()
+
+    _voice_service = VoiceService(
+        api_client=APIClient(
+            base_url=settings.api_base_url,
+            api_key=settings.bot_api_key,
+        ),
+        settings=settings,
+    )
+
+    return _voice_service
+
+
+def get_voice_service() -> VoiceService:
+    global _voice_service
+
+    if _voice_service is None:
+        _voice_service = initialize_voice_service()
+
+    return _voice_service

--- a/smarter_dev/bot/services/watch_loop.py
+++ b/smarter_dev/bot/services/watch_loop.py
@@ -33,6 +33,8 @@ WATCH_LOOP_INTERVAL = 5
 # Maximum time a watch loop can run before stopping (prevents runaway loops)
 MAX_LOOP_RUNTIME_SECONDS = 3600  # 1 hour
 
+VOICE_TRIGGER = "VOICE"
+
 
 class WatchLoop:
     """Background task that manages watchers for a channel."""
@@ -165,11 +167,16 @@ class WatchLoop:
         if not watcher.queued_messages:
             return
 
+        is_voice = self._messages_request_voice(watcher.queued_messages)
+        evaluated_messages = [msg.copy() for msg in watcher.queued_messages]
+        if is_voice:
+            for msg in evaluated_messages:
+                msg["content"] = self._strip_voice_trigger(msg.get("content", ""))
+
         # Format messages for evaluation
-        new_messages = self._format_messages_for_evaluation(watcher.queued_messages)
+        new_messages = self._format_messages_for_evaluation(evaluated_messages)
 
         # Clear queued messages (we've consumed them for evaluation)
-        evaluated_messages = watcher.queued_messages.copy()
         watcher.queued_messages = []
 
         # Update last evaluation time
@@ -213,7 +220,8 @@ class WatchLoop:
                 channel_state,
                 evaluated_messages,
                 result.relevant_message_ids,
-                result.personality_hint
+                result.personality_hint,
+                is_voice,
             )
 
     async def _invoke_response_agent(
@@ -222,7 +230,8 @@ class WatchLoop:
         channel_state,
         messages: list[dict],
         relevant_ids: list[str],
-        personality_hint: str = ""
+        personality_hint: str = "",
+        voice_mode: bool = False,
     ) -> None:
         """Invoke the response agent for a watcher.
 
@@ -264,6 +273,8 @@ class WatchLoop:
             # For watcher responses, use the FULL recent conversation timeline
             # Don't filter aggressively - the bot needs to see what was actually said
             relevant_messages = context["conversation_timeline"]
+            if voice_mode:
+                relevant_messages = self._strip_voice_trigger(relevant_messages)
             logger.debug(f"[{request_id}] Context built, invoking response agent...")
 
             # Invoke response agent
@@ -273,13 +284,14 @@ class WatchLoop:
                 channel_id=self.channel_id,
                 guild_id=self.guild_id,
                 relevant_messages=relevant_messages,
-                intent=f"Continue conversation - user said something new",
+                intent="Continue conversation - user said something new",
                 context_summary=f"Watching for: {watcher.context.watching_for}",
                 channel_info=context["channel"],
                 users=context["users"],
                 me_info=context["me"],
                 request_id=request_id,
-                personality_hint=personality_hint
+                personality_hint=personality_hint,
+                voice_mode=voice_mode,
             )
 
             if success:
@@ -287,6 +299,31 @@ class WatchLoop:
                     f"[{request_id}] Response complete: continue_watching={output.continue_watching}, "
                     f"tokens={output.tokens_used}"
                 )
+
+                if voice_mode:
+                    voice_service = getattr(self.bot, "d", {}).get("voice_service")
+                    if not voice_service:
+                        voice_service = (
+                            getattr(self.bot, "d", {}).get("_services", {}).get("voice_service")
+                        )
+                    if not voice_service:
+                        logger.error(f"[{request_id}] Voice service unavailable")
+                    else:
+                        reply_to_message_id = int(relevant_ids[0]) if relevant_ids else None
+                        try:
+                            await voice_service.synthesize_and_send(
+                                bot=self.bot,
+                                channel_id=self.channel_id,
+                                text=output.response_text,
+                                reply_to_message_id=reply_to_message_id,
+                            )
+                        except Exception:
+                            logger.exception(f"[{request_id}] Voice synthesis failed")
+                            await self.bot.rest.create_message(
+                                self.channel_id,
+                                output.response_text[:2000],
+                                reply=reply_to_message_id,
+                            )
 
                 if output.continue_watching:
                     # Update watcher for continued monitoring
@@ -315,6 +352,15 @@ class WatchLoop:
             watcher.is_responding = False
             watcher.response_lock.release()
             logger.debug(f"[{request_id}] === WATCHER COMPLETE ===")
+
+    def _messages_request_voice(self, messages: list[dict]) -> bool:
+        return any(
+            msg.get("voice_requested") or VOICE_TRIGGER in (msg.get("content") or "")
+            for msg in messages
+        )
+
+    def _strip_voice_trigger(self, text: str) -> str:
+        return text.replace(VOICE_TRIGGER, "").strip()
 
     def _format_messages_for_evaluation(self, messages: list[dict]) -> str:
         """Format messages for the evaluation agent.

--- a/smarter_dev/llm_config.py
+++ b/smarter_dev/llm_config.py
@@ -7,6 +7,7 @@ project using environment variables.
 import os
 import dotenv
 import dspy
+from google import genai
 from typing import Optional
 
 
@@ -106,6 +107,18 @@ def get_model_info(model_type: str = "fast") -> dict:
         "has_api_key": bool(api_key),
         "env_var": env_var,
     }
+
+
+def get_gemini_client_for_tts(model_name: str | None = None):
+    """Return Gemini client for TTS (not handled by DSPy)."""
+    if model_name is None:
+        from smarter_dev.shared.config import get_settings
+
+        model_name = get_settings().voice_tts_model
+    api_key = os.getenv("GEMINI_API_KEY") or dotenv.get_key(".env", "GEMINI_API_KEY")
+    if model_name.startswith("gemini/"):
+        model_name = model_name.removeprefix("gemini/")
+    return genai.Client(api_key=api_key), model_name
 
 
 def _get_provider_from_model(model_name: str) -> str:

--- a/smarter_dev/shared/config.py
+++ b/smarter_dev/shared/config.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 from typing import Optional
 
 from pydantic import Field
@@ -51,6 +50,44 @@ class Settings(BaseSettings):
     discord_application_id: str = Field(
         default="",
         description="Discord application ID",
+    )
+
+    # Discord Voice Messages
+    voice_tts_model: str = Field(
+        default="gemini-2.5-flash-preview-tts",
+        description="Gemini TTS model for Discord voice messages",
+    )
+    voice_tts_voice: str = Field(
+        default="Kore",
+        description="Gemini prebuilt voice name for Discord voice messages",
+    )
+    voice_tts_sample_rate: int = Field(
+        default=24000,
+        description="PCM sample rate returned by the configured TTS model",
+    )
+    voice_tts_channels: int = Field(
+        default=1,
+        description="PCM channel count returned by the configured TTS model",
+    )
+    voice_tts_sample_width: int = Field(
+        default=2,
+        description="PCM sample width in bytes returned by the configured TTS model",
+    )
+    voice_max_input_chars: int = Field(
+        default=800,
+        description="Maximum response characters sent to TTS for one voice message",
+    )
+    voice_words_per_minute: int = Field(
+        default=150,
+        description="Estimated spoken words per minute for voice response budgeting",
+    )
+    voice_max_duration_seconds: int = Field(
+        default=30,
+        description="Target maximum spoken duration for one voice response",
+    )
+    voice_opus_bitrate: str = Field(
+        default="48k",
+        description="Opus bitrate used when encoding Discord voice messages",
     )
 
     # API

--- a/tests/bot/agents/response_agent_voice_test.py
+++ b/tests/bot/agents/response_agent_voice_test.py
@@ -1,0 +1,106 @@
+"""Tests for response-agent voice mode behavior."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from smarter_dev.bot.agents import response_agent as response_agent_module
+from smarter_dev.bot.agents.response_agent import ResponseAgent
+
+
+@contextmanager
+def fake_dspy_context(*args, **kwargs):
+    yield
+
+
+class FakeReAct:
+    captured_kwargs: dict | None = None
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def acall(self, **kwargs):
+        FakeReAct.captured_kwargs = kwargs
+        return SimpleNamespace(
+            response="text model response",
+            continue_watching=False,
+            watching_for="",
+            wait_duration=60,
+            update_frequency="1m",
+        )
+
+
+async def test_voice_mode_adds_word_budget_and_captures_response(monkeypatch):
+    agent = ResponseAgent()
+    captured_parts: list[str] | None = None
+
+    def fake_create_response_tools(*, voice_response_parts=None, **kwargs):
+        nonlocal captured_parts
+        captured_parts = voice_response_parts
+        voice_response_parts.append("captured voice response")
+        return [], []
+
+    monkeypatch.setattr(response_agent_module, "create_response_tools", fake_create_response_tools)
+    monkeypatch.setattr(response_agent_module.dspy, "context", fake_dspy_context)
+    monkeypatch.setattr(response_agent_module.dspy, "ReAct", FakeReAct)
+    monkeypatch.setattr(
+        "smarter_dev.shared.config.get_settings",
+        Mock(
+            return_value=SimpleNamespace(
+                voice_words_per_minute=120,
+                voice_max_duration_seconds=15,
+            )
+        ),
+    )
+
+    success, output = await agent.generate_response(
+        bot=Mock(),
+        channel_id=123,
+        guild_id=456,
+        relevant_messages="User asked for a voice reply",
+        intent="Answer briefly",
+        context_summary="Test context",
+        channel_info={},
+        users=[],
+        me_info={},
+        request_id="test",
+        voice_mode=True,
+    )
+
+    assert success is True
+    assert captured_parts == ["captured voice response"]
+    assert output.response_text == "captured voice response"
+    assert "under 30 words" in FakeReAct.captured_kwargs["personality_hint"]
+
+
+async def test_text_mode_does_not_add_voice_budget(monkeypatch):
+    agent = ResponseAgent()
+
+    def fake_create_response_tools(*, voice_response_parts=None, **kwargs):
+        assert voice_response_parts is None
+        return [], []
+
+    monkeypatch.setattr(response_agent_module, "create_response_tools", fake_create_response_tools)
+    monkeypatch.setattr(response_agent_module.dspy, "context", fake_dspy_context)
+    monkeypatch.setattr(response_agent_module.dspy, "ReAct", FakeReAct)
+
+    success, output = await agent.generate_response(
+        bot=Mock(),
+        channel_id=123,
+        guild_id=456,
+        relevant_messages="User asked for a text reply",
+        intent="Answer normally",
+        context_summary="Test context",
+        channel_info={},
+        users=[],
+        me_info={},
+        request_id="test",
+        personality_hint="dry wit",
+        voice_mode=False,
+    )
+
+    assert success is True
+    assert output.response_text == "text model response"
+    assert FakeReAct.captured_kwargs["personality_hint"] == "dry wit"


### PR DESCRIPTION
## Summary

This PR adds voice message functionality to the bot, allowing users to receive responses as discord voice messages instead of text. Voice messages are returned if the message includes the string "VOICE" (case sensitive). It does so by redirecting the output of the text response into the Gemini TTS api, and then returns the voice message by using the discord API.

## Changes

### Voice Service (New)
- Added `smarter_dev/bot/services/discord_voice.py` service for calling the Gemini TTS api, processing the audio with ffmpeg, & returning the audio as a voice message
- Added `discord_voice` to the bot client's `setup_bot_services` function
- Enforces a voice-specific word limit (based on duration + WPM) by modifying the prompt/personality hint in `agents/tools.py`
- Captures the model’s final response into voice_response_parts so it can be passed to TTS instead of sent directly in `agents/tools.py`

### Redirecting Voice Messages
- Added `is_voice` check to `handle_mention` & message watchers in `mention.py` + `watch_loop.py` which if true redirects the output to use the new voice services `synthesize_and_send` method

### Config Additions
- Adds a helper that returns a configured Gemini client and model name for TTS using the API key and settings.
- Added `voice_tts_model`, `voice_tts_voice`, `voice_tts_sample_rate`, `voice_tts_channels`, `voice_tts_sample_width`, `voice_max_input_chars`, `voice_words_per_minute`, `voice_max_duration_seconds`, & `voice_opus_bitrate` to `shared/config.py`
- Added `VOICE_TTS_MODEL`, `VOICE_TTS_VOICE`, `VOICE_TTS_SAMPLE_RATE`, `VOICE_TTS_CHANNELS`, `VOICE_TTS_SAMPLE_WIDTH`, `VOICE_MAX_INPUT_CHARS`, `VOICE_WORDS_PER_MINUTE`, `VOICE_MAX_DURATION_SECONDS`, `VOICE_OPUS_BITRATE` to `configmap.yaml` and `.env.example`

### Dependencies
- Added `ffmpeg` to the `Dockerfile.bot` system dependencies argument

### Documentation Additions
-  Added description of configurable voice message TTS variables to `LLM_CONFIG.md`
- Added clarification in `README.md`s optional secrets overview that the `GEMINI_API_KEY` is also used in the new discord TTS voice message system.

## Tests
- No existing tests regressed, only `tests/web/test_admin/test_auth.py`, `tests/web/test_admin/test_integration.py`, & `tests/web/test_admin/test_integration.py` fail, but these were failing before this PR as well.
- Added `response_agent_voice_test.py` which tests that voice mode enforces a word budget and captures responses for TTS, while text mode behaves normally without modification.

## Notes

- The voice message response uses the raw discord API instead of hikari, as hikari (as of now) does not support voice messages. (so dont be surprised :P)
- To allow longer / shorter messages, you can tweak the `VOICE_WORDS_PER_MINUTE` and `VOICE_MAX_DURATION_SECONDS`. There is a basic calculation that takes the max duration and the WPM to infer roughly how many words the text model should respond with so it doesn't cut out.
- If the user's message is a voice request, the text model will receive instructions to keep its responses below the specified word count that is derived from the `VOICE_WORDS_PER_MINUTE` and `VOICE_MAX_DURATION_SECONDS`