### PR TITLE
feat: durable worker queues (scheduled/timer handlers survive restarts)

### DIFF
--- a/app.development.yaml
+++ b/app.development.yaml
@@ -85,14 +85,16 @@ notifications:
 
 workers:
   enabled: true
-  preset: local
+  # single_node = in-process consumer pool + all-SQLAlchemy (Postgres) backends,
+  # so scheduled/timer jobs are durable and survive a web restart (the old
+  # `local` preset used in-memory queue/state, which wiped pending jobs on
+  # every restart).
+  preset: single_node
   queues:
     - agents
   visibility_timeout: 1800
   execution: in_process
   concurrency: 8
-  backends:
-    event_log: skrift.workers.sqlalchemy:SQLAlchemyEventLog
   imports:
     - smarter_dev.web.resources_agent
     - smarter_dev.web.title_agent

--- a/app.yaml
+++ b/app.yaml
@@ -152,9 +152,17 @@ workers:
   # its default concurrency (also passed explicitly in the manifest).
   concurrency: 8
   backends:
-    # Keep the event log in Postgres so per-run audit trails survive
-    # restarts (the distributed preset would otherwise use Redis). Deep
-    # merge in apply_preset_defaults keeps the Redis queue/state defaults.
+    # Pin queue + state + event log to Postgres so jobs and their state
+    # survive restarts AND a Redis flush (the distributed preset would
+    # otherwise keep them in Redis). This makes scheduled/timer handlers
+    # genuinely durable: a pending fire lives in `worker_queue` until due,
+    # and the recurring re-enqueue chain can't be lost to an ephemeral
+    # Redis. Affects ALL worker jobs (resources/blogging/handlers), which
+    # are low-volume and human-triggered, so Postgres is plenty. The web
+    # pods still only submit (out_of_process); the agent-worker drains the
+    # shared Postgres queue.
+    state_store: skrift.workers.sqlalchemy:SQLAlchemyStateStore
+    queue: skrift.workers.sqlalchemy:SQLAlchemyQueue
     event_log: skrift.workers.sqlalchemy:SQLAlchemyEventLog
   # Handler modules imported by BOTH tiers: the agent-worker imports them
   # to register the @handlers it executes; the web tier imports them so


### PR DESCRIPTION
Pending scheduled/timer fires (and the recurring re-enqueue chain) were lost on restart because the worker queue + state store weren't durable:
- **dev** (`local` preset): in-memory queue/state — wiped on every web restart.
- **prod** (`distributed` preset): Redis queue/state — survives pod restarts, but not a Redis flush.

## Change
- **dev**: `local` → `single_node` (in-process consumer pool + all-SQLAlchemy/Postgres backends).
- **prod**: keep `distributed` (separate agent-worker pod) but pin `queue` + `state_store` + `event_log` to SQLAlchemy, so jobs live in Postgres `worker_queue` until due.

## Verified (dev)
Registered a schedule → its job appeared in `worker_queue` (Postgres) → **restarted web → the job was still there** (under the old preset it vanished). The in-process pool picks it up when due (firing itself was already validated).

## Notes
- Affects **all** worker jobs (resources/blogging/handlers), not just handlers. Volume is low and human-triggered, so Postgres is plenty; `worker_queue`/`worker_state` tables already exist.
- This makes *new* schedules durable; it doesn't retroactively recover a schedule whose job was already lost under the old in-memory setup (re-register those). A startup reconciler that re-arms enabled schedules missing a job would be a good follow-up for full self-healing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)