### PR TITLE
ci: automate app-schema DB migrations on deploy

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -23,6 +23,7 @@ jobs:
         sed -i 's|<IMAGE_VERSION>|'${TAG}'|' $GITHUB_WORKSPACE/k8s/deploy-bot.yaml
         sed -i 's|<IMAGE_VERSION>|'${TAG}'|' $GITHUB_WORKSPACE/k8s/deploy-worker.yaml
         sed -i 's|<IMAGE_VERSION>|'${TAG}'|' $GITHUB_WORKSPACE/k8s/cron-sudo-sweep.yaml
+        sed -i 's|<IMAGE_VERSION>|'${TAG}'|' $GITHUB_WORKSPACE/k8s/migrate-job.yaml
 
     - name: Install doctl
       uses: digitalocean/action-doctl@v2
@@ -55,6 +56,27 @@ jobs:
 
     - name: Apply ConfigMap
       run: kubectl apply -f $GITHUB_WORKSPACE/k8s/configmap.yaml
+
+    # Apply this project's app-schema migrations before rolling the new images,
+    # so the new code never starts against an old schema. Runs in-cluster (the
+    # DB's only trusted source) as a one-shot Job with admin creds. A failed
+    # migration fails this step and halts the deploy (Jobs use backoffLimit 0).
+    - name: Run database migrations
+      run: |
+        kubectl delete job smarter-dev-migrate -n smarter-dev --ignore-not-found
+        kubectl apply -f $GITHUB_WORKSPACE/k8s/migrate-job.yaml
+        echo "waiting for migration job (up to 5 min)..."
+        for i in $(seq 1 60); do
+          COMPLETE=$(kubectl get job smarter-dev-migrate -n smarter-dev -o jsonpath='{.status.conditions[?(@.type=="Complete")].status}' 2>/dev/null || true)
+          FAILED=$(kubectl get job smarter-dev-migrate -n smarter-dev -o jsonpath='{.status.conditions[?(@.type=="Failed")].status}' 2>/dev/null || true)
+          [ "$COMPLETE" = "True" ] || [ "$FAILED" = "True" ] && break
+          sleep 5
+        done
+        kubectl logs job/smarter-dev-migrate -n smarter-dev || true
+        if [ "$COMPLETE" != "True" ]; then
+          echo "::error::migration job did not complete (complete=$COMPLETE failed=$FAILED)"; exit 1
+        fi
+        echo "migrations applied"
 
     - name: Deploy to DigitalOcean Kubernetes
       run: |

--- a/k8s/migrate-job.yaml
+++ b/k8s/migrate-job.yaml
@@ -1,0 +1,66 @@
+# One-shot DB migration job, run by the deploy workflow before rolling the new
+# images. Runs in-cluster (the DB's only trusted source) with the *admin*
+# (doadmin) direct connection, because migrations need DDL/ownership the app
+# role lacks. Admin creds live in the `smarter-dev-migrate-secrets` secret
+# (created out-of-band); every other env mirrors the web deployment so settings
+# load identically. backoffLimit 0 = fail loud (a failed migration fails the
+# deploy step and halts the rollout).
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: smarter-dev-migrate
+  namespace: smarter-dev
+spec:
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 600
+  template:
+    metadata:
+      labels:
+        app: smarter-dev-migrate
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: migrate
+          image: zzmmrmn/smarter-dev-website:<IMAGE_VERSION>
+          workingDir: /app
+          # --only main: apply this project's app-schema migrations (handlers,
+          # sudo, etc.). Skrift-core/legacy migrations are excluded — they load
+          # Skrift's app.yaml (which interpolates many env vars) and change only
+          # on a Skrift upgrade; run those manually when needed.
+          command: ["sh", "-c", "PYTHONPATH=/app uv run --no-sync python scripts/migrate.py --only main"]
+          envFrom:
+            - configMapRef:
+                name: smarter-dev-config
+          env:
+            # DB URLs use the admin (doadmin) direct connection — DDL needs it.
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: smarter-dev-migrate-secrets
+                  key: database-url
+            - name: LEGACY_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: smarter-dev-migrate-secrets
+                  key: legacy-database-url
+            # Everything else mirrors the web deployment so settings load.
+            - name: REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  name: smarter-dev-secrets
+                  key: redis-url
+            - name: API_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: smarter-dev-secrets
+                  key: api-secret-key
+            - name: WEB_SESSION_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: smarter-dev-secrets
+                  key: web-session-secret
+            - name: SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: smarter-dev-secrets
+                  key: secret-key


### PR DESCRIPTION
Migrations were fully manual — CI just builds images and `kubectl apply`s — so schema changes shipped without their migrations (both the handler tables and the sudo two-role migration were overdue in prod, causing the recent breakage).

## Change
- **`k8s/migrate-job.yaml`** — one-shot Job that runs `scripts/migrate.py --only main` **in-cluster** (the DB's only trusted source) using the **admin** (`doadmin`) direct connection from a `smarter-dev-migrate-secrets` secret. `backoffLimit: 0` → fail loud.
- **`deploy.yaml`** — after applying the ConfigMap and before rolling deployments, delete+apply the Job and wait for `Complete` (dumping logs). A non-complete Job **halts the deploy**, so new code never starts against an old schema.

## Scope
`--only main` covers this project's app schema (handlers, sudo, etc.). Skrift-core/legacy steps load Skrift's `app.yaml` (which interpolates many env vars) and only change on a Skrift upgrade — run those manually when needed.

## Prereqs / verification
- Requires the `smarter-dev-migrate-secrets` secret (admin direct URLs for `smarter-dev` + `bc-websites`) — already created in the cluster.
- Default privileges set so `doadmin`-created tables auto-grant DML to the app role (no more permission-denied on new tables).
- Verified in-cluster: the Job runs `--only main` as `doadmin` and completes (idempotent no-op against the now-current schema).

🤖 Generated with [Claude Code](https://claude.com/claude-code)