### PR TITLE
feat: admin page to review registered handlers

### DIFF
--- a/app.development.yaml
+++ b/app.development.yaml
@@ -61,6 +61,7 @@ controllers:
   - smarter_dev.web.jina_cache_admin:JinaCacheAdminController
   - smarter_dev.web.usage_admin:UsageAdminController
   - smarter_dev.web.bot_admin_skrift:BotAdminController
+  - smarter_dev.web.handlers_admin:HandlersAdminController
   - smarter_dev.web.quests_admin:QuestsAdminController
   - smarter_dev.web.chat_conversations_admin:ChatConversationsAdminController
   - smarter_dev.web.mod_actions_admin:ModActionsAdminController

--- a/app.yaml
+++ b/app.yaml
@@ -82,6 +82,7 @@ controllers:
   - smarter_dev.web.jina_cache_admin:JinaCacheAdminController
   - smarter_dev.web.usage_admin:UsageAdminController
   - smarter_dev.web.bot_admin_skrift:BotAdminController
+  - smarter_dev.web.handlers_admin:HandlersAdminController
   - smarter_dev.web.quests_admin:QuestsAdminController
   - smarter_dev.web.chat_conversations_admin:ChatConversationsAdminController
   - smarter_dev.web.mod_actions_admin:ModActionsAdminController

--- a/smarter_dev/web/handlers_admin.py
+++ b/smarter_dev/web/handlers_admin.py
@@ -1,0 +1,169 @@
+"""Admin controller for reviewing registered channel handlers.
+
+A sidebar (guild dropdown + the channels in that guild that have handlers) and a
+content area showing the selected channel's handlers as collapsibles that reveal
+the script. Admin-only; supports deleting a handler (which also cancels any
+queued scheduled job, mirroring the handler API).
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from litestar import Controller, Request, get, post
+from litestar.response import Redirect, Template as TemplateResponse
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from skrift.admin.helpers import get_admin_context
+from skrift.admin.navigation import ADMIN_NAV_TAG
+from skrift.auth.guards import auth_guard, Permission
+from skrift.flash import flash_error, flash_success, get_flash_messages
+
+from smarter_dev.web.admin.discord import get_discord_client
+from smarter_dev.web.models import ChannelHandler
+
+
+class HandlersAdminController(Controller):
+    """Review and delete registered channel handlers in the admin panel."""
+
+    path = "/admin"
+    guards = [auth_guard]
+
+    @get(
+        "/handlers",
+        tags=[ADMIN_NAV_TAG],
+        guards=[auth_guard, Permission("administrator")],
+        opt={"label": "Handlers", "icon": "zap", "order": 65},
+    )
+    async def list_handlers(
+        self,
+        request: Request,
+        db_session: AsyncSession,
+        guild_id: str | None = None,
+        channel_id: str | None = None,
+    ) -> TemplateResponse:
+        ctx = await get_admin_context(request, db_session)
+
+        # Guilds the bot is in, by name. Fall back to the guild ids that have
+        # handlers (shown as ids) if the Discord API is unavailable.
+        client = get_discord_client()
+        try:
+            bot_guilds = await client.get_bot_guilds()
+            guilds = [{"id": g.id, "name": g.name} for g in bot_guilds]
+        except Exception:  # noqa: BLE001 — degrade gracefully without the API
+            flash_error(request, "Couldn't reach Discord; showing guild ids only.")
+            rows = (
+                await db_session.execute(select(ChannelHandler.guild_id).distinct())
+            ).scalars().all()
+            guilds = [{"id": gid, "name": gid} for gid in rows]
+        guilds.sort(key=lambda g: g["name"].lower())
+
+        guild_ids = {g["id"] for g in guilds}
+        selected_guild_id = (
+            guild_id if guild_id in guild_ids else (guilds[0]["id"] if guilds else None)
+        )
+
+        channels: list[dict] = []
+        handlers: list[ChannelHandler] = []
+        selected_channel_id = None
+        selected_channel_name = None
+
+        if selected_guild_id:
+            counts = dict(
+                (
+                    await db_session.execute(
+                        select(ChannelHandler.channel_id, func.count())
+                        .where(ChannelHandler.guild_id == selected_guild_id)
+                        .group_by(ChannelHandler.channel_id)
+                    )
+                ).all()
+            )
+            name_map: dict[str, str] = {}
+            try:
+                for ch in await client.get_guild_channels(selected_guild_id):
+                    name_map[ch.id] = ch.name
+            except Exception:  # noqa: BLE001 — fall back to ids
+                name_map = {}
+            channels = sorted(
+                (
+                    {
+                        "id": cid,
+                        "name": name_map.get(cid, cid),
+                        "count": count,
+                    }
+                    for cid, count in counts.items()
+                ),
+                key=lambda c: c["name"].lower(),
+            )
+
+            channel_ids = set(counts)
+            if channel_id in channel_ids:
+                selected_channel_id = channel_id
+            elif channels:
+                selected_channel_id = channels[0]["id"]
+
+            if selected_channel_id:
+                selected_channel_name = name_map.get(
+                    selected_channel_id, selected_channel_id
+                )
+                handlers = list(
+                    (
+                        await db_session.execute(
+                            select(ChannelHandler)
+                            .where(
+                                ChannelHandler.guild_id == selected_guild_id,
+                                ChannelHandler.channel_id == selected_channel_id,
+                            )
+                            .order_by(
+                                ChannelHandler.trigger_type,
+                                ChannelHandler.created_at,
+                            )
+                        )
+                    ).scalars().all()
+                )
+
+        return TemplateResponse(
+            "admin/handlers/list.html",
+            context={
+                "guilds": guilds,
+                "selected_guild_id": selected_guild_id,
+                "channels": channels,
+                "selected_channel_id": selected_channel_id,
+                "selected_channel_name": selected_channel_name,
+                "handlers": handlers,
+                "flash_messages": get_flash_messages(request),
+                **ctx,
+            },
+        )
+
+    @post(
+        "/handlers/{handler_id:uuid}/delete",
+        guards=[auth_guard, Permission("administrator")],
+    )
+    async def delete_handler(
+        self, request: Request, db_session: AsyncSession, handler_id: UUID
+    ) -> Redirect:
+        record = await db_session.get(ChannelHandler, handler_id)
+        if record is None:
+            flash_error(request, "Handler not found.")
+            return Redirect(path="/admin/handlers")
+
+        guild_id, channel_id = record.guild_id, record.channel_id
+        scheduled_job_id = record.scheduled_job_id
+        await db_session.delete(record)
+        await db_session.commit()
+
+        # Cancel any queued scheduled fire, mirroring the handler API's delete.
+        if scheduled_job_id:
+            try:
+                from skrift.workers import get_handle
+
+                await get_handle(scheduled_job_id).cancel()
+            except Exception:  # noqa: BLE001 — best-effort; the chain self-stops
+                pass
+
+        flash_success(request, "Handler deleted.")
+        return Redirect(
+            path=f"/admin/handlers?guild_id={guild_id}&channel_id={channel_id}"
+        )

--- a/templates/admin/handlers/list.html
+++ b/templates/admin/handlers/list.html
@@ -1,0 +1,125 @@
+{% extends "admin/base.html" %}
+
+{% block title %}Handlers - Admin - {{ site_name() }}{% endblock %}
+
+{% block head %}
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/styles/github-dark.min.css">
+<style>
+  .hx-wrap { display: flex; gap: 1.5rem; align-items: flex-start; }
+  .hx-sidebar { flex: 0 0 260px; max-width: 260px; }
+  .hx-content { flex: 1 1 auto; min-width: 0; }
+  .hx-sidebar select { width: 100%; }
+  .hx-channels { list-style: none; margin: 1rem 0 0; padding: 0; display: flex; flex-direction: column; gap: .25rem; }
+  .hx-channel { display: flex; justify-content: space-between; align-items: center; gap: .5rem;
+                padding: .4rem .6rem; border-radius: .4rem; text-decoration: none; color: inherit;
+                border: 1px solid transparent; }
+  .hx-channel:hover { background: rgba(127,127,127,.12); }
+  .hx-channel.is-active { background: rgba(127,127,127,.18); border-color: rgba(127,127,127,.35); font-weight: 600; }
+  .hx-handler { border: 1px solid rgba(127,127,127,.3); border-radius: .5rem; margin-bottom: .75rem; overflow: hidden; }
+  .hx-handler > summary { cursor: pointer; padding: .65rem .85rem; display: flex; align-items: center; gap: .6rem; }
+  .hx-handler > summary::-webkit-details-marker { display: none; }
+  .hx-desc { flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .hx-body { padding: .25rem .85rem .85rem; border-top: 1px solid rgba(127,127,127,.2); }
+  .hx-meta { display: grid; grid-template-columns: max-content 1fr; gap: .15rem 1rem; margin: .6rem 0; font-size: .9rem; }
+  .hx-meta dt { font-weight: 600; opacity: .75; }
+  .hx-meta dd { margin: 0; }
+  .hx-code { margin: .5rem 0; border-radius: .5rem; max-height: 480px; overflow: auto; }
+  .hx-code code { font-size: .85rem; }
+</style>
+{% endblock %}
+
+{% block admin_content %}
+<hgroup>
+  <h1>Handlers</h1>
+  <p>Registered channel handlers, by guild and channel. Expand one to review its script.</p>
+</hgroup>
+
+{% if flash_messages %}
+<div class="sk-flash-list">
+  {% for msg in flash_messages %}
+  <div class="sk-flash sk-flash-{{ msg.level }}">{{ msg.message }}</div>
+  {% endfor %}
+</div>
+{% endif %}
+
+{% if not guilds %}
+<p class="sk-no-items">The bot isn't in any guilds (or Discord is unreachable).</p>
+{% else %}
+<div class="hx-wrap">
+  <aside class="hx-sidebar">
+    <form method="get" action="/admin/handlers">
+      <label for="guild-select"><strong>Guild</strong></label>
+      <select id="guild-select" name="guild_id" onchange="this.form.submit()">
+        {% for g in guilds %}
+        <option value="{{ g.id }}" {% if g.id == selected_guild_id %}selected{% endif %}>{{ g.name }}</option>
+        {% endfor %}
+      </select>
+      <noscript><button type="submit" class="sk-btn-outline sk-btn-small">Go</button></noscript>
+    </form>
+
+    {% if channels %}
+    <ul class="hx-channels">
+      {% for c in channels %}
+      <li>
+        <a class="hx-channel {% if c.id == selected_channel_id %}is-active{% endif %}"
+           href="/admin/handlers?guild_id={{ selected_guild_id }}&channel_id={{ c.id }}">
+          <span>#{{ c.name }}</span>
+          <span class="sk-pill">{{ c.count }}</span>
+        </a>
+      </li>
+      {% endfor %}
+    </ul>
+    {% else %}
+    <p class="sk-no-items" style="margin-top:1rem;">No channels have handlers in this guild.</p>
+    {% endif %}
+  </aside>
+
+  <section class="hx-content">
+    {% if selected_channel_id %}
+    <h2 style="margin-top:0;">#{{ selected_channel_name }}</h2>
+    {% for h in handlers %}
+    <details class="hx-handler">
+      <summary>
+        <span class="sk-pill">{{ h.trigger_type }}</span>
+        <span class="hx-desc">{{ h.description }}</span>
+        {% if not h.enabled %}<span class="sk-pill sk-pill-draft">disabled</span>{% endif %}
+      </summary>
+      <div class="hx-body">
+        <dl class="hx-meta">
+          <dt>Handler ID</dt><dd><code>{{ h.id }}</code></dd>
+          <dt>Trigger</dt><dd>{{ h.trigger_type }}</dd>
+          <dt>Settings</dt><dd><code>{{ h.settings | tojson }}</code></dd>
+          <dt>Created by</dt><dd>{{ h.created_by }}</dd>
+          <dt>Created</dt><dd>{{ h.created_at.strftime('%Y-%m-%d %H:%M UTC') }}</dd>
+        </dl>
+        <pre class="hx-code"><code class="language-python">{{ h.script }}</code></pre>
+        <form method="post" action="/admin/handlers/{{ h.id }}/delete"
+              onsubmit="return confirm('Delete this handler? This cannot be undone.')">
+          {{ csrf_field() }}
+          <button type="submit" class="sk-btn-outline sk-btn-small sk-btn-danger">Delete handler</button>
+        </form>
+      </div>
+    </details>
+    {% else %}
+    <p class="sk-no-items">No handlers in this channel.</p>
+    {% endfor %}
+    {% else %}
+    <p class="sk-no-items">Select a channel to view its handlers.</p>
+    {% endif %}
+  </section>
+</div>
+{% endif %}
+{% endblock %}
+
+{% block scripts %}
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/highlight.min.js"></script>
+<script>
+  document.addEventListener('DOMContentLoaded', function () {
+    if (window.hljs) {
+      document.querySelectorAll('pre.hx-code code').forEach(function (el) {
+        window.hljs.highlightElement(el);
+      });
+    }
+  });
+</script>
+{% endblock %}


### PR DESCRIPTION
Admin-only page at **`/admin/handlers`** for reviewing registered channel handlers.

## Layout
- **Sidebar**: a guild dropdown (every guild the bot is in, by name) above the list of channels in that guild that have handlers (by name, with a count). Changing the guild reloads; clicking a channel selects it.
- **Content pane**: the selected channel's handlers as `<details>` collapsibles — summary shows trigger type + description (+ a "disabled" pill); expanding reveals settings/metadata and the **script with syntax highlighting** (highlight.js).
- **Delete control** per handler (CSRF-protected `POST`, confirm dialog) that also cancels any queued scheduled job, mirroring the handler API.

## Notes
- `smarter_dev/web/handlers_admin.py` — `HandlersAdminController` (`administrator` permission). Resolves guild/channel names via the Discord client; degrades to ids if Discord is unreachable.
- No migration (uses existing `channel_handlers`).
- Verified: controller imports, route registered + auth-guarded (401 unauth), template parses, and the live data path (bot guilds → channels-with-handlers → names → handler list) returns correctly against the dev DB + bot token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)