### PR TITLE
feat: persistent per-handler memory (key/value store across fires)

### DIFF
--- a/alembic/main/versions/20260627_220000_e7b2c9f1a4d8_handler_memory.py
+++ b/alembic/main/versions/20260627_220000_e7b2c9f1a4d8_handler_memory.py
@@ -1,0 +1,40 @@
+"""Add persistent per-handler memory (JSON key/value store).
+
+Gives both channel_handlers and admin_handlers a `memory` JSON column: a small
+key/value store the script reads/writes via the memory_* functions, persisted
+across fires (counters, seen-sets, cooldown timestamps). Defaults to {} so
+existing rows are unaffected.
+
+Revision ID: e7b2c9f1a4d8
+Revises: d4f1a2b3c6e7
+Create Date: 2026-06-27 22:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "e7b2c9f1a4d8"
+down_revision: Union[str, None] = "d4f1a2b3c6e7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    for table in ("channel_handlers", "admin_handlers"):
+        op.add_column(
+            table,
+            sa.Column(
+                "memory",
+                sa.JSON(),
+                server_default="{}",
+                nullable=False,
+            ),
+        )
+
+
+def downgrade() -> None:
+    for table in ("channel_handlers", "admin_handlers"):
+        op.drop_column(table, "memory")

--- a/smarter_dev/bot/agents/prompts/admin_handler_author.md
+++ b/smarter_dev/bot/agents/prompts/admin_handler_author.md
@@ -35,6 +35,14 @@ Provided async functions — you MUST `await` every call:
   await ban_user(user_id: str, reason: str = None) -> str
   await kick_user(user_id: str) -> str
   await timeout_user(user_id: str, duration_seconds: int = 600) -> str
+  PERSISTENT MEMORY (survives across fires; private to this handler; starts empty):
+  await memory_get(key: str, default=None)   -> stored value or default
+  await memory_set(key: str, value) -> True  -> store JSON-serializable value (ONLY this persists)
+  await memory_all() -> dict                  -> snapshot of all keys (safe to iterate)
+  await memory_delete(key: str) -> bool       -> remove a key
+      Use memory for state across firings: who you've already warned/banned, per-user strike
+      counts, last-run timestamps, daily counters. Mutating the memory_all() snapshot does NOT
+      save — call memory_set. Keep it small (a few KB).
 
 ## Per-fire limits (admin tier)
 - 5 messages, 25 moderation actions, 3 agent calls, 32 KB context into an agent, 120 s wall-clock.

--- a/smarter_dev/bot/agents/prompts/handler_author.md
+++ b/smarter_dev/bot/agents/prompts/handler_author.md
@@ -38,6 +38,19 @@ These async functions are provided — you MUST `await` every call:
       string and decide what to send. Reads are cached by file + instruction, so re-reading the
       same file is cheap.
 
+These functions give the handler PERSISTENT MEMORY that survives across firings (also `await` them):
+
+  await memory_get(key: str, default=None)   -> the stored value, or default if unset
+  await memory_set(key: str, value) -> True  -> store a JSON-serializable value (str/int/float/
+                                                bool/None/list/dict). ONLY memory_set persists.
+  await memory_all() -> dict                  -> a snapshot of all stored keys (safe to iterate)
+  await memory_delete(key: str) -> bool       -> remove a key
+
+Memory is private to this one handler and starts empty ({}). Use it for things that must remember
+across fires: counters ("messages seen today"), seen-sets (ids you've already replied to),
+cooldown timestamps, a running total. Mutating the dict from memory_all() does NOT save — you must
+call memory_set to persist. Keep it small (a few KB total).
+
 Only your script can emit to the channel (send_message / add_reaction / post_voice). There is NO
 direct web access from the script — gather only by calling spawn_agent.
 

--- a/smarter_dev/web/admin_handlers_jobs.py
+++ b/smarter_dev/web/admin_handlers_jobs.py
@@ -61,6 +61,7 @@ async def run_admin_handler_fire(payload: AdminHandlerFirePayload) -> dict:
         trigger_type = record.trigger_type
         channel_ids = list(record.channel_ids or [])
         handler_settings = dict(record.settings or {})
+        memory = dict(record.memory or {})
 
     # For time triggers there's no triggering channel; default to the first
     # scoped channel (the script should target channels explicitly for "all").
@@ -85,6 +86,7 @@ async def run_admin_handler_fire(payload: AdminHandlerFirePayload) -> dict:
         agent_runner=run_gathering_agent,
         budget=budget,
         actor=actor,
+        memory=memory,
     )
 
     async with get_skrift_db_session_context() as session:
@@ -105,6 +107,10 @@ async def run_admin_handler_fire(payload: AdminHandlerFirePayload) -> dict:
                 finished_at=datetime.now(timezone.utc),
             )
         )
+        if result.memory_changed:
+            record = await session.get(AdminHandler, handler_id)
+            if record is not None:
+                record.memory = result.memory
         await session.commit()
 
     if trigger_type == "schedule":

--- a/smarter_dev/web/handler_memory.py
+++ b/smarter_dev/web/handler_memory.py
@@ -1,0 +1,86 @@
+"""Per-handler persistent memory — a small key/value dict that survives fires.
+
+A handler script gets no state of its own between firings; this gives it one.
+The host owns the dict (loaded from the handler row before the fire, saved after);
+the script reads and writes it through metered external functions, mirroring how
+every other side effect in the runtime works. Keeping the host as the owner means
+a sandbox mutation can never corrupt host state — the script only changes memory
+by asking, and only ``set``/``delete`` persist.
+
+Two rails: values must be JSON-serializable (it lands in a JSON column) and the
+whole blob is size-capped. A size breach raises :class:`CapExceeded` so it flows
+through the runtime's normal cap path; a non-serializable value is an author bug,
+so it raises ``ValueError`` and fails the fire loud.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+
+from smarter_dev.web.handler_budget import CapExceeded
+
+# Cap the serialized blob. Memory is for counters, seen-sets, and timestamps —
+# not bulk storage — so a small ceiling keeps a runaway handler from bloating the
+# row (and the per-fire load/save) without being limiting in practice.
+MAX_MEMORY_BYTES = 16 * 1024
+
+
+class HandlerMemory:
+    """Host-owned key/value store for one handler, snapshot-loaded per fire.
+
+    Writes copy-on-write so a rejected ``set`` (non-serializable or over-cap)
+    leaves the prior state intact. ``dirty`` lets the caller skip a DB write when
+    a fire never touched memory — the common case for a busy message handler.
+    """
+
+    def __init__(self, initial: dict | None = None, max_bytes: int = MAX_MEMORY_BYTES):
+        self._data: dict = dict(initial or {})
+        self._max_bytes = max_bytes
+        self._dirty = False
+
+    @property
+    def dirty(self) -> bool:
+        return self._dirty
+
+    def get(self, key: str, default=None):
+        return self._data.get(str(key), default)
+
+    def set(self, key: str, value) -> bool:
+        """Store ``value`` under ``key``. Fails loud on non-JSON or over-cap."""
+        candidate = dict(self._data)
+        candidate[str(key)] = value
+        try:
+            encoded = json.dumps(candidate)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"memory values must be JSON-serializable (str/int/float/bool/"
+                f"None/list/dict): {exc}"
+            ) from exc
+        if len(encoded.encode("utf-8")) > self._max_bytes:
+            raise CapExceeded(
+                "memory_size",
+                f"handler memory would exceed {self._max_bytes} bytes",
+            )
+        self._data = candidate
+        self._dirty = True
+        return True
+
+    def delete(self, key: str) -> bool:
+        """Remove ``key`` if present. Returns whether anything was removed."""
+        key = str(key)
+        if key not in self._data:
+            return False
+        candidate = dict(self._data)
+        del candidate[key]
+        self._data = candidate
+        self._dirty = True
+        return True
+
+    def all(self) -> dict:
+        """A deep copy of the whole store (so the script can iterate it safely)."""
+        return copy.deepcopy(self._data)
+
+    def snapshot(self) -> dict:
+        """The current state, for persisting back to the handler row."""
+        return copy.deepcopy(self._data)

--- a/smarter_dev/web/handler_runtime.py
+++ b/smarter_dev/web/handler_runtime.py
@@ -12,6 +12,9 @@ Script-facing surface (Monty external functions):
 - ``add_reaction(message_id, emoji)`` -> True
 - ``post_voice(text)`` -> True
 - ``spawn_agent(prompt, has_tools=False)`` -> plaintext str
+- ``memory_get(key, default=None)`` / ``memory_set(key, value)`` /
+  ``memory_all()`` / ``memory_delete(key)`` -> persistent per-handler key/value
+  store that survives across fires.
 
 Script-facing data (Monty input): ``context`` — a plain dict describing the
 trigger (its keys depend on ``context["trigger_type"]``).
@@ -41,6 +44,7 @@ from smarter_dev.web.handler_caps import (
     global_agent_key,
 )
 from smarter_dev.web.handler_emitter import DiscordEmitter
+from smarter_dev.web.handler_memory import HandlerMemory
 from smarter_dev.web.admin_actions import AdminActor
 
 logger = logging.getLogger(__name__)
@@ -71,6 +75,10 @@ class HandlerResult:
     duration_ms: int
     error: str | None = None
     cap: str | None = None
+    # The handler's memory after the fire, and whether the script changed it.
+    # The caller persists ``memory`` back to the handler row only when ``memory_changed``.
+    memory: dict[str, Any] = field(default_factory=dict)
+    memory_changed: bool = False
 
 
 @dataclass
@@ -86,6 +94,9 @@ class HandlerExecution:
     # Set only for admin handlers; presence enables the moderation functions and
     # lets send_message target any channel.
     actor: AdminActor | None = None
+    # Per-handler persistent key/value store, loaded before the fire. The host
+    # owns it; the script reads/writes via the memory_* external functions.
+    memory: HandlerMemory = field(default_factory=HandlerMemory)
     # The cap that stopped this fire, captured here because Monty rewraps the
     # exception that crosses out of an external function (losing its type), so
     # we record the real CapExceeded on the host side before re-raising.
@@ -97,6 +108,10 @@ class HandlerExecution:
             "add_reaction": self._guard(self._add_reaction),
             "post_voice": self._guard(self._post_voice),
             "spawn_agent": self._guard(self._spawn_agent),
+            "memory_get": self._guard(self._memory_get),
+            "memory_set": self._guard(self._memory_set),
+            "memory_all": self._guard(self._memory_all),
+            "memory_delete": self._guard(self._memory_delete),
         }
         if self.actor is not None:  # admin handler — moderation powers
             funcs.update(
@@ -191,6 +206,20 @@ class HandlerExecution:
             )
         return await self.agent_runner(prompt, bool(has_tools), self.budget)
 
+    # -- persistent per-handler memory (survives across fires) --
+
+    async def _memory_get(self, key: str, default: Any = None) -> Any:
+        return self.memory.get(str(key), default)
+
+    async def _memory_set(self, key: str, value: Any) -> bool:
+        return self.memory.set(str(key), value)
+
+    async def _memory_all(self) -> dict[str, Any]:
+        return self.memory.all()
+
+    async def _memory_delete(self, key: str) -> bool:
+        return self.memory.delete(str(key))
+
 
 async def run_handler_script(
     script: str,
@@ -203,6 +232,7 @@ async def run_handler_script(
     agent_runner: AgentRunner = _no_agent,
     budget: HandlerBudget | None = None,
     actor: AdminActor | None = None,
+    memory: dict[str, Any] | None = None,
 ) -> HandlerResult:
     """Compile and run ``script`` in Monty with every rail enforced.
 
@@ -211,9 +241,13 @@ async def run_handler_script(
     :class:`HandlerResult` for the durable run record — never raise to the caller.
 
     Passing ``actor`` enables the admin moderation functions (and lets
-    send_message target any channel).
+    send_message target any channel). ``memory`` seeds the handler's persistent
+    store; the result carries it back (with ``memory_changed``) for the caller to
+    persist regardless of outcome — a counter bumped before a later failure is
+    not lost, matching the "emitted effects stay" rule.
     """
     budget = budget or HandlerBudget()
+    handler_memory = HandlerMemory(memory or {})
     execution = HandlerExecution(
         channel_id=channel_id,
         guild_id=guild_id,
@@ -222,6 +256,7 @@ async def run_handler_script(
         limiter=limiter,
         agent_runner=agent_runner,
         actor=actor,
+        memory=handler_memory,
     )
     started = time.monotonic()
 
@@ -232,6 +267,8 @@ async def run_handler_script(
             duration_ms=int((time.monotonic() - started) * 1000),
             error=error,
             cap=cap,
+            memory=handler_memory.snapshot(),
+            memory_changed=handler_memory.dirty,
         )
 
     try:

--- a/smarter_dev/web/handlers_admin.py
+++ b/smarter_dev/web/handlers_admin.py
@@ -125,6 +125,7 @@ class HandlersAdminController(Controller):
                     "settings": r.settings or {},
                     "script": r.script,
                     "scope": _scope_label(list(r.channel_ids or [])),
+                    "memory": r.memory or {},
                 }
                 for r in admin_rows
             ]
@@ -232,3 +233,38 @@ class HandlersAdminController(Controller):
 
         flash_success(request, "Admin handler deleted.")
         return Redirect(path=f"/admin/handlers?guild_id={guild_id}&admin=1")
+
+    @post(
+        "/handlers/{handler_id:uuid}/clear-memory",
+        guards=[auth_guard, Permission("administrator")],
+    )
+    async def clear_handler_memory(
+        self, request: Request, db_session: AsyncSession, handler_id: UUID
+    ) -> Redirect:
+        record = await db_session.get(ChannelHandler, handler_id)
+        if record is None:
+            flash_error(request, "Handler not found.")
+            return Redirect(path="/admin/handlers")
+        record.memory = {}
+        await db_session.commit()
+        flash_success(request, "Handler memory cleared.")
+        return Redirect(
+            path=f"/admin/handlers?guild_id={record.guild_id}"
+            f"&channel_id={record.channel_id}"
+        )
+
+    @post(
+        "/handlers/admin/{handler_id:uuid}/clear-memory",
+        guards=[auth_guard, Permission("administrator")],
+    )
+    async def clear_admin_handler_memory(
+        self, request: Request, db_session: AsyncSession, handler_id: UUID
+    ) -> Redirect:
+        record = await db_session.get(AdminHandler, handler_id)
+        if record is None:
+            flash_error(request, "Admin handler not found.")
+            return Redirect(path="/admin/handlers")
+        record.memory = {}
+        await db_session.commit()
+        flash_success(request, "Admin handler memory cleared.")
+        return Redirect(path=f"/admin/handlers?guild_id={record.guild_id}&admin=1")

--- a/smarter_dev/web/handlers_jobs.py
+++ b/smarter_dev/web/handlers_jobs.py
@@ -64,6 +64,7 @@ async def run_handler_fire(payload: HandlerFirePayload) -> dict:
         guild_id = record.guild_id
         trigger_type = record.trigger_type
         handler_settings = dict(record.settings or {})
+        memory = dict(record.memory or {})
 
     # Lazy: these pull pydantic-ai / Monty, kept out of web-tier import.
     from smarter_dev.web.handler_agent import run_gathering_agent
@@ -82,6 +83,7 @@ async def run_handler_fire(payload: HandlerFirePayload) -> dict:
         limiter=limiter,
         agent_runner=run_gathering_agent,
         budget=budget,
+        memory=memory,
     )
 
     async with get_skrift_db_session_context() as session:
@@ -100,6 +102,12 @@ async def run_handler_fire(payload: HandlerFirePayload) -> dict:
                 finished_at=datetime.now(timezone.utc),
             )
         )
+        # Persist memory only when the script changed it (the common message-handler
+        # path leaves it untouched and skips the write).
+        if result.memory_changed:
+            record = await session.get(ChannelHandler, handler_id)
+            if record is not None:
+                record.memory = result.memory
         await session.commit()
 
     if trigger_type == "schedule":

--- a/smarter_dev/web/models.py
+++ b/smarter_dev/web/models.py
@@ -4517,6 +4517,11 @@ class ChannelHandler(Base):
     enabled: Mapped[bool] = mapped_column(
         Boolean, nullable=False, default=True, server_default="true"
     )
+    # Persistent per-handler key/value store: the script reads/writes it via the
+    # memory_* functions and it survives across fires (counters, seen-sets, etc.).
+    memory: Mapped[dict] = mapped_column(
+        JSON, nullable=False, default=dict, server_default="{}"
+    )
     # Queue job id for the next scheduled fire (time triggers), so delete can
     # cancel it.
     scheduled_job_id: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
@@ -4605,5 +4610,9 @@ class AdminHandler(Base):
     created_by_admin: Mapped[str] = mapped_column(String(20), nullable=False)
     enabled: Mapped[bool] = mapped_column(
         Boolean, nullable=False, default=True, server_default="true"
+    )
+    # Persistent per-handler key/value store (see ChannelHandler.memory).
+    memory: Mapped[dict] = mapped_column(
+        JSON, nullable=False, default=dict, server_default="{}"
     )
     scheduled_job_id: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)

--- a/templates/admin/handlers/list.html
+++ b/templates/admin/handlers/list.html
@@ -26,6 +26,7 @@
   .hx-meta dd { margin: 0; }
   .hx-code { margin: .5rem 0; border-radius: .5rem; max-height: 480px; overflow: auto; }
   .hx-code code { font-size: .85rem; }
+  .hx-actions { display: flex; gap: .5rem; align-items: center; flex-wrap: wrap; }
 </style>
 {% endblock %}
 
@@ -101,13 +102,23 @@
           <dt>Trigger</dt><dd>{{ h.trigger_type }}</dd>
           <dt>Scope</dt><dd>{{ h.scope }}</dd>
           <dt>Settings</dt><dd><code>{{ h.settings | tojson }}</code></dd>
+          <dt>Memory</dt><dd><code>{{ h.memory | tojson }}</code></dd>
         </dl>
         <pre class="hx-code"><code class="language-python">{{ h.script }}</code></pre>
-        <form method="post" action="/admin/handlers/admin/{{ h.id }}/delete"
-              onsubmit="return confirm('Delete this admin handler? This cannot be undone.')">
-          {{ csrf_field() }}
-          <button type="submit" class="sk-btn-outline sk-btn-small sk-btn-danger">Delete admin handler</button>
-        </form>
+        <div class="hx-actions">
+          {% if h.memory %}
+          <form method="post" action="/admin/handlers/admin/{{ h.id }}/clear-memory"
+                onsubmit="return confirm('Clear this handler\'s saved memory?')">
+            {{ csrf_field() }}
+            <button type="submit" class="sk-btn-outline sk-btn-small">Clear memory</button>
+          </form>
+          {% endif %}
+          <form method="post" action="/admin/handlers/admin/{{ h.id }}/delete"
+                onsubmit="return confirm('Delete this admin handler? This cannot be undone.')">
+            {{ csrf_field() }}
+            <button type="submit" class="sk-btn-outline sk-btn-small sk-btn-danger">Delete admin handler</button>
+          </form>
+        </div>
       </div>
     </details>
     {% else %}
@@ -127,15 +138,25 @@
           <dt>Handler ID</dt><dd><code>{{ h.id }}</code></dd>
           <dt>Trigger</dt><dd>{{ h.trigger_type }}</dd>
           <dt>Settings</dt><dd><code>{{ h.settings | tojson }}</code></dd>
+          <dt>Memory</dt><dd><code>{{ h.memory | tojson }}</code></dd>
           <dt>Created by</dt><dd>{{ h.created_by }}</dd>
           <dt>Created</dt><dd>{{ h.created_at.strftime('%Y-%m-%d %H:%M UTC') }}</dd>
         </dl>
         <pre class="hx-code"><code class="language-python">{{ h.script }}</code></pre>
-        <form method="post" action="/admin/handlers/{{ h.id }}/delete"
-              onsubmit="return confirm('Delete this handler? This cannot be undone.')">
-          {{ csrf_field() }}
-          <button type="submit" class="sk-btn-outline sk-btn-small sk-btn-danger">Delete handler</button>
-        </form>
+        <div class="hx-actions">
+          {% if h.memory %}
+          <form method="post" action="/admin/handlers/{{ h.id }}/clear-memory"
+                onsubmit="return confirm('Clear this handler\'s saved memory?')">
+            {{ csrf_field() }}
+            <button type="submit" class="sk-btn-outline sk-btn-small">Clear memory</button>
+          </form>
+          {% endif %}
+          <form method="post" action="/admin/handlers/{{ h.id }}/delete"
+                onsubmit="return confirm('Delete this handler? This cannot be undone.')">
+            {{ csrf_field() }}
+            <button type="submit" class="sk-btn-outline sk-btn-small sk-btn-danger">Delete handler</button>
+          </form>
+        </div>
       </div>
     </details>
     {% else %}

--- a/tests/web/handler_memory_test.py
+++ b/tests/web/handler_memory_test.py
@@ -1,0 +1,143 @@
+"""Tests for per-handler persistent memory — the HandlerMemory store and the
+memory_* external functions wired through the runtime."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import pytest
+
+from smarter_dev.web.handler_budget import CapExceeded
+from smarter_dev.web.handler_memory import HandlerMemory
+from smarter_dev.web.handler_runtime import run_handler_script
+
+
+# -- HandlerMemory unit --------------------------------------------------------
+
+
+def test_set_get_roundtrip_and_dirty():
+    mem = HandlerMemory()
+    assert mem.dirty is False
+    assert mem.get("x") is None
+    assert mem.get("x", 0) == 0
+    mem.set("x", 5)
+    assert mem.get("x") == 5
+    assert mem.dirty is True
+
+
+def test_seeds_from_initial_without_marking_dirty():
+    mem = HandlerMemory({"count": 3})
+    assert mem.get("count") == 3
+    assert mem.dirty is False  # loading prior state isn't a change
+
+
+def test_delete_returns_whether_removed():
+    mem = HandlerMemory({"a": 1})
+    assert mem.delete("missing") is False
+    assert mem.dirty is False
+    assert mem.delete("a") is True
+    assert mem.dirty is True
+    assert mem.get("a") is None
+
+
+def test_all_returns_independent_deep_copy():
+    mem = HandlerMemory({"nested": {"k": [1]}})
+    snap = mem.all()
+    snap["nested"]["k"].append(2)
+    # Mutating the snapshot must not touch the store.
+    assert mem.get("nested") == {"k": [1]}
+
+
+def test_non_serializable_value_raises_and_leaves_state_intact():
+    mem = HandlerMemory({"keep": 1})
+    with pytest.raises(ValueError):
+        mem.set("bad", {1, 2, 3})  # a set isn't JSON
+    assert mem.get("bad") is None
+    assert mem.get("keep") == 1
+    assert mem.dirty is False  # rejected write doesn't dirty the store
+
+
+def test_size_cap_raises_capexceeded():
+    mem = HandlerMemory(max_bytes=64)
+    with pytest.raises(CapExceeded) as exc:
+        mem.set("big", "x" * 200)
+    assert exc.value.cap == "memory_size"
+    assert mem.dirty is False
+
+
+# -- runtime integration -------------------------------------------------------
+
+
+@dataclass
+class _FakeEmitter:
+    messages: list = field(default_factory=list)
+
+    async def create_message(self, channel_id: str, content: str) -> str:
+        self.messages.append((channel_id, content))
+        return f"msg{len(self.messages)}"
+
+    async def add_reaction(self, channel_id, message_id, emoji) -> None:
+        pass
+
+
+@dataclass
+class _StubLimiter:
+    async def hit(self, key: str, limit: int) -> bool:
+        return True
+
+
+async def _run(script, *, memory=None):
+    return await run_handler_script(
+        script,
+        {"trigger_type": "message", "message_content": "hi"},
+        channel_id="C1",
+        guild_id="G1",
+        emitter=_FakeEmitter(),
+        limiter=_StubLimiter(),
+        memory=memory,
+    )
+
+
+async def test_memory_persists_across_a_fire():
+    script = (
+        'n = await memory_get("count", 0)\n'
+        'await memory_set("count", n + 1)\n'
+    )
+    # First fire from empty.
+    r1 = await _run(script, memory={})
+    assert r1.outcome == "ok"
+    assert r1.memory_changed is True
+    assert r1.memory == {"count": 1}
+
+    # Second fire seeded with the saved memory.
+    r2 = await _run(script, memory=r1.memory)
+    assert r2.memory == {"count": 2}
+
+
+async def test_unchanged_memory_is_not_flagged_dirty():
+    script = 'v = await memory_get("count", 0)\nawait send_message(str(v))\n'
+    r = await _run(script, memory={"count": 7})
+    assert r.outcome == "ok"
+    assert r.memory_changed is False  # only read -> no write-back
+    assert r.memory == {"count": 7}
+
+
+async def test_memory_all_and_delete_from_script():
+    script = (
+        'await memory_set("a", 1)\n'
+        'await memory_set("b", 2)\n'
+        'snap = await memory_all()\n'
+        'await memory_delete("a")\n'
+        'await send_message(str(sorted(snap.keys())))\n'
+    )
+    r = await _run(script, memory={})
+    assert r.outcome == "ok"
+    assert r.memory == {"b": 2}
+
+
+async def test_memory_size_cap_surfaces_as_cap_exceeded():
+    # 16 KB default cap; write something far larger.
+    script = 'await memory_set("blob", "x" * 20000)\n'
+    r = await _run(script, memory={})
+    assert r.outcome == "cap_exceeded"
+    assert r.cap == "memory_size"


### PR DESCRIPTION
## What

Handlers had no state between firings. This gives each one a small **private, persistent dict** — counters, seen-sets, cooldown timestamps, running totals — that survives across fires.

## How

Monty doesn't surface a mutated input back to the host, so instead of a literal dict the script gets four metered external functions backed by a host-owned store (mirroring how every other side effect already works — host owns the value, sandbox can only ask it to change, so a sandbox mutation can't corrupt host state):

```python
await memory_get(key, default=None)
await memory_set(key, value)      # only this persists
await memory_all()                # snapshot to iterate
await memory_delete(key)
```

- **`handler_memory.py`** — `HandlerMemory`: copy-on-write set/delete with two rails — values must be JSON-serializable (`ValueError`, fail loud) and the blob is size-capped at 16 KB (`CapExceeded`, surfaces via the normal cap path). Dirty-tracking so a fire that only reads skips the write-back.
- **Storage** — `memory` JSON column on `channel_handlers` + `admin_handlers` (durable, survives Redis eviction). Migration `e7b2c9f1a4d8`, auto-applied on deploy; default `{}` so existing rows are unaffected.
- **Runtime + jobs** — `run_handler_script` seeds memory and returns it (`memory_changed`); both fire jobs persist it back, regardless of outcome (a counter bumped before a later failure isn't lost).
- **Prompts** — standard + admin author prompts document `memory_*` and that only `memory_set` persists.
- **Admin page** — shows each handler's memory JSON with a **Clear memory** button.

**Caveat:** concurrent fires of the same handler do load-modify-write (last-write-wins) — fine at this scale; atomic ops can back specific counters later if needed.

## Verification

- 10 new tests (HandlerMemory unit + runtime integration: persistence across fires, dirty-skip, size cap → `cap_exceeded`, non-serializable rejection) — all pass.
- Full suite: 1045 passed (only the pre-existing `test_chat_engine.py` MagicMock failures remain, unrelated).
- Migration applied cleanly to dev. gitleaks + semgrep clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)