### PR TITLE
feat: let handler scripts read the wall clock (datetime.now / date.today)

### DIFF
--- a/smarter_dev/bot/agents/prompts/admin_handler_author.md
+++ b/smarter_dev/bot/agents/prompts/admin_handler_author.md
@@ -15,6 +15,11 @@ IMPORTS: the sandbox BLOCKS every import except `re`, `datetime`, `json`, `math`
 anything else (random, os, collections, itertools, requests, …) raises ModuleNotFoundError and the
 handler ERRORS on every fire. Import nothing else.
 
+CLOCK: current time IS available — `datetime.datetime.now(datetime.timezone.utc)` and
+`datetime.date.today()` work (after `import datetime`). Always pass UTC so comparisons against ISO
+timestamps in `context` (e.g. `author_joined_at`) are correct; datetime subtraction,
+`.total_seconds()`, and `fromisoformat` all work.
+
 RANDOMNESS without import — call these top-level functions directly (never `import random` /
 `random.`): randint(a, b), randrange(a[, b]), randfloat() (0–1), uniform(a, b), choice(seq),
 shuffled(seq) (new list), sample(seq, k) (new list).

--- a/smarter_dev/bot/agents/prompts/handler_author.md
+++ b/smarter_dev/bot/agents/prompts/handler_author.md
@@ -14,6 +14,11 @@ Importing ANYTHING else (random, os, sys, collections, itertools, string, reques
 ModuleNotFoundError at runtime and the handler ERRORS on every single fire. Do not import any
 other module, and do not import re/datetime/json/math unless you actually use them.
 
+CLOCK: the current time IS available — `datetime.datetime.now(datetime.timezone.utc)` returns the
+real now, and `datetime.date.today()` works too (after `import datetime`). Pass an explicit
+timezone (UTC) so comparisons against ISO timestamps in `context` are correct. Date/time math
+(subtracting two datetimes, `.total_seconds()`, `fromisoformat`) all work in the sandbox.
+
 RANDOMNESS is available WITHOUT any import, as top-level functions (do NOT write `random.` and do
 NOT `import random` — that would fail). Call these directly:
   randint(a, b) -> int in [a, b]      randrange(a) / randrange(a, b) -> int

--- a/smarter_dev/web/handler_runtime.py
+++ b/smarter_dev/web/handler_runtime.py
@@ -19,6 +19,10 @@ Script-facing surface (Monty external functions):
 Script-facing data (Monty input): ``context`` — a plain dict describing the
 trigger (its keys depend on ``context["trigger_type"]``).
 
+The wall clock is available: scripts may call ``datetime.datetime.now(tz)`` and
+``datetime.date.today()`` (wired through ``_clock_os``). Every other OS surface —
+filesystem, env — stays blocked.
+
 Gathering is agent-only: the script itself has no web access. A spawned agent
 returns plaintext and cannot emit. The budget bounds both the agent's *input*
 (``enforce_agent_context``, regardless of ``has_tools``) and any searches/reads
@@ -27,6 +31,7 @@ it performs (shared with the script's pool).
 
 from __future__ import annotations
 
+import datetime
 import logging
 import random
 import time
@@ -65,6 +70,26 @@ AgentRunner = Callable[[str, bool, HandlerBudget], Awaitable[str]]
 
 async def _no_agent(prompt: str, has_tools: bool, budget: HandlerBudget) -> str:
     raise RuntimeError("no agent runner configured for this handler execution")
+
+
+def _clock_os(
+    function_name: str, args: tuple[Any, ...], kwargs: dict[str, Any] | None = None
+) -> Any:
+    """Monty ``os=`` callback that grants ONLY the wall-clock functions.
+
+    Monty treats ``datetime.now(tz)`` and ``date.today()`` as OS calls (they are
+    non-deterministic, so the sandbox refuses them — ``datetime.now`` is "not
+    implemented" — unless a host opts in). We answer just those two from the real
+    host clock and return ``NOT_HANDLED`` for everything else, so filesystem, env,
+    and every other OS surface stay blocked exactly as before. Scripts get the
+    natural ``datetime.datetime.now(datetime.timezone.utc)`` with no special API.
+    """
+    if function_name == "datetime.now":
+        tz = args[0] if args else None
+        return datetime.datetime.now(tz=tz)
+    if function_name == "date.today":
+        return datetime.date.today()
+    return monty.NOT_HANDLED
 
 
 def _random_functions() -> dict[str, Callable[..., Any]]:
@@ -310,6 +335,7 @@ async def run_handler_script(
             inputs={"context": context},
             limits=limits,
             external_functions=execution.external_functions(),
+            os=_clock_os,
         )
     except CapExceeded as exc:  # defensive: a direct (non-sandbox) breach
         logger.info("handler hit cap %s (channel=%s)", exc.cap, channel_id)

--- a/tests/web/handler_runtime_test.py
+++ b/tests/web/handler_runtime_test.py
@@ -252,3 +252,42 @@ async def test_import_random_still_errors():
     assert result.outcome == "error"
     assert "random" in (result.error or "")
     assert emitter.messages == []
+
+
+async def test_datetime_now_returns_host_clock():
+    # datetime.now(tz) is an OS call Monty refuses unless the host wires a clock;
+    # _clock_os grants it. A script must be able to compute a recency window
+    # against an ISO timestamp from context — the canonical "new account" guard.
+    script = (
+        "import datetime\n"
+        "now = datetime.datetime.now(datetime.timezone.utc)\n"
+        'joined = datetime.datetime.fromisoformat("2000-01-01T00:00:00+00:00")\n'
+        "age = (now - joined).total_seconds()\n"
+        'await send_message("old" if age > 86400 else "new")\n'
+    )
+    result, emitter, _ = await _run(script)
+    assert result.outcome == "ok", result.error
+    assert emitter.messages[0][1] == "old"  # joined in year 2000 -> well past 24h
+
+
+async def test_date_today_available():
+    script = (
+        "import datetime\n"
+        "y = datetime.date.today().year\n"
+        'await send_message("yes" if y >= 2026 else "no")\n'
+    )
+    result, emitter, _ = await _run(script)
+    assert result.outcome == "ok", result.error
+    assert emitter.messages[0][1] == "yes"
+
+
+async def test_filesystem_still_blocked_with_clock_wired():
+    # Wiring the clock OS callback must not crack open any other OS surface:
+    # filesystem reads still fail loud.
+    script = (
+        "from pathlib import Path\n"
+        'await send_message(Path("/etc/passwd").read_text())\n'
+    )
+    result, emitter, _ = await _run(script)
+    assert result.outcome == "error"
+    assert emitter.messages == []


### PR DESCRIPTION
## Problem

Monty treats `datetime.now()` and `date.today()` as non-deterministic OS calls and refuses them (`OS function 'datetime.now' not implemented`) unless the host opts in. Any handler computing a recency window — e.g. a new-account moderation guard checking `author_joined_at` — errored on **every** fire.

## Fix

Wire a clock-only `os=` callback into `run_async` that answers exactly `datetime.now` (passing the tz through) and `date.today` from the real host clock, and returns `NOT_HANDLED` for everything else — so filesystem and env access stay blocked exactly as before. Scripts use the natural `datetime.datetime.now(datetime.timezone.utc)` with no new API to learn.

- `handler_runtime.py`: `_clock_os` callback + `os=_clock_os` on the single `run_async` call.
- Author prompts (`handler_author.md`, `admin_handler_author.md`): document the clock, recommend explicit UTC.
- Tests: `now`/`today` work; filesystem stays blocked with the clock wired.

No new migrations — the deploy's migration Job step is a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)