### PR TITLE
fix: harden chat image delivery (attach-perm fallback, crash salvage, no burned turn)

### DIFF
--- a/smarter_dev/bot/services/chat_engine.py
+++ b/smarter_dev/bot/services/chat_engine.py
@@ -71,6 +71,14 @@ MAX_NO_RESPONSE_TURNS = 3
 INACTIVITY_TIMEOUT = timedelta(minutes=30)
 MAX_RUNTIME = timedelta(hours=2)
 
+# Appended to a text reply when a generated image can't be attached because the
+# bot is missing the "Attach Files" permission — so the answer still lands and
+# the gap is explained instead of silent.
+_ATTACH_PERM_NOTE = (
+    "\n\n-# (couldn't attach the generated image here — I'm missing the "
+    '"Attach Files" permission in this channel)'
+)
+
 
 @dataclass
 class _QueuedMessage:
@@ -450,10 +458,19 @@ class ChannelEngine:
                     self.channel_id,
                 )
                 drain_collection()  # discard
-                await self._post_error(
-                    "Sorry, couldn't generate a reply for that one — try again?",
-                    reply_to=error_reply_to,
-                )
+                # The run may have crashed *after* generate_image already spent a
+                # quota slot and stashed an image. Salvage it — the user paid for
+                # it — and only show the generic error if nothing was delivered.
+                salvaged = False
+                if deps.pending_images:
+                    salvaged = await self._post_images(
+                        list(deps.pending_images), reply_to=error_reply_to
+                    )
+                if not salvaged:
+                    await self._post_error(
+                        "Sorry, couldn't generate a reply for that one — try again?",
+                        reply_to=error_reply_to,
+                    )
                 return
             compaction_events = drain_collection()
 
@@ -576,14 +593,18 @@ class ChannelEngine:
             self.last_sent_at = datetime.now(UTC)
             outcome.voice = await self._send(output.response, images)
         else:
-            # No textual reply this turn — but if the agent still generated an
-            # image, post it standalone so the work isn't lost.
-            if images:
-                await self._post_images(images, reply_to=None)
-            self.consecutive_no_response += 1
-            if self.consecutive_no_response >= MAX_NO_RESPONSE_TURNS:
-                outcome.deactivate_reason = "no_response_quota"
-                return outcome
+            # No textual reply this turn. If the agent still generated an image,
+            # post it standalone — that counts as engagement, so it must NOT burn
+            # a no-response strike. Only a turn that delivered nothing is silence.
+            posted = await self._post_images(images, reply_to=None) if images else False
+            if posted:
+                self.consecutive_no_response = 0
+                self.last_sent_at = datetime.now(UTC)
+            else:
+                self.consecutive_no_response += 1
+                if self.consecutive_no_response >= MAX_NO_RESPONSE_TURNS:
+                    outcome.deactivate_reason = "no_response_quota"
+                    return outcome
 
         if not output.continue_watching:
             outcome.deactivate_reason = "continue_watching_false"
@@ -675,22 +696,52 @@ class ChannelEngine:
         reply_to: int | None,
         images: list[GeneratedImage] | None = None,
     ) -> bool:
+        content = message.strip()[:2000]
+        base_kwargs: dict[str, Any] = {"content": content}
+        if reply_to is not None:
+            base_kwargs["reply"] = reply_to
+        attachments = (
+            [hikari.Bytes(img.data, img.filename, img.mime_type) for img in images]
+            if images
+            else []
+        )
         try:
-            kwargs: dict[str, Any] = {"content": message.strip()[:2000]}
-            if reply_to is not None:
-                kwargs["reply"] = reply_to
-            if images:
-                kwargs["attachments"] = [
-                    hikari.Bytes(img.data, img.filename, img.mime_type)
-                    for img in images
-                ]
+            kwargs = dict(base_kwargs)
+            if attachments:
+                kwargs["attachments"] = attachments
             await self.bot.rest.create_message(self.channel_id, **kwargs)
             return True
-        except Exception:
-            logger.exception(
-                "Failed to send chat agent text in channel %s", self.channel_id
+        except Exception as err:
+            if not attachments:
+                logger.exception(
+                    "Failed to send chat agent text in channel %s", self.channel_id
+                )
+                return False
+            # The image upload failed — most often the bot lacks the "Attach
+            # Files" permission here (or the file is too big). Don't lose the
+            # whole reply: resend the text alone so the answer still lands, and
+            # note the missing permission when that's the cause.
+            logger.warning(
+                "Send with %d attachment(s) failed in channel %s (%s); "
+                "retrying text-only",
+                len(attachments),
+                self.channel_id,
+                type(err).__name__,
+                exc_info=True,
             )
-            return False
+            text_only = dict(base_kwargs)
+            if isinstance(err, hikari.ForbiddenError):
+                text_only["content"] = (content + _ATTACH_PERM_NOTE)[:2000]
+            try:
+                await self.bot.rest.create_message(self.channel_id, **text_only)
+                return True
+            except Exception:
+                logger.exception(
+                    "Failed to send chat agent text (text-only fallback) in "
+                    "channel %s",
+                    self.channel_id,
+                )
+                return False
 
     async def _post_images(
         self, images: list[GeneratedImage], reply_to: int | None
@@ -709,10 +760,24 @@ class ChannelEngine:
                 kwargs["reply"] = reply_to
             await self.bot.rest.create_message(self.channel_id, **kwargs)
             return True
-        except Exception:
+        except Exception as err:
             logger.exception(
                 "Failed to post generated image(s) in channel %s", self.channel_id
             )
+            # No text body to fall back to — but if it's a permission problem,
+            # say so instead of going silent.
+            if isinstance(err, hikari.ForbiddenError):
+                try:
+                    note_kwargs: dict[str, Any] = {"content": _ATTACH_PERM_NOTE.strip()}
+                    if reply_to is not None:
+                        note_kwargs["reply"] = reply_to
+                    await self.bot.rest.create_message(self.channel_id, **note_kwargs)
+                except Exception:
+                    logger.debug(
+                        "could not post attach-permission note in channel %s",
+                        self.channel_id,
+                        exc_info=True,
+                    )
             return False
 
     def _shared_api_client(self) -> Any | None:

--- a/tests/bot/services/test_chat_engine_image_send.py
+++ b/tests/bot/services/test_chat_engine_image_send.py
@@ -1,0 +1,167 @@
+"""Tests for graceful degradation when a generated image can't be attached.
+
+If the bot lacks the Discord "Attach Files" permission (or the upload otherwise
+fails), the reply must still land — the text answer should be resent without the
+attachment rather than the whole message being lost. See the prod incident where
+a 403 on the image upload swallowed the entire reply.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import hikari
+
+from smarter_dev.bot.agents.chat_tools import GeneratedImage
+from smarter_dev.bot.services.chat_engine import ChannelEngine, MAX_NO_RESPONSE_TURNS
+
+
+def _forbidden() -> hikari.ForbiddenError:
+    return hikari.ForbiddenError("https://discord/api", {}, "Missing Permissions",
+                                 "Missing Permissions", 50013)
+
+
+def _engine(create_message: AsyncMock) -> ChannelEngine:
+    bot = MagicMock()
+    bot.rest = MagicMock()
+    bot.rest.create_message = create_message
+
+    async def _noop_voice(*a, **k):
+        return None
+
+    async def _noop_deactivate(_):
+        return None
+
+    return ChannelEngine(
+        bot=bot, channel_id=42, guild_id=99,
+        voice_send=_noop_voice, on_deactivate=_noop_deactivate,
+    )
+
+
+def _img() -> GeneratedImage:
+    return GeneratedImage(data=b"PNGDATA", mime_type="image/png", filename="diagram.png")
+
+
+async def test_send_text_falls_back_to_text_only_when_attachment_forbidden():
+    calls = []
+
+    async def create_message(channel_id, **kwargs):
+        calls.append(kwargs)
+        if "attachments" in kwargs:  # first attempt carries the image
+            raise _forbidden()
+        return MagicMock()  # text-only retry succeeds
+
+    engine = _engine(AsyncMock(side_effect=create_message))
+    ok = await engine._send_text("here's the diagram", reply_to=None, images=[_img()])
+
+    assert ok is True
+    assert len(calls) == 2
+    assert "attachments" in calls[0]
+    assert "attachments" not in calls[1]
+    # The user still gets the answer, plus a note about the missing permission.
+    assert calls[1]["content"].startswith("here's the diagram")
+    assert "Attach Files" in calls[1]["content"]
+
+
+async def test_send_text_fallback_has_no_note_for_generic_failure():
+    calls = []
+
+    async def create_message(channel_id, **kwargs):
+        calls.append(kwargs)
+        if "attachments" in kwargs:
+            raise RuntimeError("network blip")
+        return MagicMock()
+
+    engine = _engine(AsyncMock(side_effect=create_message))
+    ok = await engine._send_text("the answer", reply_to=None, images=[_img()])
+
+    assert ok is True
+    assert len(calls) == 2
+    # Non-permission failure: text still lands, but no permission note appended.
+    assert calls[1]["content"] == "the answer"
+    assert "Attach Files" not in calls[1]["content"]
+
+
+async def test_send_text_without_images_does_not_retry():
+    calls = []
+
+    async def create_message(channel_id, **kwargs):
+        calls.append(kwargs)
+        raise RuntimeError("boom")
+
+    engine = _engine(AsyncMock(side_effect=create_message))
+    ok = await engine._send_text("plain text", reply_to=None, images=None)
+
+    assert ok is False
+    assert len(calls) == 1  # no fallback loop when there was no attachment
+
+
+async def test_post_images_notes_missing_permission():
+    calls = []
+
+    async def create_message(channel_id, **kwargs):
+        calls.append(kwargs)
+        if "attachments" in kwargs:
+            raise _forbidden()
+        return MagicMock()
+
+    engine = _engine(AsyncMock(side_effect=create_message))
+    ok = await engine._post_images([_img()], reply_to=None)
+
+    assert ok is False  # the image itself didn't post
+    # But a permission note was sent so the turn isn't silent.
+    assert len(calls) == 2
+    assert "Attach Files" in calls[1]["content"]
+
+
+# -- image-only turn should not burn a no-response strike -----------------
+
+
+def _no_response_output() -> SimpleNamespace:
+    return SimpleNamespace(
+        response=None, topic="topic", notes=None, continue_watching=True
+    )
+
+
+async def _apply(engine: ChannelEngine, output, images):
+    memory = MagicMock()
+    memory.write_topic = AsyncMock()
+    memory.write_notes = AsyncMock()
+    with patch(
+        "smarter_dev.bot.services.chat_engine.get_chat_memory",
+        return_value=memory,
+    ):
+        return await engine._apply_output(output, images)
+
+
+async def test_image_only_turn_does_not_burn_a_no_response_strike():
+    engine = _engine(AsyncMock(return_value=MagicMock()))  # image posts fine
+    engine.consecutive_no_response = MAX_NO_RESPONSE_TURNS - 1  # one before cutoff
+
+    outcome = await _apply(engine, _no_response_output(), [_img()])
+
+    # Posting the image is engagement — the strike counter resets, no deactivation.
+    assert engine.consecutive_no_response == 0
+    assert outcome.deactivate_reason is None
+
+
+async def test_image_only_turn_that_fails_to_post_counts_as_silence():
+    engine = _engine(AsyncMock(side_effect=RuntimeError("no perms")))
+    engine.consecutive_no_response = MAX_NO_RESPONSE_TURNS - 1
+
+    outcome = await _apply(engine, _no_response_output(), [_img()])
+
+    # Nothing was delivered, so it IS a no-response turn and trips the cutoff.
+    assert engine.consecutive_no_response == MAX_NO_RESPONSE_TURNS
+    assert outcome.deactivate_reason == "no_response_quota"
+
+
+async def test_no_image_no_response_still_counts_as_silence():
+    engine = _engine(AsyncMock(return_value=MagicMock()))
+    engine.consecutive_no_response = 0
+
+    outcome = await _apply(engine, _no_response_output(), [])
+
+    assert engine.consecutive_no_response == 1
+    assert outcome.deactivate_reason is None


### PR DESCRIPTION
Follow-up to #46 after a prod incident: a generated image was never delivered and the whole reply went silent.

## Root cause (from bot logs)
Image generated fine and the quota slot was spent, but posting the reply **with the image attached** hit `hikari.ForbiddenError: 403 (50013) Missing Permissions` — the bot lacks **Attach Files** in that channel. Because the image rode on the same `create_message` as the text, the 403 killed the entire reply.

## Changes
- **Attach-permission fallback** — if the image can't attach, the text answer is resent **without** the attachment so the reply still lands, with a note when it's the missing "Attach Files" permission (`_send_text` / `_post_images`).
- **Crash salvage** — if `agent.run()` throws *after* `generate_image` already spent a slot and stashed an image, the run handler now posts that image instead of dropping it (generic error only if nothing was delivered).
- **No burned turn** — an image-only turn (no text) now counts as engagement: resets `consecutive_no_response` and updates `last_sent_at`, so it no longer nudges toward the 3-strike auto-deactivation. Only a turn that delivers nothing counts as silence.

## Note (ops)
The underlying unblock is still granting the bot **Attach Files** (+ Embed Links) in the channel. These changes make the failure mode non-silent and non-wasteful, not a substitute for the permission.

## Tests
`tests/bot/services/test_chat_engine_image_send.py` — 7 tests (attach fallback, permission note, image-only strike counting). Full engine suite green bar the 2 pre-existing unrelated failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)