### PR TITLE
fix: admin ban with reason crashed on duplicate headers kwarg

### DIFF
--- a/smarter_dev/web/admin_actions.py
+++ b/smarter_dev/web/admin_actions.py
@@ -10,47 +10,33 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
+from typing import ClassVar
+from urllib.parse import quote
 
-import httpx
-
-_API_BASE = "https://discord.com/api/v10"
+from smarter_dev.web.discord_rest import DiscordBotClient, DiscordRestError
 
 
-class AdminActionError(Exception):
+class AdminActionError(DiscordRestError):
     """A moderation action's REST call failed."""
 
 
-@dataclass
-class AdminActor:
+@dataclass(kw_only=True)
+class AdminActor(DiscordBotClient):
     """Performs moderation actions for one guild via Discord REST."""
 
-    bot_token: str
     guild_id: str
-    timeout: float = 15.0
 
-    @property
-    def _headers(self) -> dict[str, str]:
-        return {
-            "Authorization": f"Bot {self.bot_token}",
-            "User-Agent": "SmarterDev-AdminHandlers/1.0",
-        }
-
-    async def _request(self, method: str, endpoint: str, **kwargs) -> None:
-        async with httpx.AsyncClient(timeout=self.timeout) as client:
-            response = await client.request(
-                method, f"{_API_BASE}{endpoint}", headers=self._headers, **kwargs
-            )
-        if response.status_code >= 400:
-            raise AdminActionError(
-                f"{method} {endpoint} -> {response.status_code}: {response.text[:300]}"
-            )
+    user_agent: ClassVar[str] = "SmarterDev-AdminHandlers/1.0"
+    error_type: ClassVar[type[DiscordRestError]] = AdminActionError
 
     async def ban_user(self, user_id: str, reason: str | None = None) -> str:
-        kwargs: dict = {}
-        if reason:
-            kwargs["headers"] = {**self._headers, "X-Audit-Log-Reason": reason[:400]}
+        # Discord expects the audit-log reason URL-encoded; encoding also keeps
+        # non-latin-1 reasons (em dashes, emoji) out of raw header bytes.
+        headers = (
+            {"X-Audit-Log-Reason": quote(reason[:400])} if reason else None
+        )
         await self._request(
-            "PUT", f"/guilds/{self.guild_id}/bans/{user_id}", **kwargs
+            "PUT", f"/guilds/{self.guild_id}/bans/{user_id}", headers=headers
         )
         return f"banned {user_id}"
 

--- a/smarter_dev/web/discord_rest.py
+++ b/smarter_dev/web/discord_rest.py
@@ -1,0 +1,70 @@
+"""Shared bot-token Discord REST plumbing for the worker tier.
+
+The handler runtime runs in the agent-worker process, which has no gateway
+connection — everything a handler does to Discord goes out as a plain
+bot-token REST call. This module is the single place that builds those calls
+(auth headers, base URL, error mapping); :class:`DiscordEmitter` and
+:class:`AdminActor` are thin subclasses that add their endpoints.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import ClassVar
+
+import httpx
+
+API_BASE = "https://discord.com/api/v10"
+_ERROR_BODY_MAX = 500
+
+
+class DiscordRestError(Exception):
+    """A Discord REST call failed with an error status."""
+
+
+@dataclass(kw_only=True)
+class DiscordBotClient:
+    """Minimal bot-token REST caller.
+
+    Subclasses override ``user_agent`` to identify themselves and
+    ``error_type`` so callers can keep catching their existing exception.
+    """
+
+    bot_token: str
+    timeout: float = 15.0
+    # Handed to httpx.AsyncClient so tests can drive the real request path
+    # with a MockTransport; None means httpx's default network transport.
+    transport: httpx.AsyncBaseTransport | None = None
+
+    user_agent: ClassVar[str] = "SmarterDev/1.0"
+    error_type: ClassVar[type[DiscordRestError]] = DiscordRestError
+
+    @property
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bot {self.bot_token}",
+            "User-Agent": self.user_agent,
+        }
+
+    async def _request(
+        self,
+        method: str,
+        endpoint: str,
+        *,
+        headers: dict[str, str] | None = None,
+        **kwargs,
+    ) -> httpx.Response:
+        """Send one request; extra ``headers`` merge over the auth headers."""
+        merged_headers = {**self._headers, **(headers or {})}
+        async with httpx.AsyncClient(
+            timeout=self.timeout, transport=self.transport
+        ) as client:
+            response = await client.request(
+                method, f"{API_BASE}{endpoint}", headers=merged_headers, **kwargs
+            )
+        if response.status_code >= 400:
+            raise self.error_type(
+                f"{method} {endpoint} -> {response.status_code}: "
+                f"{response.text[:_ERROR_BODY_MAX]}"
+            )
+        return response

--- a/smarter_dev/web/handler_emitter.py
+++ b/smarter_dev/web/handler_emitter.py
@@ -6,22 +6,21 @@ is the *only* way a handler reaches a channel; the sandboxed script can call it
 solely through the metered external functions in
 :mod:`smarter_dev.web.handler_runtime`.
 
-Kept deliberately small: send a message, add a reaction. Mirrors the request
-shape of :class:`smarter_dev.web.admin.discord.DiscordClient` but for the
-POST/PUT endpoints that client does not expose.
+Kept deliberately small: send a message, add a reaction. Request plumbing
+lives in :mod:`smarter_dev.web.discord_rest`, shared with ``AdminActor``.
 """
 
 from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from typing import ClassVar
 from urllib.parse import quote
 
-import httpx
+from smarter_dev.web.discord_rest import DiscordBotClient, DiscordRestError
 
 logger = logging.getLogger(__name__)
 
-_API_BASE = "https://discord.com/api/v10"
 _MESSAGE_MAX = 2000
 # Discord message flag: suppress auto-generated link-preview embeds. Handler
 # output is often a list of links (e.g. a news digest); without this each URL
@@ -29,36 +28,16 @@ _MESSAGE_MAX = 2000
 _SUPPRESS_EMBEDS = 1 << 2
 
 
-class DiscordEmitError(Exception):
+class DiscordEmitError(DiscordRestError):
     """A Discord REST emit failed."""
 
 
-@dataclass
-class DiscordEmitter:
+@dataclass(kw_only=True)
+class DiscordEmitter(DiscordBotClient):
     """Minimal bot-token REST emitter used by handler executions."""
 
-    bot_token: str
-    timeout: float = 15.0
-
-    @property
-    def _headers(self) -> dict[str, str]:
-        return {
-            "Authorization": f"Bot {self.bot_token}",
-            "User-Agent": "SmarterDev-Handlers/1.0",
-        }
-
-    async def _request(self, method: str, endpoint: str, **kwargs) -> httpx.Response:
-        url = f"{_API_BASE}{endpoint}"
-        async with httpx.AsyncClient(timeout=self.timeout) as client:
-            response = await client.request(
-                method, url, headers=self._headers, **kwargs
-            )
-        if response.status_code >= 400:
-            body = response.text[:500]
-            raise DiscordEmitError(
-                f"{method} {endpoint} -> {response.status_code}: {body}"
-            )
-        return response
+    user_agent: ClassVar[str] = "SmarterDev-Handlers/1.0"
+    error_type: ClassVar[type[DiscordRestError]] = DiscordEmitError
 
     async def create_message(self, channel_id: str, content: str) -> str:
         """Post a message to a channel; return the new message id.

--- a/tests/web/admin_actions_test.py
+++ b/tests/web/admin_actions_test.py
@@ -1,42 +1,84 @@
-"""Tests for AdminActor (moderation REST calls)."""
+"""Tests for AdminActor (moderation REST calls).
+
+These run through the real ``_request`` path over ``httpx.MockTransport`` — a
+mock of ``_request`` itself is what let the ban-with-reason double-``headers``
+TypeError reach production.
+"""
 
 from __future__ import annotations
 
-from smarter_dev.web.admin_actions import AdminActor
+import json
+
+import httpx
+import pytest
+
+from smarter_dev.web.admin_actions import AdminActionError, AdminActor
 
 
-class _RecordingActor(AdminActor):
-    def __init__(self):
-        super().__init__(bot_token="t", guild_id="G1")
-        self.calls = []
+def _actor(requests: list[httpx.Request], status_code: int = 204) -> AdminActor:
+    def handle(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(status_code)
 
-    async def _request(self, method, endpoint, **kwargs):
-        self.calls.append((method, endpoint, kwargs))
+    return AdminActor(
+        bot_token="t", guild_id="G1", transport=httpx.MockTransport(handle)
+    )
 
 
-async def test_ban_user():
-    a = _RecordingActor()
-    out = await a.ban_user("U1", reason="scam")
+async def test_ban_user_with_reason_sends_auth_and_audit_headers():
+    """Regression: a ban with a reason must not crash on duplicate headers."""
+    requests: list[httpx.Request] = []
+    out = await _actor(requests).ban_user("U1", reason="scam")
     assert "banned U1" in out
-    assert a.calls[0][:2] == ("PUT", "/guilds/G1/bans/U1")
-    assert "X-Audit-Log-Reason" in a.calls[0][2].get("headers", {})
+    request = requests[0]
+    assert request.method == "PUT"
+    assert request.url.path.endswith("/guilds/G1/bans/U1")
+    assert request.headers["Authorization"] == "Bot t"
+    assert request.headers["X-Audit-Log-Reason"] == "scam"
+
+
+async def test_ban_user_without_reason():
+    requests: list[httpx.Request] = []
+    await _actor(requests).ban_user("U1")
+    request = requests[0]
+    assert request.method == "PUT"
+    assert request.url.path.endswith("/guilds/G1/bans/U1")
+    assert "X-Audit-Log-Reason" not in request.headers
+
+
+async def test_ban_reason_is_url_encoded_for_the_audit_header():
+    """Non-latin-1 reasons must not crash httpx's header encoding."""
+    requests: list[httpx.Request] = []
+    await _actor(requests).ban_user("U1", reason="crypto scam — telegram")
+    assert requests[0].headers["X-Audit-Log-Reason"] == "crypto%20scam%20%E2%80%94%20telegram"
 
 
 async def test_kick_user():
-    a = _RecordingActor()
-    await a.kick_user("U1")
-    assert a.calls[0][:2] == ("DELETE", "/guilds/G1/members/U1")
+    requests: list[httpx.Request] = []
+    await _actor(requests).kick_user("U1")
+    request = requests[0]
+    assert request.method == "DELETE"
+    assert request.url.path.endswith("/guilds/G1/members/U1")
 
 
 async def test_timeout_user():
-    a = _RecordingActor()
-    await a.timeout_user("U1", duration_seconds=120)
-    method, endpoint, kwargs = a.calls[0]
-    assert (method, endpoint) == ("PATCH", "/guilds/G1/members/U1")
-    assert "communication_disabled_until" in kwargs["json"]
+    requests: list[httpx.Request] = []
+    await _actor(requests).timeout_user("U1", duration_seconds=120)
+    request = requests[0]
+    assert request.method == "PATCH"
+    assert request.url.path.endswith("/guilds/G1/members/U1")
+    assert "communication_disabled_until" in json.loads(request.content)
 
 
 async def test_delete_message():
-    a = _RecordingActor()
-    await a.delete_message("C1", "M1")
-    assert a.calls[0][:2] == ("DELETE", "/channels/C1/messages/M1")
+    requests: list[httpx.Request] = []
+    await _actor(requests).delete_message("C1", "M1")
+    request = requests[0]
+    assert request.method == "DELETE"
+    assert request.url.path.endswith("/channels/C1/messages/M1")
+
+
+async def test_error_status_raises_admin_action_error():
+    requests: list[httpx.Request] = []
+    with pytest.raises(AdminActionError):
+        await _actor(requests, status_code=403).kick_user("U1")

--- a/tests/web/discord_rest_test.py
+++ b/tests/web/discord_rest_test.py
@@ -1,0 +1,95 @@
+"""Tests for the shared bot-token Discord REST client."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from smarter_dev.web.discord_rest import (
+    API_BASE,
+    DiscordBotClient,
+    DiscordRestError,
+)
+
+
+def _recording_transport(
+    requests: list[httpx.Request], status_code: int = 200, body: str = "{}"
+) -> httpx.MockTransport:
+    def handle(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(status_code, text=body)
+
+    return httpx.MockTransport(handle)
+
+
+async def test_request_sends_bot_auth_headers():
+    requests: list[httpx.Request] = []
+    client = DiscordBotClient(
+        bot_token="tok", transport=_recording_transport(requests)
+    )
+    await client._request("GET", "/users/@me")
+    request = requests[0]
+    assert str(request.url) == f"{API_BASE}/users/@me"
+    assert request.headers["Authorization"] == "Bot tok"
+    assert request.headers["User-Agent"] == DiscordBotClient.user_agent
+
+
+async def test_request_merges_extra_headers_with_auth_headers():
+    """Regression: extra headers must merge, not collide with the auth headers.
+
+    The pre-extraction AdminActor passed ``headers`` both explicitly and via
+    ``**kwargs``, so any ban with an audit-log reason crashed with a TypeError
+    before the request was ever sent.
+    """
+    requests: list[httpx.Request] = []
+    client = DiscordBotClient(
+        bot_token="tok", transport=_recording_transport(requests)
+    )
+    await client._request(
+        "PUT", "/guilds/G/bans/U", headers={"X-Audit-Log-Reason": "scam"}
+    )
+    request = requests[0]
+    assert request.headers["Authorization"] == "Bot tok"
+    assert request.headers["X-Audit-Log-Reason"] == "scam"
+
+
+async def test_request_returns_response_on_success():
+    requests: list[httpx.Request] = []
+    client = DiscordBotClient(
+        bot_token="tok",
+        transport=_recording_transport(requests, body='{"id": "42"}'),
+    )
+    response = await client._request("POST", "/channels/C/messages")
+    assert response.json() == {"id": "42"}
+
+
+async def test_request_raises_error_type_on_error_status():
+    requests: list[httpx.Request] = []
+    client = DiscordBotClient(
+        bot_token="tok",
+        transport=_recording_transport(requests, status_code=403, body="Forbidden"),
+    )
+    with pytest.raises(DiscordRestError) as exc_info:
+        await client._request("DELETE", "/guilds/G/members/U")
+    message = str(exc_info.value)
+    assert "DELETE /guilds/G/members/U" in message
+    assert "403" in message
+    assert "Forbidden" in message
+
+
+async def test_subclass_error_type_and_user_agent_are_used():
+    class _CustomError(DiscordRestError):
+        pass
+
+    class _CustomClient(DiscordBotClient):
+        user_agent = "Custom-Agent/1.0"
+        error_type = _CustomError
+
+    requests: list[httpx.Request] = []
+    client = _CustomClient(
+        bot_token="tok",
+        transport=_recording_transport(requests, status_code=500, body="boom"),
+    )
+    with pytest.raises(_CustomError):
+        await client._request("GET", "/gateway")
+    assert requests[0].headers["User-Agent"] == "Custom-Agent/1.0"

--- a/tests/web/handler_emitter_test.py
+++ b/tests/web/handler_emitter_test.py
@@ -1,0 +1,63 @@
+"""Tests for DiscordEmitter (worker-tier message/reaction REST calls)."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from smarter_dev.web.handler_emitter import DiscordEmitError, DiscordEmitter
+
+
+def _emitter(
+    requests: list[httpx.Request], status_code: int = 200, body: str = "{}"
+) -> DiscordEmitter:
+    def handle(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(status_code, text=body)
+
+    return DiscordEmitter(bot_token="t", transport=httpx.MockTransport(handle))
+
+
+async def test_create_message_posts_content_and_returns_id():
+    requests: list[httpx.Request] = []
+    message_id = await _emitter(requests, body='{"id": "M9"}').create_message(
+        "C1", "hello"
+    )
+    assert message_id == "M9"
+    request = requests[0]
+    assert request.method == "POST"
+    assert request.url.path.endswith("/channels/C1/messages")
+    assert request.headers["Authorization"] == "Bot t"
+    payload = json.loads(request.content)
+    assert payload["content"] == "hello"
+    # Link-preview embeds are suppressed so URL-heavy output doesn't flood.
+    assert payload["flags"] == 1 << 2
+
+
+async def test_create_message_truncates_to_discord_limit():
+    requests: list[httpx.Request] = []
+    await _emitter(requests, body='{"id": "M9"}').create_message("C1", "x" * 3000)
+    assert len(json.loads(requests[0].content)["content"]) == 2000
+
+
+async def test_add_reaction_encodes_emoji():
+    requests: list[httpx.Request] = []
+    await _emitter(requests, status_code=204).add_reaction(
+        "C1", "M1", "<party:12345>"
+    )
+    request = requests[0]
+    assert request.method == "PUT"
+    # str(url) preserves the wire encoding; url.path would show it decoded.
+    assert str(request.url).endswith(
+        "/channels/C1/messages/M1/reactions/party%3A12345/@me"
+    )
+
+
+async def test_error_status_raises_emit_error():
+    requests: list[httpx.Request] = []
+    with pytest.raises(DiscordEmitError):
+        await _emitter(requests, status_code=403, body="nope").create_message(
+            "C1", "hello"
+        )


### PR DESCRIPTION
## What happened

The scam-monitor admin handler correctly flagged a scammer on 2026-07-02 08:50 UTC, but the ban crashed with `TypeError: httpx AsyncClient.request() got multiple values for keyword argument 'headers'` — the scammer was never banned. `AdminActor.ban_user` stuffed a merged headers dict into `**kwargs` while `_request` also passed `headers=` explicitly, so **every ban with an audit-log reason has always failed**. Kick/timeout/delete and reason-less bans were unaffected.

## Fix

- New `smarter_dev/web/discord_rest.py`: shared `DiscordBotClient` base for the worker tier's bot-token REST calls. Caller-supplied headers merge over the auth headers in exactly one place; `DiscordEmitter` and `AdminActor` are now thin subclasses. `admin/discord.py`'s admin-UI client is deliberately left alone (different error semantics).
- `ban_user` passes the audit-log reason as a clean `headers=` argument, and URL-encodes it — Discord expects `X-Audit-Log-Reason` URL-encoded, and a non-latin-1 reason (em dash, emoji) would otherwise crash httpx's header encoding.
- Exception types are preserved: `DiscordEmitError` and `AdminActionError` still exist, now subclassing the shared `DiscordRestError`.

## Tests

The old test mocked `_request` itself, which is exactly how this bug got through. The new tests drive the real request path over `httpx.MockTransport`:

- regression: ban-with-reason sends a single merged header set (Authorization + X-Audit-Log-Reason)
- regression: non-latin-1 reason is URL-encoded rather than crashing
- first-time coverage for `DiscordEmitter` (message post, 2000-char truncation, embed suppression, emoji encoding)

All 100 handler-related tests pass; semgrep and gitleaks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017RP9r7JpmkDMqKdbRiJdVN