### PR TITLE
feat: named handlers — multiple per trigger, author decides edit-vs-create

### DIFF
--- a/alembic/main/versions/20260702_120000_a9c4e2f7b1d3_named_handlers.py
+++ b/alembic/main/versions/20260702_120000_a9c4e2f7b1d3_named_handlers.py
@@ -1,0 +1,85 @@
+"""Named handlers: multiple per (channel, trigger), each with a unique name.
+
+Adds ``name`` to channel_handlers (unique per channel) and admin_handlers
+(unique per guild), backfilled as ``<trigger>-<first 8 of id>`` for existing
+rows. Drops the single-listener partial unique index — any number of event
+handlers may now share a (channel, trigger) and every enabled one fires.
+
+Revision ID: a9c4e2f7b1d3
+Revises: f1a3d6c8b2e9
+Create Date: 2026-07-02 12:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "a9c4e2f7b1d3"
+down_revision: Union[str, None] = "f1a3d6c8b2e9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "channel_handlers", sa.Column("name", sa.String(length=64), nullable=True)
+    )
+    op.execute(
+        "UPDATE channel_handlers "
+        "SET name = trigger_type || '-' || substr(CAST(id AS TEXT), 1, 8)"
+    )
+    op.alter_column("channel_handlers", "name", nullable=False)
+    op.drop_index("uq_channel_handlers_event_listener", table_name="channel_handlers")
+    op.create_index(
+        "uq_channel_handlers_channel_name",
+        "channel_handlers",
+        ["channel_id", "name"],
+        unique=True,
+    )
+
+    op.add_column(
+        "admin_handlers", sa.Column("name", sa.String(length=64), nullable=True)
+    )
+    op.execute(
+        "UPDATE admin_handlers "
+        "SET name = trigger_type || '-' || substr(CAST(id AS TEXT), 1, 8)"
+    )
+    op.alter_column("admin_handlers", "name", nullable=False)
+    op.create_index(
+        "uq_admin_handlers_guild_name",
+        "admin_handlers",
+        ["guild_id", "name"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("uq_admin_handlers_guild_name", table_name="admin_handlers")
+    op.drop_column("admin_handlers", "name")
+
+    op.drop_index(
+        "uq_channel_handlers_channel_name", table_name="channel_handlers"
+    )
+    # Restore the single-listener invariant; keep the newest event handler per
+    # (channel, trigger) and drop the rest so the unique index can be built.
+    op.execute(
+        "DELETE FROM channel_handlers WHERE trigger_type IN ('message', 'reaction') "
+        "AND id NOT IN ("
+        "  SELECT id FROM ("
+        "    SELECT DISTINCT ON (channel_id, trigger_type) id FROM channel_handlers "
+        "    WHERE trigger_type IN ('message', 'reaction') "
+        "    ORDER BY channel_id, trigger_type, id DESC"
+        "  ) AS keep"
+        ")"
+    )
+    op.drop_column("channel_handlers", "name")
+    op.create_index(
+        "uq_channel_handlers_event_listener",
+        "channel_handlers",
+        ["channel_id", "trigger_type"],
+        unique=True,
+        postgresql_where=sa.text("trigger_type IN ('message', 'reaction')"),
+        sqlite_where=sa.text("trigger_type IN ('message', 'reaction')"),
+    )

--- a/smarter_dev/bot/agents/handler_authoring.py
+++ b/smarter_dev/bot/agents/handler_authoring.py
@@ -5,11 +5,12 @@ in the live user-interaction context — so a *triggered* execution, which runs 
 the worker, structurally has no path to this code. That is the "triggered
 executions can't author" invariant, enforced by where the code lives.
 
-Pipeline: Author (Gemini 3 Flash) writes a script or returns ``ERROR:``; the
-host-side :mod:`~smarter_dev.web.handler_lint` rejects opaque blobs / dynamic
-execution; Judge (Gemini 3 Flash) reviews the script as inert data and
-APPROVEs or REJECTs. The author and judge callables are injectable so the
-orchestration is unit-testable without any model calls.
+Pipeline: Author (Gemini 3 Flash) sees the existing named handlers and returns
+a structured plan — edit one of them or create a new, named one — or marks the
+request infeasible; the host-side :mod:`~smarter_dev.web.handler_lint` rejects
+opaque blobs / dynamic execution; Judge (Gemini 3 Flash) reviews the script as
+inert data and APPROVEs or REJECTs. The author and judge callables are
+injectable so the orchestration is unit-testable without any model calls.
 """
 
 from __future__ import annotations
@@ -63,15 +64,56 @@ Judge = Callable[[str, str], Awaitable["JudgeVerdict"]]
 Progress = Callable[[str], Awaitable[None]]
 
 
-class AdminHandlerPlan(BaseModel):
-    """The admin author's structured plan — trigger/scope/script in one shot.
+class HandlerPlan(BaseModel):
+    """The author's structured plan: edit one of the channel's handlers or
+    create a new, named one.
 
-    The admin describes a behavior in free text; the author decides everything.
-    ``channel_ids`` empty = all channels in the guild.
+    The author sees the channel's existing handlers (name, trigger, script) and
+    decides. ``target_handler_id`` names the handler to edit; ``name`` labels a
+    newly created one.
     """
 
     feasible: bool = Field(description="False if the request can't fit the limits")
     error: str = Field(default="", description="One-line reason when not feasible")
+    action: str = Field(
+        default="create", description="'edit' an existing handler or 'create' a new one"
+    )
+    target_handler_id: str = Field(
+        default="", description="handler_id of the handler to edit (action='edit')"
+    )
+    name: str = Field(
+        default="", description="Short kebab-case name for a new handler (action='create')"
+    )
+    trigger_type: str = Field(
+        default="message", description="message | reaction | schedule | timer"
+    )
+    settings: dict = Field(default_factory=dict, description="Timing for time triggers")
+    description: str = Field(
+        default="",
+        description="One line: what the handler does AFTER this change",
+    )
+    script: str = Field(default="", description="The Monty script")
+
+
+class AdminHandlerPlan(BaseModel):
+    """The admin author's structured plan — edit-vs-create, trigger/scope/script.
+
+    The admin describes a behavior in free text; the author sees the guild's
+    existing admin handlers and decides everything. ``channel_ids`` empty = all
+    channels in the guild.
+    """
+
+    feasible: bool = Field(description="False if the request can't fit the limits")
+    error: str = Field(default="", description="One-line reason when not feasible")
+    action: str = Field(
+        default="create", description="'edit' an existing handler or 'create' a new one"
+    )
+    target_handler_id: str = Field(
+        default="", description="handler_id of the handler to edit (action='edit')"
+    )
+    name: str = Field(
+        default="", description="Short kebab-case name for a new handler (action='create')"
+    )
     trigger_type: str = Field(
         default="message", description="message | reaction | schedule | timer"
     )
@@ -79,14 +121,24 @@ class AdminHandlerPlan(BaseModel):
         default_factory=list, description="Channel scope; empty = all channels"
     )
     settings: dict = Field(default_factory=dict, description="Timing for time triggers")
+    description: str = Field(
+        default="",
+        description="One line: what the handler does AFTER this change",
+    )
     script: str = Field(default="", description="The Monty script")
 
 
 @dataclass
 class CreationResult:
-    """Outcome of the creation pipeline."""
+    """Outcome of the creation pipeline: an approved create or edit."""
 
     ok: bool
+    action: str | None = None
+    target_handler_id: str | None = None
+    name: str | None = None
+    trigger_type: str | None = None
+    settings: dict | None = None
+    description: str | None = None
     script: str | None = None
     error: str | None = None
 
@@ -96,11 +148,116 @@ class AdminCreationResult:
     """Outcome of the admin creation pipeline (carries trigger/scope/settings)."""
 
     ok: bool
+    action: str | None = None
+    target_handler_id: str | None = None
+    name: str | None = None
     trigger_type: str | None = None
     channel_ids: list[str] | None = None
     settings: dict | None = None
+    description: str | None = None
     script: str | None = None
     error: str | None = None
+
+
+@dataclass
+class _ResolvedTarget:
+    """A plan's edit/create intent validated against the real handler list."""
+
+    action: str
+    target_handler_id: str | None
+    name: str
+    trigger_type: str
+    settings: dict
+
+
+def _resolve_plan_target(
+    *,
+    action: str,
+    target_handler_id: str,
+    name: str,
+    trigger_type: str,
+    settings: dict,
+    existing_handlers: list[dict],
+) -> tuple[str, None] | tuple[None, _ResolvedTarget]:
+    """Validate edit-vs-create against the handlers the author was shown.
+
+    Returns ``(error, None)`` or ``(None, resolved)``. On edit the target's
+    trigger wins (a handler cannot change trigger type) and its settings are
+    kept unless the plan supplies new ones. On create the name must be new
+    (case-insensitive) among the existing handlers.
+    """
+    if action == "edit":
+        target = next(
+            (h for h in existing_handlers if h["handler_id"] == target_handler_id),
+            None,
+        )
+        if target is None:
+            return (
+                f"the author chose to edit unknown handler {target_handler_id!r}",
+                None,
+            )
+        return None, _ResolvedTarget(
+            action="edit",
+            target_handler_id=target_handler_id,
+            name=target["name"],
+            trigger_type=target["trigger_type"],
+            settings=dict(settings) if settings else dict(target.get("settings") or {}),
+        )
+
+    if action != "create":
+        return f"the author chose an invalid action {action!r}", None
+    cleaned_name = name.strip()
+    if not cleaned_name or len(cleaned_name) > 64:
+        return "the author didn't give the new handler a usable name", None
+    taken = {h["name"].casefold() for h in existing_handlers}
+    if cleaned_name.casefold() in taken:
+        return f"a handler named {cleaned_name!r} already exists — the author should edit it", None
+    if trigger_type not in HANDLER_TRIGGER_TYPES:
+        return f"the author chose an invalid trigger {trigger_type!r}", None
+    return None, _ResolvedTarget(
+        action="create",
+        target_handler_id=None,
+        name=cleaned_name,
+        trigger_type=trigger_type,
+        settings=dict(settings),
+    )
+
+
+def _final_description(
+    plan_description: str,
+    resolved: _ResolvedTarget,
+    existing_handlers: list[dict],
+    request: str,
+) -> str:
+    """The stored handler description: the author's restatement when given,
+    else the target's old description (edit) or the raw request (create)."""
+    cleaned = plan_description.strip()
+    if cleaned:
+        return cleaned
+    if resolved.action == "edit":
+        target = next(
+            h for h in existing_handlers if h["handler_id"] == resolved.target_handler_id
+        )
+        return target.get("description", "") or request
+    return request
+
+
+def _render_existing_handlers(existing_handlers: list[dict]) -> str:
+    """The handler inventory the author decides against, scripts included."""
+    if not existing_handlers:
+        return "There are NO existing handlers here — any request means creating a new one."
+    blocks = []
+    for h in existing_handlers:
+        blocks.append(
+            f"- handler_id: {h['handler_id']}\n"
+            f"  name: {h['name']} | trigger: {h['trigger_type']} | "
+            f"settings: {json.dumps(h.get('settings') or {})}\n"
+            f"  description: {h.get('description', '')}\n"
+            f"  script:\n  ---\n{h.get('script', '')}\n  ---"
+        )
+    return "Existing handlers (edit ONE of these, or create a new one):\n" + "\n".join(
+        blocks
+    )
 
 
 def _humanize_seconds(seconds: int) -> str:
@@ -185,16 +342,17 @@ _HANDLER_THINKING = GoogleModelSettings(
 )
 
 
-_author_agent: Agent[_AuthorDeps, str] | None = None
+_author_agent: Agent[_AuthorDeps, HandlerPlan] | None = None
 _judge_agent: Agent[None, JudgeVerdict] | None = None
 
 
-def _get_author_agent() -> Agent[_AuthorDeps, str]:
+def _get_author_agent() -> Agent[_AuthorDeps, HandlerPlan]:
     global _author_agent
     if _author_agent is None:
         _author_agent = Agent(
             _build_google_model(get_settings().handler_author_model),
             deps_type=_AuthorDeps,
+            output_type=HandlerPlan,
             system_prompt=AUTHOR_PROMPT,
             tools=[_list_channel_emojis],
             model_settings=_HANDLER_THINKING,
@@ -215,36 +373,30 @@ def _get_judge_agent() -> Agent[None, JudgeVerdict]:
 
 
 def _build_author_prompt(
-    description: str, trigger_type: str, settings: dict, existing_script: str | None
+    request: str, trigger_type: str, settings: dict, existing_handlers: list[dict]
 ) -> str:
-    parts = [
-        f"Trigger: {trigger_type}",
-        f"Settings: {json.dumps(settings)}",
-        f"Description:\n{description}",
-    ]
-    if existing_script:
-        parts.append(
-            "An existing handler is installed for this channel + trigger. Merge the "
-            "new behavior into it, or replace it — the combined result must still "
-            "satisfy every limit. Existing script:\n---\n"
-            + existing_script
-            + "\n---"
-        )
-    return "\n\n".join(parts)
+    return "\n\n".join(
+        [
+            f"Requested trigger (a hint — you decide): {trigger_type}",
+            f"Requested settings (a hint — you decide): {json.dumps(settings)}",
+            f"Request:\n{request}",
+            _render_existing_handlers(existing_handlers),
+        ]
+    )
 
 
 async def _default_author(
     *,
-    description: str,
+    request: str,
     trigger_type: str,
     settings: dict,
-    existing_script: str | None,
+    existing_handlers: list[dict],
     emoji_lister: EmojiLister,
-) -> str:
+) -> HandlerPlan:
     agent = _get_author_agent()
-    prompt = _build_author_prompt(description, trigger_type, settings, existing_script)
+    prompt = _build_author_prompt(request, trigger_type, settings, existing_handlers)
     result = await agent.run(prompt, deps=_AuthorDeps(list_emojis=emoji_lister))
-    return str(result.output)
+    return result.output
 
 
 async def _default_judge(script: str, trigger_context: str) -> JudgeVerdict:
@@ -264,47 +416,64 @@ async def _empty_emoji_lister() -> list[dict]:
 
 async def run_creation_pipeline(
     *,
-    description: str,
+    request: str,
     trigger_type: str,
     settings: dict,
-    existing_script: str | None = None,
+    existing_handlers: list[dict],
     emoji_lister: EmojiLister | None = None,
     author: Author | None = None,
     judge: Judge | None = None,
     progress: Progress | None = None,
 ) -> CreationResult:
-    """Author -> lint -> judge. Return an approved script or a one-line error.
+    """Author (plans edit-vs-create) -> lint -> judge.
 
-    Each stage is logged (description, author output, lint result, judge verdict)
-    so a rejection is always diagnosable from the bot log, and the returned
-    error carries a concrete reason the chatbot can relay verbatim.
+    The author sees the channel's existing named handlers and either edits one
+    (by handler_id) or creates a new, named one. ``trigger_type``/``settings``
+    are the chatbot's hints; the validated plan is authoritative. Each stage is
+    logged so a rejection is always diagnosable from the bot log, and the
+    returned error carries a concrete reason the chatbot can relay verbatim.
     """
     author = author or _default_author
     judge = judge or _default_judge
     emoji_lister = emoji_lister or _empty_emoji_lister
 
     logger.info(
-        "creation pipeline: trigger=%s settings=%s description=%r",
-        trigger_type, settings, description,
+        "creation pipeline: trigger=%s settings=%s request=%r existing=%d",
+        trigger_type, settings, request, len(existing_handlers),
     )
 
-    raw = (
-        await author(
-            description=description,
-            trigger_type=trigger_type,
-            settings=settings,
-            existing_script=existing_script,
-            emoji_lister=emoji_lister,
+    plan = await author(
+        request=request,
+        trigger_type=trigger_type,
+        settings=settings,
+        existing_handlers=existing_handlers,
+        emoji_lister=emoji_lister,
+    )
+    logger.info(
+        "author plan: feasible=%s action=%s target=%s name=%s trigger=%s settings=%s\n%s",
+        plan.feasible, plan.action, plan.target_handler_id, plan.name,
+        plan.trigger_type, plan.settings, plan.script,
+    )
+
+    if not plan.feasible:
+        return CreationResult(
+            ok=False,
+            error=f"the author couldn't build this: {plan.error or 'not feasible'}",
         )
-    ).strip()
-    logger.info("author output:\n%s", raw)
 
-    if raw.upper().startswith("ERROR:"):
-        detail = raw.split(":", 1)[1].strip()
-        logger.info("author declined: %s", detail)
-        return CreationResult(ok=False, error=f"the author couldn't build this: {detail}")
+    error, resolved = _resolve_plan_target(
+        action=plan.action,
+        target_handler_id=plan.target_handler_id,
+        name=plan.name,
+        trigger_type=plan.trigger_type,
+        settings=plan.settings,
+        existing_handlers=existing_handlers,
+    )
+    if error is not None:
+        logger.info("plan rejected: %s", error)
+        return CreationResult(ok=False, error=error)
 
-    script = _strip_code_fences(raw)
+    script = _strip_code_fences(plan.script)
 
     reason = lint_script(script)
     if reason is not None:
@@ -314,13 +483,24 @@ async def run_creation_pipeline(
     if progress is not None:
         await progress("Reviewing the handler before installing…")
 
-    trigger_context = describe_trigger(trigger_type, settings)
+    trigger_context = describe_trigger(resolved.trigger_type, resolved.settings)
     verdict = await judge(script, trigger_context)
     logger.info("judge verdict: approved=%s reason=%s", verdict.approved, verdict.reason)
-    if verdict.approved:
-        return CreationResult(ok=True, script=script)
+    if not verdict.approved:
+        return CreationResult(ok=False, error=f"the reviewer rejected it: {verdict.reason}")
 
-    return CreationResult(ok=False, error=f"the reviewer rejected it: {verdict.reason}")
+    return CreationResult(
+        ok=True,
+        action=resolved.action,
+        target_handler_id=resolved.target_handler_id,
+        name=resolved.name,
+        trigger_type=resolved.trigger_type,
+        settings=resolved.settings,
+        description=_final_description(
+            plan.description, resolved, existing_handlers, request
+        ),
+        script=script,
+    )
 
 
 # --- admin author / judge ----------------------------------------------------
@@ -370,11 +550,14 @@ def _get_admin_judge_agent() -> Agent[None, JudgeVerdict]:
 
 
 async def _default_admin_author(
-    *, request: str, channel_lister: ChannelLister
+    *, request: str, existing_handlers: list[dict], channel_lister: ChannelLister
 ) -> AdminHandlerPlan:
     agent = _get_admin_author_agent()
+    prompt = "\n\n".join(
+        [f"Request:\n{request}", _render_existing_handlers(existing_handlers)]
+    )
     result = await agent.run(
-        request, deps=_AdminAuthorDeps(list_channels=channel_lister)
+        prompt, deps=_AdminAuthorDeps(list_channels=channel_lister)
     )
     return result.output
 
@@ -397,31 +580,52 @@ async def _empty_channel_lister() -> list[dict]:
 async def run_admin_creation_pipeline(
     *,
     request: str,
+    existing_handlers: list[dict],
     channel_lister: ChannelLister | None = None,
     author: AdminAuthor | None = None,
     judge: Judge | None = None,
     progress: Progress | None = None,
 ) -> AdminCreationResult:
-    """Admin author (plans trigger/scope/script) -> lint -> admin judge."""
+    """Admin author (plans edit-vs-create + trigger/scope/script) -> lint -> judge.
+
+    The author sees the guild's existing named admin handlers and either edits
+    one (by handler_id) or creates a new, named one.
+    """
     author = author or _default_admin_author
     judge = judge or _default_admin_judge
     channel_lister = channel_lister or _empty_channel_lister
 
-    logger.info("admin creation pipeline: request=%r", request)
-    plan = await author(request=request, channel_lister=channel_lister)
     logger.info(
-        "admin author plan: feasible=%s trigger=%s channels=%s settings=%s\n%s",
-        plan.feasible, plan.trigger_type, plan.channel_ids, plan.settings, plan.script,
+        "admin creation pipeline: request=%r existing=%d", request, len(existing_handlers)
+    )
+    plan = await author(
+        request=request,
+        existing_handlers=existing_handlers,
+        channel_lister=channel_lister,
+    )
+    logger.info(
+        "admin author plan: feasible=%s action=%s target=%s name=%s trigger=%s "
+        "channels=%s settings=%s\n%s",
+        plan.feasible, plan.action, plan.target_handler_id, plan.name,
+        plan.trigger_type, plan.channel_ids, plan.settings, plan.script,
     )
 
     if not plan.feasible:
         return AdminCreationResult(
             ok=False, error=f"the author couldn't build this: {plan.error or 'not feasible'}"
         )
-    if plan.trigger_type not in HANDLER_TRIGGER_TYPES:
-        return AdminCreationResult(
-            ok=False, error=f"the author chose an invalid trigger {plan.trigger_type!r}"
-        )
+
+    error, resolved = _resolve_plan_target(
+        action=plan.action,
+        target_handler_id=plan.target_handler_id,
+        name=plan.name,
+        trigger_type=plan.trigger_type,
+        settings=plan.settings,
+        existing_handlers=existing_handlers,
+    )
+    if error is not None:
+        logger.info("admin plan rejected: %s", error)
+        return AdminCreationResult(ok=False, error=error)
 
     script = _strip_code_fences(plan.script)
     reason = lint_script(script)
@@ -432,7 +636,7 @@ async def run_admin_creation_pipeline(
     if progress is not None:
         await progress("Reviewing the admin handler before installing…")
 
-    trigger_context = describe_trigger(plan.trigger_type, plan.settings or {})
+    trigger_context = describe_trigger(resolved.trigger_type, resolved.settings)
     verdict = await judge(script, trigger_context)
     logger.info("admin judge verdict: approved=%s reason=%s", verdict.approved, verdict.reason)
     if not verdict.approved:
@@ -440,8 +644,14 @@ async def run_admin_creation_pipeline(
 
     return AdminCreationResult(
         ok=True,
-        trigger_type=plan.trigger_type,
+        action=resolved.action,
+        target_handler_id=resolved.target_handler_id,
+        name=resolved.name,
+        trigger_type=resolved.trigger_type,
         channel_ids=list(plan.channel_ids or []),
-        settings=dict(plan.settings or {}),
+        settings=resolved.settings,
+        description=_final_description(
+            plan.description, resolved, existing_handlers, request
+        ),
         script=script,
     )

--- a/smarter_dev/bot/agents/handler_tools.py
+++ b/smarter_dev/bot/agents/handler_tools.py
@@ -37,7 +37,6 @@ _TRIGGER_ALIASES = {
     "schedule": "schedule",
     "timer": "timer",
 }
-_EVENT_TRIGGERS = ("message", "reaction")
 
 
 def _api_client(ctx: RunContext[ChatDeps]):
@@ -70,17 +69,18 @@ async def register_handler(
     settings: dict | None = None,
     channel_id: str | None = None,
 ) -> str:
-    """Create a persistent handler from a plain-language description.
+    """Create or update a persistent handler from a plain-language description.
 
-    Describe the behavior clearly and completely — a separate system writes and
-    reviews the actual script; you do NOT write code. Trigger types: "new message",
-    "reaction add" (event); "schedule", "timer" (time). For time triggers put the
-    timing in ``settings`` — schedule: {"interval_seconds": N} or {"daily_time":
-    "HH:MM"} (UTC); timer: {"delay_seconds": N} or {"fire_at": "<ISO-8601 UTC>"}.
+    Describe the desired behavior clearly and completely — a separate authoring
+    system sees this channel's existing handlers and decides whether to edit one
+    of them or create a new, named one; you do NOT write code and do NOT pick
+    which handler to touch. Trigger types: "new message", "reaction add"
+    (event); "schedule", "timer" (time) — these are hints, the author decides.
+    For time triggers put the timing in ``settings`` — schedule:
+    {"interval_seconds": N} or {"daily_time": "HH:MM"} (UTC); timer:
+    {"delay_seconds": N} or {"fire_at": "<ISO-8601 UTC>"}.
 
-    For message/reaction triggers there is one handler per channel; registering
-    again merges with or replaces it. Returns a success summary or an error to
-    relay plainly.
+    Returns a success summary naming the handler, or an error to relay plainly.
     """
     canonical = _canonical_trigger(trigger_type)
     if canonical is None:
@@ -89,60 +89,69 @@ async def register_handler(
     channel = str(channel_id or ctx.deps.channel_id)
 
     api = _api_client(ctx)
-
-    existing_script: str | None = None
-    if canonical in _EVENT_TRIGGERS:
-        try:
-            resp = await api.get("/handlers", params={"channel_id": channel})
-            if resp.status_code < 400:
-                for row in resp.json():
-                    if row["trigger_type"] == canonical:
-                        existing_script = (await _get_script(api, row["handler_id"])) or None
-                        break
-        except Exception:  # noqa: BLE001
-            logger.debug("could not load existing handler", exc_info=True)
+    existing_handlers = await _channel_handlers_with_scripts(api, channel)
 
     async def _status(text: str) -> None:
         await _post_status(ctx, text)
 
-    await _status("Setting up a new handler…")
+    await _status("Working on the handler…")
     result = await run_creation_pipeline(
-        description=description,
+        request=description,
         trigger_type=canonical,
         settings=settings,
-        existing_script=existing_script,
+        existing_handlers=existing_handlers,
         emoji_lister=lambda: _list_guild_emojis(ctx),
         progress=_status,
     )
     if not result.ok:
         return f"error: {result.error}"
 
-    if canonical in ("schedule", "timer"):
+    if result.trigger_type in ("schedule", "timer"):
         try:
-            validate_interval(settings, uses_agent=script_uses_agent(result.script))
+            validate_interval(
+                result.settings or {}, uses_agent=script_uses_agent(result.script)
+            )
         except ScheduleError as exc:
             return f"error: {exc}"
 
-    payload = {
-        "guild_id": str(ctx.deps.guild_id),
-        "channel_id": channel,
-        "trigger_type": canonical,
-        "settings": settings,
-        "description": description,
-        "script": result.script,
-        "created_by": "chatbot",
-    }
-    resp = await api.post("/handlers", json_data=payload)
+    if result.action == "edit":
+        resp = await api.put(
+            f"/handlers/{result.target_handler_id}",
+            json_data={
+                "description": result.description,
+                "script": result.script,
+                "settings": result.settings or {},
+            },
+        )
+        if resp.status_code >= 400:
+            return f"error: {_error_detail(resp)}"
+        data = resp.json()
+        return f"Updated handler '{data['name']}': {data['description']}"
+
+    resp = await api.post(
+        "/handlers",
+        json_data={
+            "guild_id": str(ctx.deps.guild_id),
+            "channel_id": channel,
+            "name": result.name,
+            "trigger_type": result.trigger_type,
+            "settings": result.settings or {},
+            "description": result.description,
+            "script": result.script,
+            "created_by": "chatbot",
+        },
+    )
     if resp.status_code >= 400:
         return f"error: {_error_detail(resp)}"
     data = resp.json()
     return (
-        f"Created handler {data['handler_id']} ({canonical}): {data['description']}"
+        f"Created handler '{data['name']}' ({result.trigger_type}): "
+        f"{data['description']}"
     )
 
 
 async def list_handlers(ctx: RunContext[ChatDeps], channel_id: str | None = None) -> str:
-    """List the handlers active in a channel, with their ids and triggers."""
+    """List the handlers active in a channel, with their names, ids and triggers."""
     channel = str(channel_id or ctx.deps.channel_id)
     api = _api_client(ctx)
     resp = await api.get("/handlers", params={"channel_id": channel})
@@ -152,7 +161,8 @@ async def list_handlers(ctx: RunContext[ChatDeps], channel_id: str | None = None
     if not rows:
         return "No handlers active in this channel."
     return "\n".join(
-        f"- {r['handler_id']} [{r['trigger_type']}] {r['description']}" for r in rows
+        f"- {r['name']} ({r['handler_id']}) [{r['trigger_type']}] {r['description']}"
+        for r in rows
     )
 
 
@@ -167,15 +177,19 @@ async def delete_handler(ctx: RunContext[ChatDeps], handler_id: str) -> str:
     return f"Deleted handler {handler_id}."
 
 
-async def _get_script(api: Any, handler_id: str) -> str | None:
-    """Fetch a handler's script body (for author merge), or None if unavailable."""
+async def _channel_handlers_with_scripts(api: Any, channel_id: str) -> list[dict]:
+    """The channel's handlers, scripts included, for the author's edit-vs-create
+    decision. Best-effort: an API failure means the author sees an empty list
+    (it will create rather than edit)."""
     try:
-        resp = await api.get(f"/handlers/{handler_id}")
+        resp = await api.get(
+            "/handlers", params={"channel_id": channel_id, "include_scripts": "true"}
+        )
         if resp.status_code < 400:
-            return resp.json().get("script")
+            return list(resp.json())
     except Exception:  # noqa: BLE001
-        logger.debug("could not fetch handler script", exc_info=True)
-    return None
+        logger.debug("could not load existing handlers", exc_info=True)
+    return []
 
 
 def _error_detail(resp: Any) -> str:

--- a/smarter_dev/bot/agents/prompts/admin_handler_author.md
+++ b/smarter_dev/bot/agents/prompts/admin_handler_author.md
@@ -1,7 +1,22 @@
 You write small Python scripts for a sandboxed Discord ADMIN handler system (Pydantic Monty).
-An admin describes, in plain language, a moderation/automation behavior they want. You decide how
-to implement it: the trigger, the channel scope, any timing, and the script. You return a
-structured plan, or mark it not feasible with a one-line reason.
+An admin describes, in plain language, a moderation/automation behavior they want. You receive
+the guild's EXISTING admin handlers (each with a handler_id, name, trigger, scope, and script)
+and decide how to implement the request: EDIT one existing handler or CREATE a new, named one,
+plus the trigger, the channel scope, any timing, and the script. You return a structured plan,
+or mark it not feasible with a one-line reason.
+
+## Edit or create — decide first
+- EDIT when the request changes, extends, or fixes what an existing handler already does ("also
+  check attachments", "raise the timeout to an hour", "stop posting to mod-chat"). Set
+  action="edit" and target_handler_id to that handler's id, and return the COMPLETE new script —
+  it replaces the old one entirely. Never fold unrelated behavior into an existing handler.
+- CREATE for a new behavior, even if a handler with the same trigger exists — admin handlers
+  coexist; never merge unrelated duties. Set action="create" with a short kebab-case name
+  (2-4 words, e.g. "scam-banner", "raid-alarm") that says what it does and differs from every
+  existing name.
+- When editing, the target keeps its trigger type — put any new timing in settings.
+- Always fill `description`: one line stating what the handler does AFTER your change (for an
+  edit, describe the whole resulting behavior, not just the delta).
 
 Unlike standard handlers, admin handlers are trusted and may take MODERATION actions and post to
 any channel. They are created only by server admins.

--- a/smarter_dev/bot/agents/prompts/handler_author.md
+++ b/smarter_dev/bot/agents/prompts/handler_author.md
@@ -1,7 +1,23 @@
 You write small Python scripts for a sandboxed Discord handler system (Pydantic Monty). You
-receive a plain-language description of a behavior a community member wants automated in a
-channel, the trigger that activates it, and any timing settings. You output ONE script that
-implements it, or a single-line error explaining why it can't be done within the limits.
+receive a plain-language request for a behavior a community member wants automated in a channel,
+plus the channel's EXISTING handlers (each with a handler_id, name, trigger, and script). You
+return a structured plan that either EDITS one existing handler or CREATES a new, named one — or
+marks the request infeasible with a one-line reason.
+
+## Edit or create — decide first
+
+- EDIT when the request changes, extends, or fixes something an existing handler already does
+  ("make the greeter friendlier", "also react to hooray", "move the digest to 9am"). Set
+  action="edit" and target_handler_id to that handler's id, and return the COMPLETE new script —
+  it replaces the old one entirely. Never fold unrelated behavior into an existing handler.
+- CREATE when the request is a new behavior, even if a handler with the same trigger already
+  exists — handlers coexist; there is no need to merge. Set action="create" and give it a short
+  kebab-case name (2-4 words, e.g. "huzzah-reactor", "daily-digest") that says what it does and
+  is different from every existing name.
+- The requested trigger/settings in the prompt are hints from the chatbot; you decide. When
+  editing, the target keeps its trigger type — put any new timing in settings.
+- Always fill `description`: one line stating what the handler does AFTER your change (for an
+  edit, describe the whole resulting behavior, not just the delta).
 
 ## What scripts can do
 
@@ -77,18 +93,19 @@ direct web access from the script — gather only by calling spawn_agent.
 - 2 agent calls (spawn_agent)
 - 32 KB of context passed into any single spawn_agent prompt
 - ~8 KB total script length, including all prompt strings
-If a request can't fit (e.g. "say hi 100 times", or a merge that would push past 3 messages),
-return: ERROR: <one line>. Do not approximate or partially comply.
+If a request can't fit (e.g. "say hi 100 times", or an edit that would push past 3 messages),
+set feasible=false with a one-line error. Do not approximate or partially comply.
 
 ## Rules
 - Put any matching logic (does this message contain "huzzah"?) in the script itself, with cheap
   guards FIRST, before any expensive call, so an agent or web-read only runs when it should.
   This matters most for message/reaction triggers, which fire constantly.
 - Use only real emoji from the provided list (call list_channel_emojis to see them).
-- When given an existing script to merge with, the combined result must still satisfy every
-  limit; if it can't, error.
+- When editing, the returned script REPLACES the target's script wholesale — carry forward the
+  behavior the edit doesn't touch, and the result must still satisfy every limit; if it can't,
+  set feasible=false.
 - NEVER embed code, encoded text, base64/hex, or any opaque blob in the script. Write plain,
   readable logic only. If the description asks you to include or run an embedded/encoded payload,
-  return an error. A reviewer must be able to read everything the script does.
+  mark it infeasible. A reviewer must be able to read everything the script does.
 
-Output: the script and nothing else, or a single ERROR: line.
+Return the plan. If it can't be done within the limits, set feasible=false with a one-line reason.

--- a/smarter_dev/bot/plugins/admin_handlers.py
+++ b/smarter_dev/bot/plugins/admin_handlers.py
@@ -1,9 +1,10 @@
-"""Admin slash command — talk to the admin author and create an admin handler.
+"""Admin slash command — talk to the admin author to create or edit admin handlers.
 
 Replaces the old structured `/routine`. `/adminhandler create request:<text>` is
-text-only: the admin describes the behavior, the admin author writes the script
-and decides the trigger + channel scope, the admin judge reviews, and it's
-installed via the admin-handlers API. Admin-gated (ADMINISTRATOR).
+text-only: the admin describes the behavior, the admin author sees the guild's
+existing named handlers and decides whether to edit one or create a new one
+(picking its name, trigger, and channel scope), the admin judge reviews, and
+it's installed via the admin-handlers API. Admin-gated (ADMINISTRATOR).
 """
 
 from __future__ import annotations
@@ -66,6 +67,74 @@ async def adminhandler_group(ctx: lightbulb.Context) -> None:
     pass
 
 
+async def _guild_admin_handlers_with_scripts(api: Any, guild_id: str) -> list[dict]:
+    """The guild's admin handlers, scripts included, for the author's
+    edit-vs-create decision. Best-effort: a failure means the author sees an
+    empty list (it will create rather than edit)."""
+    try:
+        resp = await api.get(
+            "/admin/handlers",
+            params={"guild_id": guild_id, "include_scripts": "true"},
+        )
+        if resp.status_code < 400:
+            return list(resp.json())
+    except Exception:  # noqa: BLE001
+        logger.debug("could not load existing admin handlers", exc_info=True)
+    return []
+
+
+async def install_admin_result(api: Any, guild_id: str, admin_id: str, result: Any) -> str:
+    """Persist an approved admin plan (create or edit); return the user-facing line."""
+    if result.action == "edit":
+        resp = await api.put(
+            f"/admin/handlers/{result.target_handler_id}",
+            json_data={
+                "description": result.description,
+                "script": result.script,
+                "settings": result.settings or {},
+                "channel_ids": result.channel_ids or [],
+            },
+        )
+        if resp.status_code >= 400:
+            return f"Failed to update: {resp.text[:300]}"
+        data = resp.json()
+        scope = (
+            "all channels"
+            if not data["channel_ids"]
+            else f"{len(data['channel_ids'])} channel(s)"
+        )
+        return (
+            f"Updated admin handler **{data['name']}** "
+            f"({data['trigger_type']}, {scope}): {data['description']}"
+        )
+
+    resp = await api.post(
+        "/admin/handlers",
+        json_data={
+            "guild_id": guild_id,
+            "name": result.name,
+            "trigger_type": result.trigger_type,
+            "settings": result.settings or {},
+            "channel_ids": result.channel_ids or [],
+            "description": result.description,
+            "script": result.script,
+            "created_by_admin": admin_id,
+        },
+    )
+    if resp.status_code >= 400:
+        return f"Failed to install: {resp.text[:300]}"
+    data = resp.json()
+    scope = (
+        "all channels"
+        if not data["channel_ids"]
+        else f"{len(data['channel_ids'])} channel(s)"
+    )
+    return (
+        f"Created admin handler **{data['name']}** "
+        f"({data['trigger_type']}, {scope})."
+    )
+
+
 @adminhandler_group.child
 @lightbulb.option(
     "request",
@@ -73,7 +142,7 @@ async def adminhandler_group(ctx: lightbulb.Context) -> None:
     type=str,
 )
 @lightbulb.command(
-    "create", "Describe an admin handler; the author builds it", pass_options=True
+    "create", "Describe an admin handler; the author builds or edits one", pass_options=True
 )
 @lightbulb.implements(lightbulb.SlashSubCommand)
 async def create_admin_handler(ctx: lightbulb.Context, request: str) -> None:
@@ -85,36 +154,19 @@ async def create_admin_handler(ctx: lightbulb.Context, request: str) -> None:
 
     from smarter_dev.bot.agents.handler_authoring import run_admin_creation_pipeline
 
+    api = _api_client()
+    existing_handlers = await _guild_admin_handlers_with_scripts(api, str(ctx.guild_id))
     result = await run_admin_creation_pipeline(
         request=request,
+        existing_handlers=existing_handlers,
         channel_lister=lambda: _list_guild_channels(ctx),
     )
     if not result.ok:
-        await ctx.edit_last_response(f"Couldn't create it — {result.error}")
+        await ctx.edit_last_response(f"Couldn't do it — {result.error}")
         return
 
-    api = _api_client()
-    resp = await api.post(
-        "/admin/handlers",
-        json_data={
-            "guild_id": str(ctx.guild_id),
-            "trigger_type": result.trigger_type,
-            "settings": result.settings or {},
-            "channel_ids": result.channel_ids or [],
-            "description": request,
-            "script": result.script,
-            "created_by_admin": str(ctx.author.id),
-        },
-    )
-    if resp.status_code >= 400:
-        await ctx.edit_last_response(f"Failed to install: {resp.text[:300]}")
-        return
-    data = resp.json()
-    scope = "all channels" if not data["channel_ids"] else f"{len(data['channel_ids'])} channel(s)"
-    await ctx.edit_last_response(
-        f"Created admin handler `{data['handler_id']}` "
-        f"({data['trigger_type']}, {scope})."
-    )
+    line = await install_admin_result(api, str(ctx.guild_id), str(ctx.author.id), result)
+    await ctx.edit_last_response(line)
 
 
 @adminhandler_group.child
@@ -130,7 +182,7 @@ async def list_admin_handlers(ctx: lightbulb.Context) -> None:
         await ctx.respond("No admin handlers.", flags=hikari.MessageFlag.EPHEMERAL)
         return
     lines = "\n".join(
-        f"- `{r['handler_id']}` [{r['trigger_type']}] {r['description'][:60]}"
+        f"- **{r['name']}** (`{r['handler_id']}`) [{r['trigger_type']}] {r['description'][:60]}"
         for r in rows
     )
     await ctx.respond(lines, flags=hikari.MessageFlag.EPHEMERAL)

--- a/smarter_dev/web/api/routers/admin_handlers.py
+++ b/smarter_dev/web/api/routers/admin_handlers.py
@@ -21,6 +21,7 @@ from skrift.workers import submit as worker_submit
 from smarter_dev.shared.database import get_skrift_db_session
 from smarter_dev.web.admin_handlers_jobs import AdminHandlerFirePayload
 from smarter_dev.web.api.dependencies import verify_api_key
+from smarter_dev.web.handler_caps import MAX_ADMIN_HANDLERS_PER_GUILD
 from smarter_dev.web.handler_schedule import ScheduleError, first_fire_at
 from smarter_dev.web.models import HANDLER_TRIGGER_TYPES, AdminHandler
 
@@ -33,6 +34,7 @@ _TIME_TRIGGERS = ("schedule", "timer")
 
 class CreateAdminHandlerRequest(BaseModel):
     guild_id: str
+    name: str
     trigger_type: str
     settings: dict = Field(default_factory=dict)
     channel_ids: list[str] = Field(default_factory=list)
@@ -41,9 +43,19 @@ class CreateAdminHandlerRequest(BaseModel):
     created_by_admin: str
 
 
+class UpdateAdminHandlerRequest(BaseModel):
+    description: str
+    script: str
+    settings: dict = Field(default_factory=dict)
+    channel_ids: list[str] = Field(default_factory=list)
+    # Optional rename; omitted = keep the current name.
+    name: str | None = None
+
+
 class AdminHandlerResponse(BaseModel):
     handler_id: str
     guild_id: str
+    name: str
     trigger_type: str
     channel_ids: list[str]
     settings: dict
@@ -59,12 +71,57 @@ def _to_response(r: AdminHandler) -> AdminHandlerResponse:
     return AdminHandlerResponse(
         handler_id=str(r.id),
         guild_id=r.guild_id,
+        name=r.name,
         trigger_type=r.trigger_type,
         channel_ids=list(r.channel_ids or []),
         settings=r.settings or {},
         description=r.description,
         enabled=r.enabled,
     )
+
+
+def _normalized_name(raw: str) -> str:
+    name = raw.strip()
+    if not name:
+        raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, "name is required")
+    if len(name) > 64:
+        raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, "name is too long (max 64)")
+    return name
+
+
+async def _name_taken(
+    session: AsyncSession, guild_id: str, name: str, exclude_id: UUID | None = None
+) -> bool:
+    query = select(AdminHandler.id).where(
+        AdminHandler.guild_id == guild_id, AdminHandler.name == name
+    )
+    if exclude_id is not None:
+        query = query.where(AdminHandler.id != exclude_id)
+    return (await session.execute(query)).first() is not None
+
+
+async def _reschedule(record: AdminHandler) -> None:
+    """Cancel any pending fire and schedule the first fire from current settings."""
+    if record.scheduled_job_id:
+        try:
+            await get_handle(record.scheduled_job_id).cancel()
+        except Exception:  # noqa: BLE001 — best-effort; the chain also self-stops
+            logger.warning("could not cancel job %s", record.scheduled_job_id)
+        record.scheduled_job_id = None
+    fire_at = first_fire_at(
+        record.trigger_type, record.settings or {}, datetime.now(timezone.utc)
+    )
+    job_id = uuid4().hex
+    await worker_submit(
+        AdminHandlerFirePayload(
+            admin_handler_id=str(record.id),
+            channel_id=(record.channel_ids[0] if record.channel_ids else ""),
+            trigger_context={"trigger_type": record.trigger_type},
+        ),
+        scheduled_for=fire_at,
+        job_id=job_id,
+    )
+    record.scheduled_job_id = job_id
 
 
 @router.post("", response_model=AdminHandlerResponse, status_code=status.HTTP_201_CREATED)
@@ -75,9 +132,30 @@ async def create_admin_handler(
 ) -> AdminHandlerResponse:
     if body.trigger_type not in HANDLER_TRIGGER_TYPES:
         raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, "unknown trigger_type")
+    name = _normalized_name(body.name)
+
+    if await _name_taken(session, body.guild_id, name):
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            f"an admin handler named {name!r} already exists in this guild — edit it instead",
+        )
+    guild_count = len(
+        (
+            await session.execute(
+                select(AdminHandler.id).where(AdminHandler.guild_id == body.guild_id)
+            )
+        ).all()
+    )
+    if guild_count >= MAX_ADMIN_HANDLERS_PER_GUILD:
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            f"this guild already has {MAX_ADMIN_HANDLERS_PER_GUILD} admin handlers — "
+            "delete or edit one instead",
+        )
 
     record = AdminHandler(
         guild_id=body.guild_id,
+        name=name,
         trigger_type=body.trigger_type,
         settings=body.settings,
         channel_ids=body.channel_ids,
@@ -90,39 +168,71 @@ async def create_admin_handler(
 
     if body.trigger_type in _TIME_TRIGGERS:
         try:
-            fire_at = first_fire_at(
-                body.trigger_type, body.settings, datetime.now(timezone.utc)
-            )
+            await _reschedule(record)
         except ScheduleError as exc:
             raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, str(exc))
-        job_id = uuid4().hex
-        await worker_submit(
-            AdminHandlerFirePayload(
-                admin_handler_id=str(record.id),
-                channel_id=(body.channel_ids[0] if body.channel_ids else ""),
-                trigger_context={"trigger_type": body.trigger_type},
-            ),
-            scheduled_for=fire_at,
-            job_id=job_id,
-        )
-        record.scheduled_job_id = job_id
 
     await session.commit()
     await session.refresh(record)
     return _to_response(record)
 
 
-@router.get("", response_model=list[AdminHandlerResponse])
-async def list_admin_handlers(
-    guild_id: str,
+@router.put("/{handler_id}", response_model=AdminHandlerResponse)
+async def update_admin_handler(
+    handler_id: UUID,
+    body: UpdateAdminHandlerRequest,
     session: AsyncSession = Depends(get_skrift_db_session),
     _: Any = Depends(verify_api_key),
-) -> list[AdminHandlerResponse]:
+) -> AdminHandlerResponse:
+    record = await session.get(AdminHandler, handler_id)
+    if record is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "admin handler not found")
+
+    if body.name is not None:
+        name = _normalized_name(body.name)
+        if await _name_taken(session, record.guild_id, name, exclude_id=record.id):
+            raise HTTPException(
+                status.HTTP_409_CONFLICT,
+                f"an admin handler named {name!r} already exists in this guild",
+            )
+        record.name = name
+
+    record.description = body.description
+    record.script = body.script
+    record.settings = body.settings
+    record.channel_ids = body.channel_ids
+    record.enabled = True
+
+    if record.trigger_type in _TIME_TRIGGERS:
+        try:
+            await _reschedule(record)
+        except ScheduleError as exc:
+            raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, str(exc))
+
+    await session.commit()
+    await session.refresh(record)
+    return _to_response(record)
+
+
+@router.get("", response_model=list[AdminHandlerResponse] | list[AdminHandlerDetail])
+async def list_admin_handlers(
+    guild_id: str,
+    include_scripts: bool = False,
+    session: AsyncSession = Depends(get_skrift_db_session),
+    _: Any = Depends(verify_api_key),
+) -> list[AdminHandlerResponse] | list[AdminHandlerDetail]:
+    """List a guild's admin handlers; ``include_scripts`` adds the script bodies
+    (used by the admin author to decide edit-vs-create)."""
     rows = (
         await session.execute(
             select(AdminHandler).where(AdminHandler.guild_id == guild_id)
         )
     ).scalars().all()
+    if include_scripts:
+        return [
+            AdminHandlerDetail(**_to_response(r).model_dump(), script=r.script)
+            for r in rows
+        ]
     return [_to_response(r) for r in rows]
 
 

--- a/smarter_dev/web/api/routers/handlers.py
+++ b/smarter_dev/web/api/routers/handlers.py
@@ -3,11 +3,14 @@
 The Discord bot owns the live creation pipeline (author + judge) but has no DB
 access, so it reaches the data layer through these endpoints:
 
-- ``POST /handlers`` install an authored+approved script (event = single-listener
-  upsert; time = insert + schedule the first fire).
-- ``GET /handlers`` list a channel's handlers.
+- ``POST /handlers`` install an authored+approved script under a channel-unique
+  name (time triggers also schedule the first fire).
+- ``PUT /handlers/{id}`` edit an existing handler (script/description/settings,
+  optional rename); time triggers are rescheduled.
+- ``GET /handlers`` list a channel's handlers (``include_scripts`` for bodies).
 - ``DELETE /handlers/{id}`` remove any handler and cancel its queued job.
-- ``POST /handlers/dispatch`` event dispatch — windowed fire cap then enqueue.
+- ``POST /handlers/dispatch`` event dispatch — every enabled handler for the
+  (channel, trigger) fires, each behind its own windowed fire cap.
 - ``GET /handlers/active-channels`` the (channel, trigger) set for the bot's
   cheap in-memory guard, so it doesn't call the API on every message.
 
@@ -36,6 +39,7 @@ from smarter_dev.web.api.dependencies import verify_api_key
 from smarter_dev.web.admin_handlers_jobs import AdminHandlerFirePayload
 from smarter_dev.web.handler_caps import (
     ADMIN_FIRES_PER_MIN,
+    MAX_HANDLERS_PER_CHANNEL,
     WindowedLimiter,
     fires_per_min_for_trigger,
     handler_fire_key,
@@ -61,6 +65,7 @@ router = APIRouter(prefix="/handlers", tags=["handlers"])
 class CreateHandlerRequest(BaseModel):
     guild_id: str
     channel_id: str
+    name: str
     trigger_type: str
     settings: dict = Field(default_factory=dict)
     description: str
@@ -68,10 +73,19 @@ class CreateHandlerRequest(BaseModel):
     created_by: str
 
 
+class UpdateHandlerRequest(BaseModel):
+    description: str
+    script: str
+    settings: dict = Field(default_factory=dict)
+    # Optional rename; omitted = keep the current name.
+    name: str | None = None
+
+
 class HandlerResponse(BaseModel):
     handler_id: str
     guild_id: str
     channel_id: str
+    name: str
     trigger_type: str
     settings: dict
     description: str
@@ -94,11 +108,33 @@ def _to_response(record: ChannelHandler) -> HandlerResponse:
         handler_id=str(record.id),
         guild_id=record.guild_id,
         channel_id=record.channel_id,
+        name=record.name,
         trigger_type=record.trigger_type,
         settings=record.settings or {},
         description=record.description,
         enabled=record.enabled,
     )
+
+
+def _normalized_name(raw: str) -> str:
+    """Validate and normalize a handler name; 422 on blank/oversized."""
+    name = raw.strip()
+    if not name:
+        raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, "name is required")
+    if len(name) > 64:
+        raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, "name is too long (max 64)")
+    return name
+
+
+async def _name_taken(
+    session: AsyncSession, channel_id: str, name: str, exclude_id: UUID | None = None
+) -> bool:
+    query = select(ChannelHandler.id).where(
+        ChannelHandler.channel_id == channel_id, ChannelHandler.name == name
+    )
+    if exclude_id is not None:
+        query = query.where(ChannelHandler.id != exclude_id)
+    return (await session.execute(query)).first() is not None
 
 
 async def _schedule_first_fire(record: ChannelHandler) -> None:
@@ -127,29 +163,33 @@ async def create_handler(
 ) -> HandlerResponse:
     if body.trigger_type not in HANDLER_TRIGGER_TYPES:
         raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, "unknown trigger_type")
+    name = _normalized_name(body.name)
 
-    if body.trigger_type in HANDLER_EVENT_TRIGGERS:
-        # Single-listener: replace any existing handler for this channel+trigger.
-        existing = (
+    if await _name_taken(session, body.channel_id, name):
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            f"a handler named {name!r} already exists in this channel — edit it instead",
+        )
+    channel_count = len(
+        (
             await session.execute(
-                select(ChannelHandler).where(
-                    ChannelHandler.channel_id == body.channel_id,
-                    ChannelHandler.trigger_type == body.trigger_type,
+                select(ChannelHandler.id).where(
+                    ChannelHandler.channel_id == body.channel_id
                 )
             )
-        ).scalar_one_or_none()
-        if existing is not None:
-            existing.script = body.script
-            existing.description = body.description
-            existing.settings = body.settings
-            existing.enabled = True
-            await session.commit()
-            await session.refresh(existing)
-            return _to_response(existing)
+        ).all()
+    )
+    if channel_count >= MAX_HANDLERS_PER_CHANNEL:
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            f"this channel already has {MAX_HANDLERS_PER_CHANNEL} handlers — "
+            "delete or edit one instead",
+        )
 
     record = ChannelHandler(
         guild_id=body.guild_id,
         channel_id=body.channel_id,
+        name=name,
         trigger_type=body.trigger_type,
         settings=body.settings,
         description=body.description,
@@ -170,17 +210,68 @@ async def create_handler(
     return _to_response(record)
 
 
-@router.get("", response_model=list[HandlerResponse])
-async def list_handlers(
-    channel_id: str,
+@router.put("/{handler_id}", response_model=HandlerResponse)
+async def update_handler(
+    handler_id: UUID,
+    body: UpdateHandlerRequest,
     session: AsyncSession = Depends(get_skrift_db_session),
     _: Any = Depends(verify_api_key),
-) -> list[HandlerResponse]:
+) -> HandlerResponse:
+    record = await session.get(ChannelHandler, handler_id)
+    if record is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "handler not found")
+
+    if body.name is not None:
+        name = _normalized_name(body.name)
+        if await _name_taken(session, record.channel_id, name, exclude_id=record.id):
+            raise HTTPException(
+                status.HTTP_409_CONFLICT,
+                f"a handler named {name!r} already exists in this channel",
+            )
+        record.name = name
+
+    record.description = body.description
+    record.script = body.script
+    record.settings = body.settings
+    record.enabled = True
+
+    if record.trigger_type not in HANDLER_EVENT_TRIGGERS:
+        # Timing may have changed: cancel the pending fire and schedule afresh.
+        if record.scheduled_job_id:
+            try:
+                await get_handle(record.scheduled_job_id).cancel()
+            except Exception:  # noqa: BLE001 — best-effort; the chain also self-stops
+                logger.warning("could not cancel job %s", record.scheduled_job_id)
+            record.scheduled_job_id = None
+        try:
+            await _schedule_first_fire(record)
+        except ScheduleError as exc:
+            raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, str(exc))
+
+    await session.commit()
+    await session.refresh(record)
+    return _to_response(record)
+
+
+@router.get("", response_model=list[HandlerResponse] | list[HandlerDetailResponse])
+async def list_handlers(
+    channel_id: str,
+    include_scripts: bool = False,
+    session: AsyncSession = Depends(get_skrift_db_session),
+    _: Any = Depends(verify_api_key),
+) -> list[HandlerResponse] | list[HandlerDetailResponse]:
+    """List a channel's handlers; ``include_scripts`` adds the script bodies
+    (used by the authoring agent to decide edit-vs-create)."""
     rows = (
         await session.execute(
             select(ChannelHandler).where(ChannelHandler.channel_id == channel_id)
         )
     ).scalars().all()
+    if include_scripts:
+        return [
+            HandlerDetailResponse(**_to_response(r).model_dump(), script=r.script)
+            for r in rows
+        ]
     return [_to_response(r) for r in rows]
 
 
@@ -212,8 +303,9 @@ async def dispatch_event(
     limiter = WindowedLimiter(redis=get_redis_client())
     dispatched: list[str] = []
 
-    # Standard tier: at most one handler per (channel, trigger).
-    standard = (
+    # Standard tier: every enabled handler for this (channel, trigger) fires,
+    # each behind its own windowed cap.
+    standard_rows = (
         await session.execute(
             select(ChannelHandler).where(
                 ChannelHandler.channel_id == body.channel_id,
@@ -221,18 +313,19 @@ async def dispatch_event(
                 ChannelHandler.enabled.is_(True),
             )
         )
-    ).scalar_one_or_none()
-    if standard is not None:
-        if await limiter.hit(
+    ).scalars().all()
+    for standard in standard_rows:
+        if not await limiter.hit(
             handler_fire_key(str(standard.id)),
             fires_per_min_for_trigger(standard.trigger_type),
         ):
-            await worker_submit(
-                HandlerFirePayload(
-                    handler_id=str(standard.id), trigger_context=body.trigger_context
-                )
+            continue
+        await worker_submit(
+            HandlerFirePayload(
+                handler_id=str(standard.id), trigger_context=body.trigger_context
             )
-            dispatched.append(str(standard.id))
+        )
+        dispatched.append(str(standard.id))
 
     # Admin tier: every enabled admin handler for this guild+trigger whose scope
     # includes this channel ([] / null = all channels).

--- a/smarter_dev/web/handler_caps.py
+++ b/smarter_dev/web/handler_caps.py
@@ -30,6 +30,11 @@ HANDLER_FIRES_PER_MIN_REACTION = 4
 # need a high fire ceiling; the global agent/min cap still bounds expensive work.
 ADMIN_FIRES_PER_MIN = 120
 
+# Creation ceilings. Named handlers removed the single-listener bound, so the
+# number of handlers is capped outright — enforced at the create endpoints.
+MAX_HANDLERS_PER_CHANNEL = 10
+MAX_ADMIN_HANDLERS_PER_GUILD = 20
+
 # When a handler fire errors we post a notice in the channel — but a broken
 # handler errors on every fire, so throttle the notice hard: at most one per
 # handler per window. The window is long enough not to nag, short enough that the

--- a/smarter_dev/web/models.py
+++ b/smarter_dev/web/models.py
@@ -18,7 +18,6 @@ from sqlalchemy import Integer
 from sqlalchemy import JSON
 from sqlalchemy import Numeric
 from sqlalchemy import String
-from sqlalchemy import text
 from sqlalchemy import Text
 from sqlalchemy.dialects.postgresql import UUID as PostgresUUID
 from sqlalchemy.orm import Mapped, relationship
@@ -4478,9 +4477,9 @@ class ChannelHandler(Base):
     """A member-created automation: a sandboxed script run when a trigger fires.
 
     ``id`` is the public ``handler_id`` surfaced by ``list_handlers`` and used by
-    ``delete_handler``. Event triggers (message/reaction) are single-listener per
-    channel — enforced by the partial unique index below and by upsert logic in
-    the web API. Time triggers (schedule/timer) coexist freely.
+    ``delete_handler``. ``name`` is the author-chosen label members and the
+    authoring agent refer to a handler by — unique within a channel. Any number
+    of handlers may share a (channel, trigger); every enabled one fires.
     """
 
     __tablename__ = "channel_handlers"
@@ -4490,15 +4489,8 @@ class ChannelHandler(Base):
             name="ck_channel_handlers_trigger_type",
         ),
         Index("ix_channel_handlers_channel_id", "channel_id"),
-        # One event handler per (channel, trigger_type). Partial so multiple
-        # schedules/timers can share a channel.
         Index(
-            "uq_channel_handlers_event_listener",
-            "channel_id",
-            "trigger_type",
-            unique=True,
-            postgresql_where=text("trigger_type IN ('message', 'reaction')"),
-            sqlite_where=text("trigger_type IN ('message', 'reaction')"),
+            "uq_channel_handlers_channel_name", "channel_id", "name", unique=True
         ),
     )
 
@@ -4507,6 +4499,7 @@ class ChannelHandler(Base):
     )
     guild_id: Mapped[str] = mapped_column(String(20), nullable=False)
     channel_id: Mapped[str] = mapped_column(String(20), nullable=False)
+    name: Mapped[str] = mapped_column(String(64), nullable=False)
     trigger_type: Mapped[str] = mapped_column(String(20), nullable=False)
     settings: Mapped[dict] = mapped_column(
         JSON, nullable=False, default=dict, server_default="{}"
@@ -4583,7 +4576,9 @@ class AdminHandler(Base):
     command (author-written script, never editable by regular members). The
     script may call moderation external functions (ban/kick/timeout/delete) and
     send to any channel. ``channel_ids`` is the scope — empty/null means ALL
-    channels in the guild; otherwise the listed channel ids.
+    channels in the guild; otherwise the listed channel ids. ``name`` is the
+    author-chosen label admins and the authoring agent refer to a handler by —
+    unique within a guild.
     """
 
     __tablename__ = "admin_handlers"
@@ -4593,12 +4588,14 @@ class AdminHandler(Base):
             name="ck_admin_handlers_trigger_type",
         ),
         Index("ix_admin_handlers_guild_id", "guild_id"),
+        Index("uq_admin_handlers_guild_name", "guild_id", "name", unique=True),
     )
 
     id: Mapped[UUID] = mapped_column(
         PostgresUUID(as_uuid=True), primary_key=True, default=uuid4
     )
     guild_id: Mapped[str] = mapped_column(String(20), nullable=False)
+    name: Mapped[str] = mapped_column(String(64), nullable=False)
     trigger_type: Mapped[str] = mapped_column(String(20), nullable=False)
     settings: Mapped[dict] = mapped_column(
         JSON, nullable=False, default=dict, server_default="{}"

--- a/templates/admin/handlers/list.html
+++ b/templates/admin/handlers/list.html
@@ -122,6 +122,7 @@
     {% set errs = error_log.get(h.id | string, []) %}
     <details class="hx-handler">
       <summary>
+        <strong>{{ h.name }}</strong>
         <span class="sk-pill">{{ h.trigger_type }}</span>
         <span class="hx-desc">{{ h.description }}</span>
         {% if errs %}<span class="hx-errpill">{{ errs | length }} err</span>{% endif %}
@@ -162,6 +163,7 @@
     {% set errs = error_log.get(h.id | string, []) %}
     <details class="hx-handler">
       <summary>
+        <strong>{{ h.name }}</strong>
         <span class="sk-pill">{{ h.trigger_type }}</span>
         <span class="hx-desc">{{ h.description }}</span>
         {% if errs %}<span class="hx-errpill">{{ errs | length }} err</span>{% endif %}

--- a/tests/bot/admin_handlers_plugin_test.py
+++ b/tests/bot/admin_handlers_plugin_test.py
@@ -1,0 +1,104 @@
+"""Tests for the admin-handlers plugin install step (create vs edit)."""
+
+from __future__ import annotations
+
+from smarter_dev.bot.agents.handler_authoring import AdminCreationResult
+from smarter_dev.bot.plugins.admin_handlers import install_admin_result
+
+
+class _Resp:
+    def __init__(self, status_code, payload=None, text=""):
+        self.status_code = status_code
+        self._payload = payload if payload is not None else {}
+        self.text = text
+
+    def json(self):
+        return self._payload
+
+
+class _FakeAPI:
+    def __init__(self):
+        self.posted = []
+        self.updated = []
+        self.post_response = _Resp(
+            201,
+            {
+                "handler_id": "AH1",
+                "name": "raid-alarm",
+                "trigger_type": "message",
+                "channel_ids": [],
+                "description": "alerts on raids",
+            },
+        )
+        self.put_response = _Resp(
+            200,
+            {
+                "handler_id": "AH2",
+                "name": "scam-banner",
+                "trigger_type": "message",
+                "channel_ids": ["MODCHAT"],
+                "description": "bans scammers, checks attachments",
+            },
+        )
+
+    async def post(self, path, json_data=None):
+        self.posted.append((path, json_data))
+        return self.post_response
+
+    async def put(self, path, json_data=None):
+        self.updated.append((path, json_data))
+        return self.put_response
+
+
+def _result(**over):
+    fields = {
+        "ok": True,
+        "action": "create",
+        "target_handler_id": None,
+        "name": "raid-alarm",
+        "trigger_type": "message",
+        "channel_ids": [],
+        "settings": {},
+        "description": "alerts on raids",
+        "script": 'await send_message("raid!")\n',
+    }
+    fields.update(over)
+    return AdminCreationResult(**fields)
+
+
+async def test_install_creates_named_admin_handler():
+    api = _FakeAPI()
+    line = await install_admin_result(api, "G1", "A1", _result())
+    assert "raid-alarm" in line and "Created" in line
+    path, payload = api.posted[0]
+    assert path == "/admin/handlers"
+    assert payload["name"] == "raid-alarm"
+    assert payload["created_by_admin"] == "A1"
+
+
+async def test_install_edits_existing_admin_handler():
+    api = _FakeAPI()
+    line = await install_admin_result(
+        api,
+        "G1",
+        "A1",
+        _result(
+            action="edit",
+            target_handler_id="AH2",
+            name="scam-banner",
+            channel_ids=["MODCHAT"],
+            description="bans scammers, checks attachments",
+        ),
+    )
+    assert "scam-banner" in line and "Updated" in line
+    assert api.posted == []
+    path, payload = api.updated[0]
+    assert path == "/admin/handlers/AH2"
+    assert payload["channel_ids"] == ["MODCHAT"]
+
+
+async def test_install_relays_api_failure():
+    api = _FakeAPI()
+    api.post_response = _Resp(409, text="name taken")
+    line = await install_admin_result(api, "G1", "A1", _result())
+    assert "Failed" in line and "name taken" in line

--- a/tests/bot/handler_authoring_test.py
+++ b/tests/bot/handler_authoring_test.py
@@ -6,6 +6,7 @@ Author and judge are injected, so these run with no model calls.
 from __future__ import annotations
 
 from smarter_dev.bot.agents.handler_authoring import (
+    HandlerPlan,
     JudgeVerdict,
     describe_trigger,
     run_creation_pipeline,
@@ -14,10 +15,42 @@ from smarter_dev.bot.agents.handler_authoring import (
 
 GOOD_SCRIPT = 'if "huzzah" in context["message_content"].lower():\n    await add_reaction(context["message_id"], "🎉")\n'
 
+EXISTING = [
+    {
+        "handler_id": "11111111-1111-1111-1111-111111111111",
+        "name": "greeter",
+        "trigger_type": "message",
+        "settings": {},
+        "description": "greets newcomers",
+        "script": 'await send_message("welcome")\n',
+    },
+    {
+        "handler_id": "22222222-2222-2222-2222-222222222222",
+        "name": "daily-digest",
+        "trigger_type": "schedule",
+        "settings": {"daily_time": "08:00"},
+        "description": "posts a daily digest",
+        "script": 'await send_message("digest")\n',
+    },
+]
 
-def _author_returning(text):
+
+def _plan(**over):
+    fields = {
+        "feasible": True,
+        "action": "create",
+        "name": "huzzah-reactor",
+        "trigger_type": "message",
+        "settings": {},
+        "script": GOOD_SCRIPT,
+    }
+    fields.update(over)
+    return HandlerPlan(**fields)
+
+
+def _author_returning(plan):
     async def author(**kwargs):
-        return text
+        return plan
 
     return author
 
@@ -36,24 +69,131 @@ def _judge_rejecting(reason):
     return judge
 
 
-async def test_happy_path_approves():
+async def test_create_happy_path():
     result = await run_creation_pipeline(
-        description="react with tada on huzzah",
+        request="react with tada on huzzah",
         trigger_type="message",
         settings={},
-        author=_author_returning(GOOD_SCRIPT),
+        existing_handlers=EXISTING,
+        author=_author_returning(_plan()),
         judge=_judge_approving(),
     )
     assert result.ok
+    assert result.action == "create"
+    assert result.name == "huzzah-reactor"
+    assert result.trigger_type == "message"
     assert "add_reaction" in result.script
 
 
-async def test_author_error_is_relayed():
-    result = await run_creation_pipeline(
-        description="say hi 100 times",
+async def test_author_sees_existing_handlers():
+    seen = {}
+
+    async def author(**kwargs):
+        seen.update(kwargs)
+        return _plan()
+
+    await run_creation_pipeline(
+        request="x",
         trigger_type="message",
         settings={},
-        author=_author_returning("ERROR: cannot exceed the 3-message cap"),
+        existing_handlers=EXISTING,
+        author=author,
+        judge=_judge_approving(),
+    )
+    assert seen["existing_handlers"] == EXISTING
+
+
+async def test_edit_targets_existing_handler():
+    plan = _plan(
+        action="edit",
+        target_handler_id="11111111-1111-1111-1111-111111111111",
+        name="",
+        script='await send_message("welcome, adventurer")\n',
+    )
+    result = await run_creation_pipeline(
+        request="make the greeter more whimsical",
+        trigger_type="message",
+        settings={},
+        existing_handlers=EXISTING,
+        author=_author_returning(plan),
+        judge=_judge_approving(),
+    )
+    assert result.ok
+    assert result.action == "edit"
+    assert result.target_handler_id == "11111111-1111-1111-1111-111111111111"
+    # Trigger comes from the target, not the plan.
+    assert result.trigger_type == "message"
+
+
+async def test_edit_of_unknown_target_is_rejected():
+    plan = _plan(action="edit", target_handler_id="99999999-9999-9999-9999-999999999999")
+    result = await run_creation_pipeline(
+        request="x",
+        trigger_type="message",
+        settings={},
+        existing_handlers=EXISTING,
+        author=_author_returning(plan),
+        judge=_judge_approving(),
+    )
+    assert not result.ok
+    assert "unknown handler" in result.error
+
+
+async def test_edit_uses_target_trigger_and_plan_settings():
+    plan = _plan(
+        action="edit",
+        target_handler_id="22222222-2222-2222-2222-222222222222",
+        trigger_type="message",  # author restates wrongly; the target wins
+        settings={"daily_time": "09:30"},
+        script='await send_message("digest v2")\n',
+    )
+    result = await run_creation_pipeline(
+        request="move the digest to 9:30",
+        trigger_type="schedule",
+        settings={},
+        existing_handlers=EXISTING,
+        author=_author_returning(plan),
+        judge=_judge_approving(),
+    )
+    assert result.ok
+    assert result.trigger_type == "schedule"
+    assert result.settings == {"daily_time": "09:30"}
+
+
+async def test_create_with_taken_name_is_rejected():
+    result = await run_creation_pipeline(
+        request="x",
+        trigger_type="message",
+        settings={},
+        existing_handlers=EXISTING,
+        author=_author_returning(_plan(name="Greeter")),  # case-insensitive clash
+        judge=_judge_approving(),
+    )
+    assert not result.ok
+    assert "already" in result.error
+
+
+async def test_create_without_name_is_rejected():
+    result = await run_creation_pipeline(
+        request="x",
+        trigger_type="message",
+        settings={},
+        existing_handlers=[],
+        author=_author_returning(_plan(name="  ")),
+        judge=_judge_approving(),
+    )
+    assert not result.ok
+    assert "name" in result.error
+
+
+async def test_author_infeasible_is_relayed():
+    plan = HandlerPlan(feasible=False, error="cannot exceed the 3-message cap")
+    result = await run_creation_pipeline(
+        request="say hi 100 times",
+        trigger_type="message",
+        settings={},
+        existing_handlers=[],
+        author=_author_returning(plan),
         judge=_judge_approving(),
     )
     assert not result.ok
@@ -62,10 +202,11 @@ async def test_author_error_is_relayed():
 
 async def test_judge_reject_is_relayed():
     result = await run_creation_pipeline(
-        description="whatever",
+        request="whatever",
         trigger_type="message",
         settings={},
-        author=_author_returning(GOOD_SCRIPT),
+        existing_handlers=[],
+        author=_author_returning(_plan()),
         judge=_judge_rejecting("sends in a loop, over the 3-message cap"),
     )
     assert not result.ok
@@ -81,10 +222,13 @@ async def test_lint_blocks_opaque_blob_before_judge():
 
     blob = "QUJDREVG" * 30
     result = await run_creation_pipeline(
-        description="sneaky",
+        request="sneaky",
         trigger_type="message",
         settings={},
-        author=_author_returning(f'data = "{blob}"\nawait send_message(data)\n'),
+        existing_handlers=[],
+        author=_author_returning(
+            _plan(script=f'data = "{blob}"\nawait send_message(data)\n')
+        ),
         judge=judge,
     )
     assert not result.ok
@@ -93,12 +237,12 @@ async def test_lint_blocks_opaque_blob_before_judge():
 
 
 async def test_code_fences_are_stripped():
-    fenced = "```python\n" + GOOD_SCRIPT + "```"
     result = await run_creation_pipeline(
-        description="x",
+        request="x",
         trigger_type="message",
         settings={},
-        author=_author_returning(fenced),
+        existing_handlers=[],
+        author=_author_returning(_plan(script="```python\n" + GOOD_SCRIPT + "```")),
         judge=_judge_approving(),
     )
     assert result.ok
@@ -118,10 +262,17 @@ async def test_judge_receives_trigger_cadence():
         return JudgeVerdict(approved=True, reason="ok")
 
     await run_creation_pipeline(
-        description="post fib",
+        request="post fib",
         trigger_type="schedule",
         settings={"interval_seconds": 300},
-        author=_author_returning('await send_message("0,1,1,2")\n'),
+        existing_handlers=[],
+        author=_author_returning(
+            _plan(
+                trigger_type="schedule",
+                settings={"interval_seconds": 300},
+                script='await send_message("0,1,1,2")\n',
+            )
+        ),
         judge=judge,
     )
     assert "every 5 minutes" in seen["ctx"]
@@ -152,34 +303,101 @@ ADMIN_SCRIPT = (
     '        await send_message("banned a scammer", "MODCHAT")\n'
 )
 
+ADMIN_EXISTING = [
+    {
+        "handler_id": "33333333-3333-3333-3333-333333333333",
+        "name": "scam-banner",
+        "trigger_type": "message",
+        "settings": {},
+        "channel_ids": [],
+        "description": "bans scammers",
+        "script": ADMIN_SCRIPT,
+    },
+]
+
+
+def _admin_plan(**over):
+    fields = {
+        "feasible": True,
+        "action": "create",
+        "name": "raid-alarm",
+        "trigger_type": "message",
+        "channel_ids": [],
+        "settings": {},
+        "script": ADMIN_SCRIPT,
+    }
+    fields.update(over)
+    return AdminHandlerPlan(**fields)
+
 
 def _admin_author_returning(plan):
-    async def author(*, request, channel_lister):
+    async def author(*, request, existing_handlers, channel_lister):
         return plan
 
     return author
 
 
-async def test_admin_pipeline_happy():
-    plan = AdminHandlerPlan(
-        feasible=True, trigger_type="message", channel_ids=[], settings={},
-        script=ADMIN_SCRIPT,
-    )
+async def test_admin_pipeline_create():
     result = await run_admin_creation_pipeline(
         request="watch for scams and ban them",
+        existing_handlers=ADMIN_EXISTING,
+        author=_admin_author_returning(_admin_plan()),
+        judge=_judge_approving(),
+    )
+    assert result.ok
+    assert result.action == "create"
+    assert result.name == "raid-alarm"
+    assert result.trigger_type == "message"
+    assert "ban_user" in result.script
+
+
+async def test_admin_pipeline_edit():
+    plan = _admin_plan(
+        action="edit",
+        target_handler_id="33333333-3333-3333-3333-333333333333",
+        name="",
+    )
+    result = await run_admin_creation_pipeline(
+        request="also check attachments",
+        existing_handlers=ADMIN_EXISTING,
         author=_admin_author_returning(plan),
         judge=_judge_approving(),
     )
     assert result.ok
-    assert result.trigger_type == "message"
-    assert result.channel_ids == []
-    assert "ban_user" in result.script
+    assert result.action == "edit"
+    assert result.target_handler_id == "33333333-3333-3333-3333-333333333333"
+
+
+async def test_admin_pipeline_edit_unknown_target():
+    plan = _admin_plan(action="edit", target_handler_id="not-a-real-id")
+    result = await run_admin_creation_pipeline(
+        request="x",
+        existing_handlers=ADMIN_EXISTING,
+        author=_admin_author_returning(plan),
+        judge=_judge_approving(),
+    )
+    assert not result.ok
+    assert "unknown handler" in result.error
+
+
+async def test_admin_pipeline_create_taken_name():
+    result = await run_admin_creation_pipeline(
+        request="x",
+        existing_handlers=ADMIN_EXISTING,
+        author=_admin_author_returning(_admin_plan(name="scam-banner")),
+        judge=_judge_approving(),
+    )
+    assert not result.ok
+    assert "already" in result.error
 
 
 async def test_admin_pipeline_not_feasible():
     plan = AdminHandlerPlan(feasible=False, error="needs 100 bans/sec, over the cap")
     result = await run_admin_creation_pipeline(
-        request="impossible", author=_admin_author_returning(plan), judge=_judge_approving()
+        request="impossible",
+        existing_handlers=[],
+        author=_admin_author_returning(plan),
+        judge=_judge_approving(),
     )
     assert not result.ok
     assert "over the cap" in result.error
@@ -193,9 +411,11 @@ async def test_admin_pipeline_lint_blocks_blob_before_judge():
         return JudgeVerdict(approved=True, reason="ok")
 
     blob = "QUJDREVG" * 30
-    plan = AdminHandlerPlan(feasible=True, trigger_type="message", script=f'x = "{blob}"\n')
     result = await run_admin_creation_pipeline(
-        request="sneaky", author=_admin_author_returning(plan), judge=judge
+        request="sneaky",
+        existing_handlers=[],
+        author=_admin_author_returning(_admin_plan(script=f'x = "{blob}"\n')),
+        judge=judge,
     )
     assert not result.ok
     assert "opaque" in result.error
@@ -203,9 +423,10 @@ async def test_admin_pipeline_lint_blocks_blob_before_judge():
 
 
 async def test_admin_pipeline_judge_reject():
-    plan = AdminHandlerPlan(feasible=True, trigger_type="message", script=ADMIN_SCRIPT)
     result = await run_admin_creation_pipeline(
-        request="x", author=_admin_author_returning(plan),
+        request="x",
+        existing_handlers=[],
+        author=_admin_author_returning(_admin_plan()),
         judge=_judge_rejecting("bans every author with no condition"),
     )
     assert not result.ok

--- a/tests/bot/handler_tools_test.py
+++ b/tests/bot/handler_tools_test.py
@@ -24,8 +24,14 @@ class _FakeAPI:
     def __init__(self):
         self.get_responses = {}
         self.posted = []
+        self.updated = []
         self.deleted = []
-        self.post_response = _Resp(201, {"handler_id": "H1", "description": "d"})
+        self.post_response = _Resp(
+            201, {"handler_id": "H1", "name": "greeter", "description": "d"}
+        )
+        self.put_response = _Resp(
+            200, {"handler_id": "H1", "name": "greeter", "description": "d"}
+        )
         self.delete_response = _Resp(200, {"deleted": "H1"})
         self.list_response = _Resp(200, [])
 
@@ -38,6 +44,10 @@ class _FakeAPI:
         self.posted.append((path, json_data))
         return self.post_response
 
+    async def put(self, path, json_data=None):
+        self.updated.append((path, json_data))
+        return self.put_response
+
     async def delete(self, path):
         self.deleted.append(path)
         return self.delete_response
@@ -49,8 +59,19 @@ def _ctx(api):
     return SimpleNamespace(deps=deps)
 
 
-async def _ok_pipeline(**kwargs):
-    return CreationResult(ok=True, script='await send_message("hi")\n')
+def _create_result(**over):
+    fields = {
+        "ok": True,
+        "action": "create",
+        "target_handler_id": None,
+        "name": "hi-sayer",
+        "trigger_type": "message",
+        "settings": {},
+        "description": "says hi",
+        "script": 'await send_message("hi")\n',
+    }
+    fields.update(over)
+    return CreationResult(**fields)
 
 
 async def test_register_unknown_trigger(monkeypatch):
@@ -59,17 +80,68 @@ async def test_register_unknown_trigger(monkeypatch):
     assert out.startswith("error: unknown trigger")
 
 
-async def test_register_event_handler_happy(monkeypatch):
-    monkeypatch.setattr(ht, "run_creation_pipeline", _ok_pipeline)
+async def test_register_creates_named_handler(monkeypatch):
+    seen = {}
+
+    async def _pipeline(**kwargs):
+        seen.update(kwargs)
+        return _create_result()
+
+    monkeypatch.setattr(ht, "run_creation_pipeline", _pipeline)
     api = _FakeAPI()
+    api.post_response = _Resp(
+        201, {"handler_id": "H1", "name": "hi-sayer", "description": "says hi"}
+    )
+    api.list_response = _Resp(
+        200,
+        [
+            {
+                "handler_id": "H9",
+                "name": "old-greeter",
+                "trigger_type": "message",
+                "settings": {},
+                "description": "greets",
+                "script": "pass\n",
+            }
+        ],
+    )
     out = await ht.register_handler(
         _ctx(api), "react on huzzah", "reaction add", {}, "999"
     )
-    assert "Created handler H1" in out
+    assert "hi-sayer" in out
+    # The pipeline saw the channel's existing handlers, scripts included.
+    assert seen["existing_handlers"][0]["name"] == "old-greeter"
+    assert seen["existing_handlers"][0]["script"] == "pass\n"
     path, payload = api.posted[0]
     assert path == "/handlers"
-    assert payload["trigger_type"] == "reaction"
+    assert payload["name"] == "hi-sayer"
+    assert payload["trigger_type"] == "message"  # the plan's trigger, not the hint
     assert payload["channel_id"] == "999"
+
+
+async def test_register_edits_existing_handler(monkeypatch):
+    async def _pipeline(**kwargs):
+        return _create_result(
+            action="edit",
+            target_handler_id="H9",
+            name="old-greeter",
+            description="greets adventurers",
+            script='await send_message("hail")\n',
+        )
+
+    monkeypatch.setattr(ht, "run_creation_pipeline", _pipeline)
+    api = _FakeAPI()
+    api.put_response = _Resp(
+        200,
+        {"handler_id": "H9", "name": "old-greeter", "description": "greets adventurers"},
+    )
+    out = await ht.register_handler(_ctx(api), "make the greeter medieval", "message")
+    assert "old-greeter" in out and "Updated" in out
+    assert api.posted == []
+    path, payload = api.updated[0]
+    assert path == "/handlers/H9"
+    assert payload["script"] == 'await send_message("hail")\n'
+    assert payload["description"] == "greets adventurers"
 
 
 async def test_register_pipeline_error_relayed(monkeypatch):
@@ -80,11 +152,16 @@ async def test_register_pipeline_error_relayed(monkeypatch):
     api = _FakeAPI()
     out = await ht.register_handler(_ctx(api), "spam", "new message")
     assert out == "error: cannot exceed 3 messages"
-    assert api.posted == []
+    assert api.posted == [] and api.updated == []
 
 
 async def test_register_schedule_below_floor(monkeypatch):
-    monkeypatch.setattr(ht, "run_creation_pipeline", _ok_pipeline)
+    async def _pipeline(**kwargs):
+        return _create_result(
+            trigger_type="schedule", settings={"interval_seconds": 5}
+        )
+
+    monkeypatch.setattr(ht, "run_creation_pipeline", _pipeline)
     api = _FakeAPI()
     out = await ht.register_handler(
         _ctx(api), "ping often", "schedule", {"interval_seconds": 5}
@@ -98,12 +175,12 @@ async def test_list_handlers_formats_rows():
     api.list_response = _Resp(
         200,
         [
-            {"handler_id": "H1", "trigger_type": "message", "description": "a"},
-            {"handler_id": "H2", "trigger_type": "timer", "description": "b"},
+            {"handler_id": "H1", "name": "greeter", "trigger_type": "message", "description": "a"},
+            {"handler_id": "H2", "name": "digest", "trigger_type": "timer", "description": "b"},
         ],
     )
     out = await ht.list_handlers(_ctx(api), "999")
-    assert "H1" in out and "H2" in out and "[timer]" in out
+    assert "greeter" in out and "digest" in out and "[timer]" in out
 
 
 async def test_list_handlers_empty():

--- a/tests/web/handler_models_test.py
+++ b/tests/web/handler_models_test.py
@@ -1,17 +1,20 @@
-"""Tests for the handler data model — single-listener keying in particular."""
+"""Tests for the handler data model — name uniqueness keying in particular."""
 
 from __future__ import annotations
 
 import pytest
 from sqlalchemy.exc import IntegrityError
 
-from smarter_dev.web.models import ChannelHandler
+from smarter_dev.web.models import AdminHandler, ChannelHandler
 
 
-def _handler(trigger_type: str, channel_id: str = "C1") -> ChannelHandler:
+def _handler(
+    trigger_type: str, channel_id: str = "C1", name: str = "helper"
+) -> ChannelHandler:
     return ChannelHandler(
         guild_id="G1",
         channel_id=channel_id,
+        name=name,
         trigger_type=trigger_type,
         settings={},
         description="d",
@@ -20,22 +23,42 @@ def _handler(trigger_type: str, channel_id: str = "C1") -> ChannelHandler:
     )
 
 
-async def test_event_trigger_is_single_listener_per_channel(db_session):
-    db_session.add(_handler("message"))
+async def test_same_trigger_handlers_coexist_under_different_names(db_session):
+    db_session.add(_handler("message", name="greeter"))
+    db_session.add(_handler("message", name="mood-tracker"))
+    await db_session.commit()  # multiple listeners per (channel, trigger) are fine
+
+
+async def test_name_is_unique_per_channel(db_session):
+    db_session.add(_handler("message", name="greeter"))
     await db_session.commit()
-    db_session.add(_handler("message"))
+    db_session.add(_handler("reaction", name="greeter"))
     with pytest.raises(IntegrityError):
         await db_session.commit()
 
 
-async def test_different_event_triggers_coexist(db_session):
-    db_session.add(_handler("message"))
-    db_session.add(_handler("reaction"))
-    await db_session.commit()  # no conflict — different trigger_type
+async def test_same_name_in_different_channels(db_session):
+    db_session.add(_handler("message", channel_id="C1", name="greeter"))
+    db_session.add(_handler("message", channel_id="C2", name="greeter"))
+    await db_session.commit()  # uniqueness is per channel
 
 
-async def test_many_time_triggers_share_a_channel(db_session):
-    db_session.add(_handler("timer"))
-    db_session.add(_handler("timer"))
-    db_session.add(_handler("schedule"))
-    await db_session.commit()  # partial index excludes time triggers
+async def test_admin_handler_name_is_unique_per_guild(db_session):
+    def _admin(guild_id: str, name: str) -> AdminHandler:
+        return AdminHandler(
+            guild_id=guild_id,
+            name=name,
+            trigger_type="message",
+            settings={},
+            channel_ids=[],
+            description="d",
+            script="pass\n",
+            created_by_admin="A1",
+        )
+
+    db_session.add(_admin("G1", "scam-banner"))
+    db_session.add(_admin("G2", "scam-banner"))  # other guild — fine
+    await db_session.commit()
+    db_session.add(_admin("G1", "scam-banner"))
+    with pytest.raises(IntegrityError):
+        await db_session.commit()

--- a/tests/web/test_api/test_admin_handlers.py
+++ b/tests/web/test_api/test_admin_handlers.py
@@ -12,6 +12,16 @@ from smarter_dev.web.api.app import api
 from smarter_dev.web.api.dependencies import verify_api_key
 
 
+class _StubJobHandle:
+    cancelled: list[str] = []
+
+    def __init__(self, job_id):
+        self.job_id = job_id
+
+    async def cancel(self):
+        _StubJobHandle.cancelled.append(self.job_id)
+
+
 @pytest.fixture
 async def session():
     engine = create_async_engine(
@@ -31,10 +41,14 @@ async def session():
 async def client(session, monkeypatch):
     import smarter_dev.web.api.routers.admin_handlers as ah
 
-    async def _submit(payload, **kwargs):
-        return None
+    submitted = []
 
+    async def _submit(payload, **kwargs):
+        submitted.append((payload, kwargs))
+
+    _StubJobHandle.cancelled = []
     monkeypatch.setattr(ah, "worker_submit", _submit)
+    monkeypatch.setattr(ah, "get_handle", _StubJobHandle)
 
     async def _verify():
         return object()
@@ -46,6 +60,7 @@ async def client(session, monkeypatch):
     api.dependency_overrides[get_skrift_db_session] = _session
     transport = ASGITransport(app=api)
     async with AsyncClient(transport=transport, base_url="http://t") as c:
+        c.submitted = submitted  # type: ignore[attr-defined]
         yield c
     api.dependency_overrides.pop(verify_api_key, None)
     api.dependency_overrides.pop(get_skrift_db_session, None)
@@ -54,6 +69,7 @@ async def client(session, monkeypatch):
 def _body(**over):
     body = {
         "guild_id": "G1",
+        "name": "scam-banner",
         "trigger_type": "message",
         "settings": {},
         "channel_ids": [],
@@ -71,14 +87,105 @@ async def test_create_list_delete_admin_handler(client):
     data = created.json()
     assert data["trigger_type"] == "message"
     assert data["channel_ids"] == []
+    assert data["name"] == "scam-banner"
     hid = data["handler_id"]
 
     listed = await client.get("/admin/handlers", params={"guild_id": "G1"})
     assert len(listed.json()) == 1
+    assert "script" not in listed.json()[0]
 
     deleted = await client.delete(f"/admin/handlers/{hid}")
     assert deleted.status_code == 200
     assert (await client.get("/admin/handlers", params={"guild_id": "G1"})).json() == []
+
+
+async def test_multiple_admin_handlers_per_trigger_coexist(client):
+    first = await client.post("/admin/handlers", json=_body(name="scam-banner"))
+    second = await client.post("/admin/handlers", json=_body(name="spam-sweeper"))
+    assert first.status_code == 201 and second.status_code == 201
+    listed = await client.get("/admin/handlers", params={"guild_id": "G1"})
+    assert {r["name"] for r in listed.json()} == {"scam-banner", "spam-sweeper"}
+
+
+async def test_duplicate_admin_name_in_guild_is_conflict(client):
+    await client.post("/admin/handlers", json=_body(name="scam-banner"))
+    dupe = await client.post(
+        "/admin/handlers", json=_body(name="scam-banner", trigger_type="reaction")
+    )
+    assert dupe.status_code == 409
+    other_guild = await client.post(
+        "/admin/handlers", json=_body(name="scam-banner", guild_id="G2")
+    )
+    assert other_guild.status_code == 201
+
+
+async def test_list_admin_handlers_with_scripts(client):
+    await client.post("/admin/handlers", json=_body())
+    listed = await client.get(
+        "/admin/handlers", params={"guild_id": "G1", "include_scripts": "true"}
+    )
+    assert listed.json()[0]["script"].startswith("await ban_user")
+
+
+async def test_edit_admin_handler(client):
+    created = await client.post("/admin/handlers", json=_body())
+    hid = created.json()["handler_id"]
+    resp = await client.put(
+        f"/admin/handlers/{hid}",
+        json={
+            "description": "ban scammers politely",
+            "script": 'await ban_user(context["author_id"], "scam")\n',
+            "settings": {},
+            "channel_ids": ["MODCHAT"],
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.json()["channel_ids"] == ["MODCHAT"]
+    assert resp.json()["description"] == "ban scammers politely"
+
+
+async def test_edit_admin_rename_collision_is_conflict(client):
+    await client.post("/admin/handlers", json=_body(name="scam-banner"))
+    created = await client.post("/admin/handlers", json=_body(name="spam-sweeper"))
+    hid = created.json()["handler_id"]
+    collision = await client.put(
+        f"/admin/handlers/{hid}",
+        json={
+            "description": "d",
+            "script": "pass\n",
+            "settings": {},
+            "channel_ids": [],
+            "name": "scam-banner",
+        },
+    )
+    assert collision.status_code == 409
+
+
+async def test_edit_scheduled_admin_handler_reschedules(client):
+    created = await client.post(
+        "/admin/handlers",
+        json=_body(
+            trigger_type="schedule",
+            settings={"interval_seconds": 3600},
+            channel_ids=["MODCHAT"],
+            script='await send_message("tick", "MODCHAT")\n',
+        ),
+    )
+    hid = created.json()["handler_id"]
+    assert len(client.submitted) == 1  # type: ignore[attr-defined]
+
+    resp = await client.put(
+        f"/admin/handlers/{hid}",
+        json={
+            "description": "tock",
+            "script": 'await send_message("tock", "MODCHAT")\n',
+            "settings": {"interval_seconds": 7200},
+            "channel_ids": ["MODCHAT"],
+        },
+    )
+    assert resp.status_code == 200
+    assert len(_StubJobHandle.cancelled) == 1
+    assert len(client.submitted) == 2  # type: ignore[attr-defined]
 
 
 async def test_create_scheduled_admin_handler_schedules_fire(client):

--- a/tests/web/test_api/test_handlers.py
+++ b/tests/web/test_api/test_handlers.py
@@ -10,6 +10,7 @@ from sqlalchemy.pool import StaticPool
 from smarter_dev.shared.database import Base, get_skrift_db_session
 from smarter_dev.web.api.app import api
 from smarter_dev.web.api.dependencies import verify_api_key
+from smarter_dev.web.handler_caps import MAX_HANDLERS_PER_CHANNEL
 
 
 class _StubLimiter:
@@ -18,6 +19,16 @@ class _StubLimiter:
 
     async def hit(self, key, limit):
         return self.allow
+
+
+class _StubJobHandle:
+    cancelled: list[str] = []
+
+    def __init__(self, job_id):
+        self.job_id = job_id
+
+    async def cancel(self):
+        _StubJobHandle.cancelled.append(self.job_id)
 
 
 @pytest.fixture
@@ -44,7 +55,9 @@ async def client(session, monkeypatch):
     async def _submit(payload, **kwargs):
         submitted.append((payload, kwargs))
 
+    _StubJobHandle.cancelled = []
     monkeypatch.setattr(h, "worker_submit", _submit)
+    monkeypatch.setattr(h, "get_handle", _StubJobHandle)
     monkeypatch.setattr(h, "get_redis_client", lambda: None)
     monkeypatch.setattr(h, "WindowedLimiter", lambda redis: _StubLimiter(allow=True))
 
@@ -68,6 +81,7 @@ def _event_body(**over):
     body = {
         "guild_id": "G1",
         "channel_id": "C1",
+        "name": "huzzah-reactor",
         "trigger_type": "message",
         "settings": {},
         "description": "react on huzzah",
@@ -82,13 +96,42 @@ async def test_create_event_handler(client):
     resp = await client.post("/handlers", json=_event_body())
     assert resp.status_code == 201
     assert resp.json()["trigger_type"] == "message"
+    assert resp.json()["name"] == "huzzah-reactor"
 
 
-async def test_event_handler_is_single_listener_replace(client):
-    first = await client.post("/handlers", json=_event_body(description="v1"))
-    second = await client.post("/handlers", json=_event_body(description="v2"))
-    assert first.json()["handler_id"] == second.json()["handler_id"]
-    assert second.json()["description"] == "v2"
+async def test_multiple_handlers_per_trigger_coexist(client):
+    first = await client.post("/handlers", json=_event_body(name="greeter"))
+    second = await client.post("/handlers", json=_event_body(name="mood-tracker"))
+    assert first.status_code == 201 and second.status_code == 201
+    assert first.json()["handler_id"] != second.json()["handler_id"]
+    listed = await client.get("/handlers", params={"channel_id": "C1"})
+    assert {r["name"] for r in listed.json()} == {"greeter", "mood-tracker"}
+
+
+async def test_duplicate_name_in_channel_is_conflict(client):
+    await client.post("/handlers", json=_event_body(name="greeter"))
+    dupe = await client.post(
+        "/handlers", json=_event_body(name="greeter", trigger_type="reaction")
+    )
+    assert dupe.status_code == 409
+    # Same name in a DIFFERENT channel is fine.
+    other = await client.post(
+        "/handlers", json=_event_body(name="greeter", channel_id="C2")
+    )
+    assert other.status_code == 201
+
+
+async def test_blank_name_is_rejected(client):
+    resp = await client.post("/handlers", json=_event_body(name="   "))
+    assert resp.status_code == 422
+
+
+async def test_handler_count_cap_per_channel(client):
+    for n in range(MAX_HANDLERS_PER_CHANNEL):
+        resp = await client.post("/handlers", json=_event_body(name=f"h{n}"))
+        assert resp.status_code == 201
+    over = await client.post("/handlers", json=_event_body(name="one-too-many"))
+    assert over.status_code == 422
 
 
 async def test_create_timer_schedules_first_fire(client):
@@ -119,11 +162,86 @@ async def test_list_and_delete(client):
     await client.post("/handlers", json=_event_body())
     listed = await client.get("/handlers", params={"channel_id": "C1"})
     assert len(listed.json()) == 1
+    assert "script" not in listed.json()[0]
     handler_id = listed.json()[0]["handler_id"]
     deleted = await client.delete(f"/handlers/{handler_id}")
     assert deleted.status_code == 200
     again = await client.get("/handlers", params={"channel_id": "C1"})
     assert again.json() == []
+
+
+async def test_list_with_scripts(client):
+    await client.post("/handlers", json=_event_body())
+    listed = await client.get(
+        "/handlers", params={"channel_id": "C1", "include_scripts": "true"}
+    )
+    assert listed.json()[0]["script"].startswith("await add_reaction")
+
+
+async def test_edit_handler_updates_script_and_description(client):
+    created = await client.post("/handlers", json=_event_body())
+    handler_id = created.json()["handler_id"]
+    resp = await client.put(
+        f"/handlers/{handler_id}",
+        json={
+            "description": "react on hooray too",
+            "script": 'await add_reaction(context["message_id"], "🎊")\n',
+            "settings": {},
+        },
+    )
+    assert resp.status_code == 200
+    detail = await client.get(f"/handlers/{handler_id}")
+    assert detail.json()["description"] == "react on hooray too"
+    assert "🎊" in detail.json()["script"]
+    assert detail.json()["name"] == "huzzah-reactor"  # unchanged without rename
+
+
+async def test_edit_can_rename_but_not_to_taken_name(client):
+    await client.post("/handlers", json=_event_body(name="greeter"))
+    created = await client.post("/handlers", json=_event_body(name="mood"))
+    handler_id = created.json()["handler_id"]
+    renamed = await client.put(
+        f"/handlers/{handler_id}",
+        json={"description": "d", "script": "pass\n", "settings": {}, "name": "vibes"},
+    )
+    assert renamed.status_code == 200
+    assert renamed.json()["name"] == "vibes"
+    collision = await client.put(
+        f"/handlers/{handler_id}",
+        json={"description": "d", "script": "pass\n", "settings": {}, "name": "greeter"},
+    )
+    assert collision.status_code == 409
+
+
+async def test_edit_time_handler_cancels_and_reschedules(client):
+    body = _event_body(
+        trigger_type="schedule",
+        settings={"interval_seconds": 3600},
+        script='await send_message("hourly")\n',
+    )
+    created = await client.post("/handlers", json=body)
+    handler_id = created.json()["handler_id"]
+    assert len(client.submitted) == 1  # type: ignore[attr-defined]
+
+    resp = await client.put(
+        f"/handlers/{handler_id}",
+        json={
+            "description": "every two hours",
+            "script": 'await send_message("bihourly")\n',
+            "settings": {"interval_seconds": 7200},
+        },
+    )
+    assert resp.status_code == 200
+    assert len(_StubJobHandle.cancelled) == 1
+    assert len(client.submitted) == 2  # type: ignore[attr-defined]
+
+
+async def test_edit_unknown_handler_is_404(client):
+    resp = await client.put(
+        "/handlers/00000000-0000-0000-0000-000000000000",
+        json={"description": "d", "script": "pass\n", "settings": {}},
+    )
+    assert resp.status_code == 404
 
 
 async def test_dispatch_no_handler(client):
@@ -134,8 +252,9 @@ async def test_dispatch_no_handler(client):
     assert resp.json()["dispatched"] is False
 
 
-async def test_dispatch_enqueues_when_handler_present(client):
-    await client.post("/handlers", json=_event_body())
+async def test_dispatch_fires_all_standard_handlers_for_trigger(client):
+    await client.post("/handlers", json=_event_body(name="greeter"))
+    await client.post("/handlers", json=_event_body(name="mood-tracker"))
     resp = await client.post(
         "/handlers/dispatch",
         json={
@@ -146,7 +265,8 @@ async def test_dispatch_enqueues_when_handler_present(client):
         },
     )
     assert resp.json()["dispatched"] is True
-    assert len(client.submitted) == 1  # type: ignore[attr-defined]
+    assert len(resp.json()["handler_ids"]) == 2
+    assert len(client.submitted) == 2  # type: ignore[attr-defined]
 
 
 async def test_dispatch_rate_limited(client, monkeypatch):
@@ -167,16 +287,19 @@ async def test_dispatch_fans_out_to_standard_and_admin(client, session):
     # one standard handler in C1, one all-channel admin handler, one admin handler
     # scoped to a different channel (should NOT fire for C1).
     session.add(ChannelHandler(
-        guild_id="G1", channel_id="C1", trigger_type="message", settings={},
-        description="std", script="await send_message('x')\n", created_by="U1",
+        guild_id="G1", channel_id="C1", name="std", trigger_type="message",
+        settings={}, description="std", script="await send_message('x')\n",
+        created_by="U1",
     ))
     session.add(AdminHandler(
-        guild_id="G1", trigger_type="message", settings={}, channel_ids=[],
-        description="all-chan admin", script="await send_message('y')\n", created_by_admin="A1",
+        guild_id="G1", name="all-chan", trigger_type="message", settings={},
+        channel_ids=[], description="all-chan admin",
+        script="await send_message('y')\n", created_by_admin="A1",
     ))
     session.add(AdminHandler(
-        guild_id="G1", trigger_type="message", settings={}, channel_ids=["OTHER"],
-        description="scoped admin", script="await send_message('z')\n", created_by_admin="A1",
+        guild_id="G1", name="scoped", trigger_type="message", settings={},
+        channel_ids=["OTHER"], description="scoped admin",
+        script="await send_message('z')\n", created_by_admin="A1",
     ))
     await session.commit()
 
@@ -193,7 +316,7 @@ async def test_dispatch_fans_out_to_standard_and_admin(client, session):
 
 async def test_active_channels(client):
     await client.post("/handlers", json=_event_body())
-    await client.post("/handlers", json=_event_body(trigger_type="reaction"))
+    await client.post("/handlers", json=_event_body(name="rx", trigger_type="reaction"))
     resp = await client.get("/handlers/active-channels")
     channels = resp.json()["channels"]
     assert ["C1", "message"] in channels


### PR DESCRIPTION
## Why

Only one handler could exist per (channel, trigger), so every change meant merging new behavior into one ever-growing script — complex and error-prone for Gemini 3 Flash. Handlers are now named, multiple can share a trigger, and the author agent decides whether to edit an existing handler or create a new one.

## What

**Schema + migration**
- `name` on `channel_handlers` (unique per channel) and `admin_handlers` (unique per guild); single-listener partial unique index dropped
- Backfill: existing rows named `<trigger>-<first-8-of-id>`; upgrade AND downgrade verified against Postgres 16
- Deploy's migrate job applies it automatically

**Authoring**
- Member author is now a structured planner (like the admin author already was): it sees the request + the channel's existing handlers (names, triggers, scripts) and returns edit-by-id or create-with-name, plus trigger, settings, a fresh one-line description, and the complete replacement script
- Admin author gets the same edit-vs-create powers fed with the guild's admin handlers
- Plans are validated against the real handler list (unknown target, duplicate/blank name, bad trigger → relayable error) before lint/judge
- On edit the target's trigger type wins and the script is replaced wholesale — no more merge prompts

**API**
- `POST /handlers` + `POST /admin/handlers` require `name`, 409 on duplicates, no more upsert
- New `PUT /handlers/{id}` + `PUT /admin/handlers/{id}` (time triggers cancel + reschedule)
- Dispatch fires ALL enabled standard handlers for a (channel, trigger), matching admin fan-out
- `include_scripts=true` on both list endpoints for the author's view
- Creation caps now that the structural bound is gone: 10 handlers/channel, 20 admin handlers/guild

**Surfaces** — bot replies and `/adminhandler list` show handler names; admin panel shows the name in each summary row.

## Tests

74 handler-focused tests (API, models, pipeline, tools, plugin install step) — new coverage for name conflicts, PUT/rename/reschedule, multi-handler dispatch fan-out, edit-target validation, and case-insensitive name clashes. Full suite: 1120 passed; the only failures are the two `test_chat_engine` cases that also fail on clean main (and two `scan_*` files that don't collect on main). semgrep + gitleaks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017RP9r7JpmkDMqKdbRiJdVN