### PR TITLE
Per-user chat rate limit, /bot-usage command, universal token metering, English-only policy

### DIFF
--- a/smarter_dev/bot/agents/prompts/chat_agent.md
+++ b/smarter_dev/bot/agents/prompts/chat_agent.md
@@ -114,6 +114,31 @@ Silence is always a choice you MAKE — never something that happens
 because you left `response` empty after deciding to answer. If you
 worked out a reply in your head, send it.
 
+# Language — English only
+
+You speak English, only English, in every reply — regardless of what
+language a message arrives in. Never switch languages, never mix in a
+translated answer "to be helpful", never translate-on-request as a
+workaround.
+
+When a message that earned a reply (scored >= 5) isn't written in
+English, this rule overrides the normal "it's a coding question →
+answer it" step:
+
+- **First time** — don't answer the content and don't run tools on it.
+  Send a short, polite redirect in English instead ("gonna need that in
+  english — it's the only language i speak" / "english please! happy to
+  help from there").
+- **They keep going** — a user who continues in non-English after your
+  redirect gets `response = None`, the same as any other message that
+  doesn't earn a reply. You've said your piece; don't re-warn them
+  every message.
+
+This is about the language the user is *speaking to you* in. Scattered
+non-English inside an otherwise-English message — loanwords, a pasted
+error message or log in another language, code comments — is fine, and
+you answer those normally (in English).
+
 # Style
 
 - Match the channel's energy. Casual → casual. Technical → technical

--- a/smarter_dev/bot/client.py
+++ b/smarter_dev/bot/client.py
@@ -1180,6 +1180,10 @@ def load_plugins(bot: lightbulb.BotApp) -> None:
         bot.load_extensions("smarter_dev.bot.plugins.model_override")
         logger.info("✓ Loaded model override plugin")
 
+        logger.info("Loading bot usage plugin...")
+        bot.load_extensions("smarter_dev.bot.plugins.bot_usage")
+        logger.info("✓ Loaded bot usage plugin")
+
         logger.info("✓ All plugins loaded successfully")
     except Exception as e:
         logger.error(f"Failed to load plugins: {e}")

--- a/smarter_dev/bot/plugins/bot_usage.py
+++ b/smarter_dev/bot/plugins/bot_usage.py
@@ -1,0 +1,164 @@
+"""``/bot-usage`` slash command — personal message allowance + channel token usage.
+
+Available to everyone; responds ephemerally. Shows two things:
+
+- The invoker's rolling per-user message counter (see
+  :mod:`~smarter_dev.bot.services.user_message_limit`), framed over the hours
+  the counted messages actually span ("32/60 messages in the last hour").
+- The channel's chat-token consumption for the current hour and day windows
+  against its configured budgets ("76k/100k this hour · 512k/1m today").
+  Token usage is only metered on channels with a model override, so channels
+  without one say so instead of showing numbers.
+
+Every data source is fail-soft: a Redis or API hiccup degrades that line to
+"unavailable" rather than failing the command.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC
+from datetime import datetime
+from typing import Any
+
+import hikari
+import lightbulb
+from redis.exceptions import RedisError
+
+from smarter_dev.bot.services.channel_token_budget import current_window_usage
+from smarter_dev.bot.services.exceptions import APIError
+from smarter_dev.bot.services.user_message_limit import USER_MESSAGE_LIMIT
+from smarter_dev.bot.services.user_message_limit import counted_messages
+from smarter_dev.bot.services.user_message_limit import format_counted_window
+
+logger = logging.getLogger(__name__)
+
+plugin = lightbulb.Plugin("bot_usage")
+
+_UNAVAILABLE = "unavailable right now"
+
+
+def _chat_memory_redis(bot: Any) -> Any | None:
+    """The shared chat-memory Redis, or None when unavailable."""
+    data = getattr(bot, "d", None)
+    if not isinstance(data, dict):
+        return None
+    return data.get("chat_memory_redis")
+
+
+def _override_service(bot: Any) -> Any | None:
+    """The bot's ModelOverrideService, or None when unavailable (fail-soft)."""
+    data = getattr(bot, "d", None)
+    if not isinstance(data, dict):
+        return None
+    service = data.get("model_override_service")
+    if service is None:
+        service = data.get("_services", {}).get("model_override_service")
+    return service
+
+
+def format_compact_tokens(count: int) -> str:
+    """Render a token count the way budgets read in chat: 76k, 512k, 1.5m."""
+    for threshold, suffix in ((1_000_000, "m"), (1_000, "k")):
+        if count >= threshold:
+            rendered = f"{count / threshold:.1f}".rstrip("0").rstrip(".")
+            return f"{rendered}{suffix}"
+    return str(count)
+
+
+def _render_budget_side(budget: int) -> str:
+    """The allowance half of "used/allowed"; a 0 budget is unlimited."""
+    return format_compact_tokens(budget) if budget > 0 else "unlimited"
+
+
+async def _messages_line(bot: Any, user_id: str) -> str:
+    """The invoker's "32/60 messages in the last hour" line."""
+    redis = _chat_memory_redis(bot)
+    if redis is None:
+        return f"**Your messages:** {_UNAVAILABLE}"
+    try:
+        counted, oldest_epoch = await counted_messages(redis, user_id)
+    except RedisError:
+        logger.warning(
+            "Failed to read message counter for user %s", user_id, exc_info=True
+        )
+        return f"**Your messages:** {_UNAVAILABLE}"
+    span = format_counted_window(oldest_epoch, datetime.now(UTC).timestamp())
+    return f"**Your messages:** {counted}/{USER_MESSAGE_LIMIT} in {span}"
+
+
+async def _channel_tokens_line(bot: Any, guild_id: str, channel_id: str) -> str:
+    """The channel's "76k/100k this hour · 512k/1m today" line."""
+    override = None
+    service = _override_service(bot)
+    if service is not None:
+        try:
+            override = await service.get_override(guild_id, channel_id)
+        except APIError:
+            logger.warning(
+                "Failed to read model override for channel %s", channel_id,
+                exc_info=True,
+            )
+            return f"**Bot usage here:** {_UNAVAILABLE}"
+    if override is None:
+        return (
+            "**Bot usage here:** not metered — this channel has no token budget"
+        )
+    redis = _chat_memory_redis(bot)
+    if redis is None:
+        return f"**Bot usage here:** {_UNAVAILABLE}"
+    try:
+        hour_used, day_used = await current_window_usage(redis, channel_id)
+    except RedisError:
+        logger.warning(
+            "Failed to read token usage for channel %s", channel_id, exc_info=True
+        )
+        return f"**Bot usage here:** {_UNAVAILABLE}"
+    hour = (
+        f"{format_compact_tokens(hour_used)}"
+        f"/{_render_budget_side(override.hourly_token_budget)}"
+    )
+    day = (
+        f"{format_compact_tokens(day_used)}"
+        f"/{_render_budget_side(override.daily_token_budget)}"
+    )
+    return f"**Bot usage here:** {hour} this hour · {day} today"
+
+
+async def build_usage_report(
+    bot: Any, user_id: str, guild_id: str, channel_id: str
+) -> str:
+    """The full ``/bot-usage`` response body."""
+    return "\n".join(
+        (
+            await _messages_line(bot, user_id),
+            await _channel_tokens_line(bot, guild_id, channel_id),
+        )
+    )
+
+
+@plugin.command
+@lightbulb.command(
+    "bot-usage",
+    "Your chat-bot message allowance and this channel's token usage",
+)
+@lightbulb.implements(lightbulb.SlashCommand)
+async def bot_usage(ctx: lightbulb.Context) -> None:
+    """Show the invoker their message counter and the channel's token meter."""
+    report = await build_usage_report(
+        ctx.bot,
+        str(ctx.author.id),
+        str(ctx.guild_id),
+        str(ctx.channel_id),
+    )
+    await ctx.respond(report, flags=hikari.MessageFlag.EPHEMERAL)
+
+
+def load(bot: lightbulb.BotApp) -> None:
+    """Load the bot-usage plugin."""
+    bot.add_plugin(plugin)
+
+
+def unload(bot: lightbulb.BotApp) -> None:
+    """Unload the bot-usage plugin."""
+    bot.remove_plugin(plugin)

--- a/smarter_dev/bot/plugins/bot_usage.py
+++ b/smarter_dev/bot/plugins/bot_usage.py
@@ -7,8 +7,9 @@ Available to everyone; responds ephemerally. Shows two things:
   the counted messages actually span ("32/60 messages in the last hour").
 - The channel's chat-token consumption for the current hour and day windows
   against its configured budgets ("76k/100k this hour · 512k/1m today").
-  Token usage is only metered on channels with a model override, so channels
-  without one say so instead of showing numbers.
+  Every channel is metered; without a ``/setmodel`` budget the allowance
+  reads "unlimited", and a maxed-out budget window shows a live countdown
+  to its wall-clock reset.
 
 Every data source is fail-soft: a Redis or API hiccup degrades that line to
 "unavailable" rather than failing the command.
@@ -25,7 +26,10 @@ import hikari
 import lightbulb
 from redis.exceptions import RedisError
 
+from smarter_dev.bot.services.channel_token_budget import DAY_WINDOW_SECONDS
+from smarter_dev.bot.services.channel_token_budget import HOUR_WINDOW_SECONDS
 from smarter_dev.bot.services.channel_token_budget import current_window_usage
+from smarter_dev.bot.services.channel_token_budget import next_window_reset_epoch
 from smarter_dev.bot.services.exceptions import APIError
 from smarter_dev.bot.services.user_message_limit import USER_MESSAGE_LIMIT
 from smarter_dev.bot.services.user_message_limit import counted_messages
@@ -71,6 +75,18 @@ def _render_budget_side(budget: int) -> str:
     return format_compact_tokens(budget) if budget > 0 else "unlimited"
 
 
+def _render_window_usage(
+    used: int, budget: int, label: str, now_epoch: float, window_seconds: int
+) -> str:
+    """One window's "76k/100k this hour" — plus, once a budgeted window is
+    maxed, a live countdown to its wall-clock reset."""
+    rendered = f"{format_compact_tokens(used)}/{_render_budget_side(budget)} {label}"
+    if budget > 0 and used >= budget:
+        reset_epoch = next_window_reset_epoch(now_epoch, window_seconds)
+        rendered += f" (resets <t:{reset_epoch}:R>)"
+    return rendered
+
+
 async def _messages_line(bot: Any, user_id: str) -> str:
     """The invoker's "32/60 messages in the last hour" line."""
     redis = _chat_memory_redis(bot)
@@ -100,10 +116,6 @@ async def _channel_tokens_line(bot: Any, guild_id: str, channel_id: str) -> str:
                 exc_info=True,
             )
             return f"**Bot usage here:** {_UNAVAILABLE}"
-    if override is None:
-        return (
-            "**Bot usage here:** not metered — this channel has no token budget"
-        )
     redis = _chat_memory_redis(bot)
     if redis is None:
         return f"**Bot usage here:** {_UNAVAILABLE}"
@@ -114,15 +126,17 @@ async def _channel_tokens_line(bot: Any, guild_id: str, channel_id: str) -> str:
             "Failed to read token usage for channel %s", channel_id, exc_info=True
         )
         return f"**Bot usage here:** {_UNAVAILABLE}"
-    hour = (
-        f"{format_compact_tokens(hour_used)}"
-        f"/{_render_budget_side(override.hourly_token_budget)}"
+    # No override → no budgets to enforce; usage still shows, over "unlimited".
+    hourly_budget = override.hourly_token_budget if override is not None else 0
+    daily_budget = override.daily_token_budget if override is not None else 0
+    now_epoch = datetime.now(UTC).timestamp()
+    hour = _render_window_usage(
+        hour_used, hourly_budget, "this hour", now_epoch, HOUR_WINDOW_SECONDS
     )
-    day = (
-        f"{format_compact_tokens(day_used)}"
-        f"/{_render_budget_side(override.daily_token_budget)}"
+    day = _render_window_usage(
+        day_used, daily_budget, "today", now_epoch, DAY_WINDOW_SECONDS
     )
-    return f"**Bot usage here:** {hour} this hour · {day} today"
+    return f"**Bot usage here:** {hour} · {day}"
 
 
 async def build_usage_report(

--- a/smarter_dev/bot/plugins/mention.py
+++ b/smarter_dev/bot/plugins/mention.py
@@ -13,14 +13,22 @@ Responsibilities:
 from __future__ import annotations
 
 import logging
+from datetime import UTC
+from datetime import datetime
 from typing import TYPE_CHECKING
+from typing import Any
 
 import hikari
 import lightbulb
+from redis.exceptions import RedisError
 
 from smarter_dev.bot.services.chat_engine_registry import get_chat_engine_registry
 from smarter_dev.bot.services.chat_memory import get_chat_memory
 from smarter_dev.bot.services.rate_limiter import rate_limiter
+from smarter_dev.bot.services.user_message_limit import claim_notice_throttle
+from smarter_dev.bot.services.user_message_limit import format_over_limit_notice
+from smarter_dev.bot.services.user_message_limit import over_limit_status
+from smarter_dev.bot.services.user_message_limit import record_directed_messages
 from smarter_dev.bot.utils.stop_detection import (
     is_channel_on_cooldown,
     is_stop_request,
@@ -69,6 +77,94 @@ async def _voice_send(
         reply_to_message_id=reply_to,
         instruction=instruction,
     )
+
+
+def _chat_limit_redis(bot: Any) -> Any | None:
+    """The shared chat-memory Redis used for the per-user message limit.
+
+    Returns None when Redis is unavailable (the limit then simply doesn't
+    apply — a missing counter must never silence the bot).
+    """
+    data = getattr(bot, "d", None)
+    if not isinstance(data, dict):
+        return None
+    return data.get("chat_memory_redis")
+
+
+async def _reject_when_over_limit(bot: Any, event: hikari.MessageCreateEvent) -> bool:
+    """True when the author is over the rolling message limit (drop the message).
+
+    The first rejection of an over-limit episode pings the user with how long
+    the counted window was and when they can try again; the throttle keeps
+    every later rejection silent until the limit frees. Fail-soft: any Redis
+    trouble reads as "under limit".
+    """
+    redis = _chat_limit_redis(bot)
+    if redis is None:
+        return False
+    user_id = str(event.message.author.id)
+    try:
+        status = await over_limit_status(redis, user_id)
+    except RedisError:
+        logger.warning(
+            "Failed to check message limit for user %s — allowing message",
+            user_id,
+            exc_info=True,
+        )
+        return False
+    if status is None:
+        return False
+
+    try:
+        first_rejection_of_episode = await claim_notice_throttle(
+            redis, user_id, status.retry_epoch
+        )
+    except RedisError:
+        logger.warning(
+            "Failed to claim limit-notice throttle for user %s",
+            user_id,
+            exc_info=True,
+        )
+        first_rejection_of_episode = False
+    if first_rejection_of_episode:
+        notice = format_over_limit_notice(
+            user_id, status, datetime.now(UTC).timestamp()
+        )
+        try:
+            await bot.rest.create_message(
+                event.channel_id,
+                notice,
+                reply=event.message,
+                user_mentions=[event.message.author.id],
+            )
+        except Exception:
+            logger.exception("Failed to send message-limit notice")
+    return True
+
+
+async def _record_engaged_message(bot: Any, event: hikari.MessageCreateEvent) -> None:
+    """Count an @mention/reply engagement against its author's rolling limit.
+
+    Engagements are charged here — before the agent runs — so they count even
+    when the run later fails; the agent's rankings re-record the same message
+    id post-run, which the sorted set dedupes. Best-effort: Redis trouble
+    skips the charge rather than blocking the engagement.
+    """
+    redis = _chat_limit_redis(bot)
+    if redis is None:
+        return
+    try:
+        await record_directed_messages(
+            redis,
+            str(event.message.author.id),
+            {str(event.message.id): event.message.created_at.timestamp()},
+        )
+    except RedisError:
+        logger.warning(
+            "Failed to record message-limit charge for user %s",
+            event.message.author.id,
+            exc_info=True,
+        )
 
 
 def _bot_was_engaged(event: hikari.MessageCreateEvent, bot_user_id: int) -> bool:
@@ -134,6 +230,16 @@ async def on_message_create(event: hikari.MessageCreateEvent) -> None:
                 logger.exception("Failed to send rate-limit message")
             return
 
+        if await _reject_when_over_limit(plugin.bot, event):
+            logger.info(
+                "User %s over the rolling message limit — dropping engagement "
+                "in channel %s",
+                event.message.author.id,
+                event.channel_id,
+            )
+            return
+        await _record_engaged_message(plugin.bot, event)
+
         # Distinguish "engine doesn't exist yet" (first activation in this
         # engagement) from "engine is already running and the user is
         # @mentioning again" — the two need different plumbing.
@@ -161,6 +267,12 @@ async def on_message_create(event: hikari.MessageCreateEvent) -> None:
     # idle-message counter so memory can detect staleness on the next activation.
     engine = await registry.get(event.channel_id)
     if engine is not None and engine.active:
+        # An over-limit user's in-session follow-ups are dropped before the
+        # agent sees them — otherwise one mention would buy unlimited answers
+        # for the rest of the engagement. Only users who recently conversed
+        # with the bot can be over the limit, so bystanders are never blocked.
+        if await _reject_when_over_limit(plugin.bot, event):
+            return
         await engine.observe(event)
         return
 

--- a/smarter_dev/bot/services/channel_token_budget.py
+++ b/smarter_dev/bot/services/channel_token_budget.py
@@ -79,6 +79,21 @@ async def over_budget_reset_epoch(
     return latest_reset_epoch
 
 
+async def current_window_usage(redis: Redis, channel_id: str) -> tuple[int, int]:
+    """Tokens ``channel_id`` has consumed in the current (hour, day) windows.
+
+    Reads the live counters without mutating them — backs the ``/bot-usage``
+    display. Windows with no writes yet read as 0.
+    """
+    now_epoch = datetime.now(UTC).timestamp()
+    usage = []
+    for scope, window_seconds in _WINDOWS:
+        key = budget_key(channel_id, scope, _window_index(now_epoch, window_seconds))
+        usage.append(await _consumed(redis, key))
+    hour_used, day_used = usage
+    return hour_used, day_used
+
+
 async def add_usage(redis: Redis, channel_id: str, tokens: int) -> None:
     """Add ``tokens`` to ``channel_id``'s current hour and day windows.
 

--- a/smarter_dev/bot/services/channel_token_budget.py
+++ b/smarter_dev/bot/services/channel_token_budget.py
@@ -1,9 +1,11 @@
-"""Per-channel LLM token budgets, backed by Redis fixed-window counters.
+"""Per-channel LLM token usage windows and budgets, backed by Redis counters.
 
-An admin can cap how many chat tokens a channel spends per hour and per day
-(see the ``/setmodel`` override). Enforcement runs bot-side inside
-:mod:`chat_engine`, so this module talks to the bot's Redis directly rather than
-round-tripping the web API every turn.
+Every channel's chat-token spend is metered into hour and day windows (threads
+count as their own channels). An admin can additionally cap the spend per hour
+and per day via the ``/setmodel`` override — only channels with an override
+have budgets enforced. Enforcement runs bot-side inside :mod:`chat_engine`, so
+this module talks to the bot's Redis directly rather than round-tripping the
+web API every turn.
 
 Same shape as :mod:`smarter_dev.web.image_quota`: an ``INCRBY`` per turn with
 ``EXPIRE ... NX`` so the first hit of a window fixes its expiry and later hits
@@ -33,6 +35,11 @@ def _window_index(now_epoch: float, window_seconds: int) -> int:
 def budget_key(channel_id: str, scope: str, window_index: int) -> str:
     """Redis key for one channel's ``scope`` ("hour"/"day") window."""
     return f"modelbudget:{channel_id}:{scope}:{window_index}"
+
+
+def next_window_reset_epoch(now_epoch: float, window_seconds: int) -> int:
+    """Epoch second the current wall-aligned ``window_seconds`` window rolls over."""
+    return (_window_index(now_epoch, window_seconds) + 1) * window_seconds
 
 
 # Ordered (scope, window length) pairs — the two windows every channel tracks.
@@ -73,7 +80,7 @@ async def over_budget_reset_epoch(
         window_index = _window_index(now_epoch, window_seconds)
         key = budget_key(channel_id, scope, window_index)
         if await _consumed(redis, key) >= budget:
-            window_reset_epoch = (window_index + 1) * window_seconds
+            window_reset_epoch = next_window_reset_epoch(now_epoch, window_seconds)
             if latest_reset_epoch is None or window_reset_epoch > latest_reset_epoch:
                 latest_reset_epoch = window_reset_epoch
     return latest_reset_epoch

--- a/smarter_dev/bot/services/chat_engine.py
+++ b/smarter_dev/bot/services/chat_engine.py
@@ -443,9 +443,10 @@ class ChannelEngine:
 
             # Resolve any admin per-channel override and enforce its token
             # budget before we spend a model call. A channel with no override
-            # falls through unchanged (default model, no budget checks).
+            # falls through unchanged (default model, no budget checks) —
+            # though its token usage is still metered after the run.
             override = await self._get_channel_override()
-            budget_redis = self._budget_redis() if override is not None else None
+            budget_redis = self._budget_redis()
             if override is not None and budget_redis is not None:
                 budget_reset_epoch = await over_budget_reset_epoch(
                     budget_redis,
@@ -556,11 +557,12 @@ class ChannelEngine:
 
             output = result.output
             tokens = _extract_tokens(result.usage())
-            # Charge this turn's chat tokens against the channel's budget. Only
-            # override channels are metered (no override → no tracking overhead).
+            # Meter this turn's chat tokens against the channel's usage windows.
+            # Every channel is metered (so ``/bot-usage`` always has numbers);
+            # the budgets that *enforce* only exist on override channels.
             # Compaction runs on its own summarizer model and its tokens are not
             # in ``result.usage()``, so they are not counted here.
-            if override is not None and budget_redis is not None:
+            if budget_redis is not None:
                 await self._record_budget_usage(budget_redis, tokens)
             await self._charge_directed_messages(
                 output, drained, first_activation=first_activation

--- a/smarter_dev/bot/services/chat_engine.py
+++ b/smarter_dev/bot/services/chat_engine.py
@@ -62,6 +62,8 @@ from smarter_dev.bot.services.chat_conversation_persistence import end_engagemen
 from smarter_dev.bot.services.chat_conversation_persistence import persist_turn
 from smarter_dev.bot.services.chat_conversation_persistence import start_engagement
 from smarter_dev.bot.services.chat_memory import get_chat_memory
+from smarter_dev.bot.services.user_message_limit import DIRECTED_SCORE_THRESHOLD
+from smarter_dev.bot.services.user_message_limit import record_directed_messages
 from smarter_dev.bot.utils.stop_detection import is_stop_request
 from smarter_dev.bot.utils.stop_detection import set_channel_cooldown
 
@@ -560,6 +562,9 @@ class ChannelEngine:
             # in ``result.usage()``, so they are not counted here.
             if override is not None and budget_redis is not None:
                 await self._record_budget_usage(budget_redis, tokens)
+            await self._charge_directed_messages(
+                output, drained, first_activation=first_activation
+            )
             logger.info(
                 "[%s] Chat agent returned response=%s continue_watching=%s "
                 "max_score=%s tokens=%s",
@@ -937,6 +942,62 @@ class ChannelEngine:
                 self.channel_id,
                 exc_info=True,
             )
+
+    async def _charge_directed_messages(
+        self,
+        output: TurnDecision,
+        drained: list[hikari.Message],
+        *,
+        first_activation: bool,
+    ) -> None:
+        """Count this turn's bot-directed messages against their authors' limits.
+
+        Every ranked message scoring >= DIRECTED_SCORE_THRESHOLD was (per the
+        agent) aimed at the bot, so it costs its author one slot in the rolling
+        per-user message limit — this is what makes in-session follow-ups
+        count toward the limit, not just @mention engagements. Members are
+        message ids, so a mention already charged at the gate never
+        double-counts. Best-effort: Redis trouble must never break the turn.
+        """
+        redis = self._budget_redis()
+        if redis is None:
+            return
+        turn_messages = list(drained)
+        if first_activation and self.activation_message is not None:
+            turn_messages.append(self.activation_message)
+        author_and_epoch_by_message_id: dict[str, tuple[str, float]] = {}
+        for message in turn_messages:
+            author = getattr(message, "author", None)
+            if author is None or getattr(author, "is_bot", False):
+                continue
+            created_at = getattr(message, "created_at", None)
+            sent_epoch = (
+                created_at.timestamp()
+                if created_at is not None
+                else datetime.now(UTC).timestamp()
+            )
+            author_and_epoch_by_message_id[str(message.id)] = (
+                str(author.id),
+                sent_epoch,
+            )
+        charges_by_user: dict[str, dict[str, float]] = {}
+        for ranking in output.rankings:
+            if ranking.score < DIRECTED_SCORE_THRESHOLD:
+                continue
+            charged = author_and_epoch_by_message_id.get(ranking.message_id)
+            if charged is None:
+                continue
+            user_id, sent_epoch = charged
+            charges_by_user.setdefault(user_id, {})[ranking.message_id] = sent_epoch
+        for user_id, message_epochs in charges_by_user.items():
+            try:
+                await record_directed_messages(redis, user_id, message_epochs)
+            except RedisError:
+                logger.warning(
+                    "Failed to record message-limit charges for user %s",
+                    user_id,
+                    exc_info=True,
+                )
 
     async def _maybe_notice_budget_exhausted(
         self, redis: Any, *, reset_epoch: int, reply_to: int | None

--- a/smarter_dev/bot/services/user_message_limit.py
+++ b/smarter_dev/bot/services/user_message_limit.py
@@ -1,0 +1,156 @@
+"""Per-user rolling limit on messages directed at the chat bot.
+
+A single user gets :data:`USER_MESSAGE_LIMIT` bot-directed messages per
+rolling :data:`LIMIT_WINDOW_SECONDS`, counted across all channels. Each
+counted message is a member of a per-user Redis sorted set
+(``chatlimit:{user_id}``) whose score is the message's send epoch. Members
+are Discord message ids, so recording the same message twice — once at the
+mention gate, again from the agent's rankings — never double-counts.
+
+Unlike :mod:`channel_token_budget` (fixed wall-clock windows), this is a true
+rolling window: every check trims entries older than the window and counts
+the survivors. The user unblocks the exact second enough old messages age
+out, so the over-limit notice can embed that moment as a live Discord
+countdown tag.
+
+Enforcement lives in the mention plugin (drop + notice before the engine sees
+the message); charging happens both there (mention/reply engagements) and in
+:mod:`chat_engine` (messages the agent ranked as directed at the bot).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC
+from datetime import datetime
+
+from redis.asyncio import Redis
+
+USER_MESSAGE_LIMIT = 60
+LIMIT_WINDOW_SECONDS = 4 * 60 * 60
+
+# Mirrors the response gate in ``chat_models.TurnDecision``: a ranked message
+# scoring >= 5 was directed at the bot and is eligible for a reply, so it is
+# exactly what this limit counts.
+DIRECTED_SCORE_THRESHOLD = 5
+
+# ``> -#`` renders as quoted subtext, ``<@id>`` pings the user, and
+# ``{retry_tag}`` is a Discord relative timestamp (``<t:epoch:R>``) that the
+# client renders as a live countdown to the moment the limit frees.
+_OVER_LIMIT_NOTICE_TEMPLATE = (
+    "> -# <@{user_id}> you've sent {limit} messages to the bot in the last "
+    "{span}, you can try again {retry_tag}"
+)
+
+# Below this many minutes the notice span reads in minutes; from here up it
+# rounds to whole hours ("2 hours" beats "127 minutes").
+_SPAN_HOURS_CUTOFF_MINUTES = 120
+
+
+def limit_key(user_id: str) -> str:
+    """Redis sorted-set key holding one user's counted messages."""
+    return f"chatlimit:{user_id}"
+
+
+def notice_throttle_key(user_id: str) -> str:
+    """Redis key claiming one user's over-limit ping for the current episode."""
+    return f"chatlimit-notice:{user_id}"
+
+
+@dataclass(frozen=True)
+class OverLimitStatus:
+    """A user is at/over the limit: the counted span and when it frees."""
+
+    # Send epoch of the oldest message still counted against the limit — the
+    # start of the "you've sent N messages in the last X" span, and the entry
+    # whose ageing-out frees a slot.
+    window_started_epoch: float
+    # The exact epoch second the user drops back under the limit.
+    retry_epoch: int
+
+
+async def record_directed_messages(
+    redis: Redis, user_id: str, message_epochs: dict[str, float]
+) -> None:
+    """Count ``message_epochs`` (message id → send epoch) against ``user_id``.
+
+    ``ZADD`` treats members as a set, so re-recording a message id only
+    updates its score — never inflates the count. The key's TTL is refreshed
+    to one full window on every write since the newest entry is what keeps
+    the set relevant; an idle user's set simply expires.
+    """
+    if not message_epochs:
+        return
+    key = limit_key(user_id)
+    async with redis.pipeline(transaction=True) as pipe:
+        pipe.zadd(key, message_epochs)
+        pipe.expire(key, LIMIT_WINDOW_SECONDS)
+        await pipe.execute()
+
+
+async def over_limit_status(redis: Redis, user_id: str) -> OverLimitStatus | None:
+    """``user_id``'s over-limit details, or None while they may still send.
+
+    Trims entries that have aged out of the rolling window, then counts the
+    survivors. At or past the limit, the (count - limit)-th oldest survivor is
+    the one whose expiry drops the user back under — and equivalently the
+    oldest of the ``limit`` newest messages, i.e. the start of the span the
+    notice reports.
+    """
+    now_epoch = datetime.now(UTC).timestamp()
+    key = limit_key(user_id)
+    async with redis.pipeline(transaction=True) as pipe:
+        pipe.zremrangebyscore(key, "-inf", now_epoch - LIMIT_WINDOW_SECONDS)
+        pipe.zcard(key)
+        _, counted = await pipe.execute()
+    if counted < USER_MESSAGE_LIMIT:
+        return None
+    freeing_index = counted - USER_MESSAGE_LIMIT
+    entries = await redis.zrange(key, freeing_index, freeing_index, withscores=True)
+    if not entries:
+        return None
+    _, window_started_epoch = entries[0]
+    return OverLimitStatus(
+        window_started_epoch=float(window_started_epoch),
+        retry_epoch=int(window_started_epoch) + LIMIT_WINDOW_SECONDS,
+    )
+
+
+def format_over_limit_notice(
+    user_id: str, status: OverLimitStatus, now_epoch: float
+) -> str:
+    """The user-facing over-limit ping for ``status``.
+
+    The span since the oldest counted message reads in rounded minutes, or in
+    rounded whole hours once minute-rounding reaches two hours.
+    """
+    span_seconds = max(0.0, now_epoch - status.window_started_epoch)
+    span_minutes = max(1, round(span_seconds / 60))
+    if span_minutes >= _SPAN_HOURS_CUTOFF_MINUTES:
+        span = f"{round(span_seconds / 3600)} hours"
+    elif span_minutes == 1:
+        span = "1 minute"
+    else:
+        span = f"{span_minutes} minutes"
+    return _OVER_LIMIT_NOTICE_TEMPLATE.format(
+        user_id=user_id,
+        limit=USER_MESSAGE_LIMIT,
+        span=span,
+        retry_tag=f"<t:{status.retry_epoch}:R>",
+    )
+
+
+async def claim_notice_throttle(
+    redis: Redis, user_id: str, retry_epoch: int
+) -> bool:
+    """True exactly once per over-limit episode (``SET NX EX``).
+
+    The claim lives until ``retry_epoch`` — the user is pinged once when they
+    hit the limit and stays unpinged for the rest of that episode; re-hitting
+    the limit later starts a fresh episode with a fresh ping.
+    """
+    now_epoch = int(datetime.now(UTC).timestamp())
+    ttl_seconds = max(60, retry_epoch - now_epoch)
+    return bool(
+        await redis.set(notice_throttle_key(user_id), "1", nx=True, ex=ttl_seconds)
+    )

--- a/smarter_dev/bot/services/user_message_limit.py
+++ b/smarter_dev/bot/services/user_message_limit.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import UTC
 from datetime import datetime
+from math import ceil
 
 from redis.asyncio import Redis
 
@@ -88,6 +89,51 @@ async def record_directed_messages(
         await pipe.execute()
 
 
+async def _trimmed_count(redis: Redis, key: str, now_epoch: float) -> int:
+    """Live count for ``key``: age out old entries, then count the survivors."""
+    async with redis.pipeline(transaction=True) as pipe:
+        pipe.zremrangebyscore(key, "-inf", now_epoch - LIMIT_WINDOW_SECONDS)
+        pipe.zcard(key)
+        _, counted = await pipe.execute()
+    return counted
+
+
+async def counted_messages(redis: Redis, user_id: str) -> tuple[int, float | None]:
+    """``user_id``'s live counter: (messages in the window, oldest send epoch).
+
+    The oldest epoch is None when nothing is counted — there is no window to
+    describe. Backs the ``/bot-usage`` display.
+    """
+    now_epoch = datetime.now(UTC).timestamp()
+    key = limit_key(user_id)
+    counted = await _trimmed_count(redis, key, now_epoch)
+    if counted == 0:
+        return 0, None
+    entries = await redis.zrange(key, 0, 0, withscores=True)
+    if not entries:
+        return 0, None
+    _, oldest_epoch = entries[0]
+    return counted, float(oldest_epoch)
+
+
+def format_counted_window(oldest_epoch: float | None, now_epoch: float) -> str:
+    """Human framing of the span a message counter covers.
+
+    Reads as "the last hour" / "the last N hours", where N is the hours since
+    the oldest counted message, rounded up and capped at the window length.
+    With nothing counted there is no span to shrink to, so the full window is
+    named.
+    """
+    window_hours = LIMIT_WINDOW_SECONDS // 3600
+    if oldest_epoch is None:
+        return f"the last {window_hours} hours"
+    span_hours = ceil(max(0.0, now_epoch - oldest_epoch) / 3600)
+    span_hours = min(max(span_hours, 1), window_hours)
+    if span_hours == 1:
+        return "the last hour"
+    return f"the last {span_hours} hours"
+
+
 async def over_limit_status(redis: Redis, user_id: str) -> OverLimitStatus | None:
     """``user_id``'s over-limit details, or None while they may still send.
 
@@ -99,10 +145,7 @@ async def over_limit_status(redis: Redis, user_id: str) -> OverLimitStatus | Non
     """
     now_epoch = datetime.now(UTC).timestamp()
     key = limit_key(user_id)
-    async with redis.pipeline(transaction=True) as pipe:
-        pipe.zremrangebyscore(key, "-inf", now_epoch - LIMIT_WINDOW_SECONDS)
-        pipe.zcard(key)
-        _, counted = await pipe.execute()
+    counted = await _trimmed_count(redis, key, now_epoch)
     if counted < USER_MESSAGE_LIMIT:
         return None
     freeing_index = counted - USER_MESSAGE_LIMIT

--- a/tests/bot/services/test_channel_token_budget.py
+++ b/tests/bot/services/test_channel_token_budget.py
@@ -11,6 +11,7 @@ from smarter_dev.bot.services.channel_token_budget import (
     HOUR_WINDOW_SECONDS,
     add_usage,
     budget_key,
+    current_window_usage,
     over_budget_reset_epoch,
 )
 
@@ -158,3 +159,24 @@ async def test_channels_do_not_share_budget():
 
 def test_budget_key_shape():
     assert budget_key("42", "hour", 7) == "modelbudget:42:hour:7"
+
+
+@pytest.mark.asyncio
+async def test_current_window_usage_reads_zero_before_any_writes():
+    redis = _FakeRedis()
+    assert await current_window_usage(redis, "chan") == (0, 0)
+
+
+@pytest.mark.asyncio
+async def test_current_window_usage_reflects_recorded_tokens():
+    redis = _FakeRedis()
+    await add_usage(redis, "chan", 100)
+    await add_usage(redis, "chan", 50)
+    assert await current_window_usage(redis, "chan") == (150, 150)
+
+
+@pytest.mark.asyncio
+async def test_current_window_usage_is_per_channel():
+    redis = _FakeRedis()
+    await add_usage(redis, "chan-a", 100)
+    assert await current_window_usage(redis, "chan-b") == (0, 0)

--- a/tests/bot/services/test_channel_token_budget.py
+++ b/tests/bot/services/test_channel_token_budget.py
@@ -12,6 +12,7 @@ from smarter_dev.bot.services.channel_token_budget import (
     add_usage,
     budget_key,
     current_window_usage,
+    next_window_reset_epoch,
     over_budget_reset_epoch,
 )
 
@@ -180,3 +181,11 @@ async def test_current_window_usage_is_per_channel():
     redis = _FakeRedis()
     await add_usage(redis, "chan-a", 100)
     assert await current_window_usage(redis, "chan-b") == (0, 0)
+
+
+def test_next_window_reset_epoch_is_the_next_wall_boundary():
+    now = time.time()
+    for window_seconds in (HOUR_WINDOW_SECONDS, DAY_WINDOW_SECONDS):
+        _assert_is_next_boundary(
+            next_window_reset_epoch(now, window_seconds), window_seconds
+        )

--- a/tests/bot/services/test_chat_engine_message_limit.py
+++ b/tests/bot/services/test_chat_engine_message_limit.py
@@ -1,0 +1,236 @@
+"""Tests for the engine charging bot-directed messages to the per-user limit.
+
+The agent run, memory, and input builders are patched — these verify the
+wiring: after a turn, every ranked message scoring at or above the directed
+threshold is recorded against its author's rolling message limit, and
+nothing else is.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from redis.exceptions import RedisError
+
+from smarter_dev.bot.agents.chat_models import (
+    Author,
+    ChannelInfo,
+    InitialAgentInput,
+    Me,
+    Message,
+    MessageScore,
+    ResponseBody,
+    TurnDecision,
+)
+from smarter_dev.bot.services.chat_engine import ChannelEngine, _QueuedMessage
+
+
+def _initial_input() -> InitialAgentInput:
+    return InitialAgentInput(
+        me=Me(user_id="999", username="bot"),
+        channel_history=[],
+        activation_message=Message(
+            message_id="101",
+            author_id="200",
+            body="@bot hi",
+            mentions_bot=True,
+        ),
+        authors=[Author(user_id="200", username="alice")],
+        channel=ChannelInfo(channel_id="1", name="general"),
+        now_utc=datetime.now(UTC),
+    )
+
+
+def _decision(rankings: list[tuple[str, int]]) -> TurnDecision:
+    target_id = next(mid for mid, score in rankings if score >= 5)
+    return TurnDecision(
+        rankings=[
+            MessageScore(message_id=mid, score=score, reasoning="structural")
+            for mid, score in rankings
+        ],
+        response=ResponseBody(
+            target_message_id=target_id,
+            reply_directly=False,
+            message="hi there",
+        ),
+        topic="t",
+        notes="n",
+        continue_watching=True,
+    )
+
+
+def _result(output):
+    usage = SimpleNamespace(
+        input_tokens=0, output_tokens=0, requests=1, model="test-model"
+    )
+    return SimpleNamespace(
+        output=output,
+        usage=lambda: usage,
+        all_messages=lambda: [],
+        new_messages=lambda: [],
+    )
+
+
+def _discord_message(message_id: int, author_id: int, *, is_bot: bool = False):
+    return SimpleNamespace(
+        id=message_id,
+        author=SimpleNamespace(id=author_id, username=f"user-{author_id}", is_bot=is_bot),
+        created_at=datetime.now(UTC),
+    )
+
+
+def _make_engine(fake_redis) -> ChannelEngine:
+    bot = MagicMock()
+    bot.rest = MagicMock()
+    bot.rest.create_message = AsyncMock()
+    service = MagicMock()
+    service.get_override = AsyncMock(return_value=None)
+    bot.d = {
+        "model_override_service": service,
+        "chat_memory_redis": fake_redis,
+    }
+
+    async def _on_deactivate(channel_id: int) -> None:
+        pass
+
+    async def _noop_voice(channel_id, text, reply_to, instruction=None):
+        pass
+
+    engine = ChannelEngine(
+        bot=bot,
+        channel_id=42,
+        guild_id=99,
+        voice_send=_noop_voice,
+        on_deactivate=_on_deactivate,
+    )
+    engine.activation_message = _discord_message(101, 200)
+    return engine
+
+
+def _fake_memory():
+    m = MagicMock()
+    m.reset_idle_counter = AsyncMock()
+    m.write_topic = AsyncMock()
+    m.write_notes = AsyncMock()
+    m.clear_notes = AsyncMock()
+    m.read_history = AsyncMock(return_value=[])
+    m.write_history = AsyncMock()
+    m.clear_history = AsyncMock()
+    return m
+
+
+def _run_patches(decision: TurnDecision, record_mock: AsyncMock):
+    agent_mock = MagicMock()
+    agent_mock.run = AsyncMock(return_value=_result(decision))
+    return [
+        patch(
+            "smarter_dev.bot.services.chat_engine.get_chat_agent",
+            return_value=agent_mock,
+        ),
+        patch(
+            "smarter_dev.bot.services.chat_engine.get_chat_memory",
+            return_value=_fake_memory(),
+        ),
+        patch(
+            "smarter_dev.bot.services.chat_engine.build_initial_input",
+            new=AsyncMock(return_value=_initial_input()),
+        ),
+        patch(
+            "smarter_dev.bot.services.chat_engine.record_directed_messages",
+            new=record_mock,
+        ),
+    ]
+
+
+async def _run(engine: ChannelEngine, decision: TurnDecision, record_mock: AsyncMock):
+    patches = _run_patches(decision, record_mock)
+    with patches[0], patches[1], patches[2], patches[3]:
+        await engine._run_once(first_activation=True)
+
+
+@pytest.mark.asyncio
+async def test_directed_messages_are_charged_per_author():
+    """Rankings at/above the threshold charge their authors; below stays free."""
+    fake_redis = MagicMock()
+    engine = _make_engine(fake_redis)
+    # Two queued follow-ups from different users alongside the activation.
+    engine.queue = [
+        _QueuedMessage(message=_discord_message(102, 300), enqueued_at=datetime.now(UTC)),
+        _QueuedMessage(message=_discord_message(103, 301), enqueued_at=datetime.now(UTC)),
+    ]
+    record_mock = AsyncMock()
+
+    await _run(
+        engine,
+        _decision([("101", 10), ("102", 4), ("103", 7)]),
+        record_mock,
+    )
+
+    charges = {
+        call.args[1]: call.args[2] for call in record_mock.await_args_list
+    }
+    assert set(charges) == {"200", "301"}
+    assert list(charges["200"]) == ["101"]
+    assert list(charges["301"]) == ["103"]
+    for message_epochs in charges.values():
+        for epoch in message_epochs.values():
+            assert epoch == pytest.approx(datetime.now(UTC).timestamp(), abs=5)
+
+
+@pytest.mark.asyncio
+async def test_rankings_for_unknown_messages_are_skipped():
+    """A ranked id outside this turn's messages (e.g. pre-engagement history)
+    charges nobody."""
+    fake_redis = MagicMock()
+    engine = _make_engine(fake_redis)
+    record_mock = AsyncMock()
+
+    await _run(engine, _decision([("101", 10), ("777", 9)]), record_mock)
+
+    record_mock.assert_awaited_once()
+    assert record_mock.await_args.args[1] == "200"
+    assert list(record_mock.await_args.args[2]) == ["101"]
+
+
+@pytest.mark.asyncio
+async def test_bot_authored_messages_are_never_charged():
+    fake_redis = MagicMock()
+    engine = _make_engine(fake_redis)
+    engine.queue = [
+        _QueuedMessage(
+            message=_discord_message(102, 999, is_bot=True),
+            enqueued_at=datetime.now(UTC),
+        ),
+    ]
+    record_mock = AsyncMock()
+
+    await _run(engine, _decision([("101", 10), ("102", 8)]), record_mock)
+
+    charged_users = {call.args[1] for call in record_mock.await_args_list}
+    assert charged_users == {"200"}
+
+
+@pytest.mark.asyncio
+async def test_no_redis_skips_charging():
+    engine = _make_engine(None)
+    engine.bot.d = {"model_override_service": engine.bot.d["model_override_service"]}
+    record_mock = AsyncMock()
+
+    await _run(engine, _decision([("101", 10)]), record_mock)
+
+    record_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_redis_error_never_breaks_the_turn():
+    fake_redis = MagicMock()
+    engine = _make_engine(fake_redis)
+    record_mock = AsyncMock(side_effect=RedisError("down"))
+
+    await _run(engine, _decision([("101", 10)]), record_mock)
+
+    # The response still went out despite the failed charge.
+    engine.bot.rest.create_message.assert_awaited()

--- a/tests/bot/services/test_chat_engine_override.py
+++ b/tests/bot/services/test_chat_engine_override.py
@@ -263,10 +263,15 @@ async def test_under_budget_runs_and_meters_usage(fake_memory, fake_redis):
 
 
 @pytest.mark.asyncio
-async def test_no_override_uses_default_and_skips_budget(fake_memory, fake_redis):
-    """No override → default agent, no budget check, no usage metering."""
+async def test_no_override_uses_default_and_skips_enforcement_but_meters(
+    fake_memory, fake_redis
+):
+    """No override → default agent and no budget *enforcement*, but the turn's
+    token usage is still metered so ``/bot-usage`` has numbers everywhere."""
     agent_mock = MagicMock()
-    agent_mock.run = AsyncMock(return_value=_result(_send()))
+    agent_mock.run = AsyncMock(
+        return_value=_result(_send(), input_tokens=100, output_tokens=50)
+    )
     engine, service = _make_engine(None, fake_redis)
 
     get_agent = patch(
@@ -285,7 +290,7 @@ async def test_no_override_uses_default_and_skips_budget(fake_memory, fake_redis
 
     get_agent_mock.assert_called_once_with(None, None)
     over_budget_mock.assert_not_called()
-    add_usage_mock.assert_not_called()
+    add_usage_mock.assert_awaited_once_with(fake_redis, "42", 150)
 
 
 @pytest.mark.asyncio

--- a/tests/bot/services/test_chat_engine_override.py
+++ b/tests/bot/services/test_chat_engine_override.py
@@ -102,6 +102,13 @@ def fake_memory():
 def fake_redis():
     r = MagicMock()
     r.set = AsyncMock(return_value=True)
+    # The engine also records per-user message-limit charges through a
+    # pipeline on this same Redis — make that path awaitable and inert.
+    pipe = MagicMock()
+    pipe.execute = AsyncMock(return_value=[0, True])
+    pipe.__aenter__ = AsyncMock(return_value=pipe)
+    pipe.__aexit__ = AsyncMock(return_value=False)
+    r.pipeline = MagicMock(return_value=pipe)
     return r
 
 

--- a/tests/bot/services/test_user_message_limit.py
+++ b/tests/bot/services/test_user_message_limit.py
@@ -1,0 +1,252 @@
+"""Tests for the per-user rolling chat message limit (Redis sorted set)."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from smarter_dev.bot.services.user_message_limit import (
+    LIMIT_WINDOW_SECONDS,
+    USER_MESSAGE_LIMIT,
+    claim_notice_throttle,
+    format_over_limit_notice,
+    limit_key,
+    notice_throttle_key,
+    over_limit_status,
+    record_directed_messages,
+)
+
+
+class _FakePipeline:
+    """Mimics redis.asyncio pipeline: queued sync ops, awaited execute()."""
+
+    def __init__(self, redis: "_FakeRedis"):
+        self._redis = redis
+        self._ops: list[tuple] = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    def zadd(self, key, mapping):
+        self._ops.append(("zadd", key, dict(mapping)))
+        return self
+
+    def expire(self, key, seconds):
+        self._ops.append(("expire", key, seconds))
+        return self
+
+    def zremrangebyscore(self, key, low, high):
+        self._ops.append(("zremrangebyscore", key, low, high))
+        return self
+
+    def zcard(self, key):
+        self._ops.append(("zcard", key))
+        return self
+
+    async def execute(self):
+        results = [self._redis.apply(op) for op in self._ops]
+        self._ops.clear()
+        return results
+
+
+class _FakeRedis:
+    def __init__(self):
+        self.zsets: dict[str, dict[str, float]] = {}
+        self.strings: dict[str, str] = {}
+        self.expiries: dict[str, int] = {}
+
+    def pipeline(self, transaction=True):
+        return _FakePipeline(self)
+
+    def apply(self, op: tuple):
+        kind = op[0]
+        if kind == "zadd":
+            _, key, mapping = op
+            members = self.zsets.setdefault(key, {})
+            added = sum(1 for member in mapping if member not in members)
+            members.update(mapping)
+            return added
+        if kind == "expire":
+            self.expiries[op[1]] = op[2]
+            return True
+        if kind == "zremrangebyscore":
+            _, key, low, high = op
+            members = self.zsets.get(key, {})
+            low_score = float("-inf") if low == "-inf" else float(low)
+            removed = [m for m, s in members.items() if low_score <= s <= float(high)]
+            for member in removed:
+                del members[member]
+            return len(removed)
+        if kind == "zcard":
+            return len(self.zsets.get(op[1], {}))
+        raise AssertionError(f"unexpected op {op}")
+
+    async def zrange(self, key, start, stop, withscores=False):
+        by_score = sorted(self.zsets.get(key, {}).items(), key=lambda kv: (kv[1], kv[0]))
+        end = None if stop == -1 else stop + 1
+        window = by_score[start:end]
+        if withscores:
+            return [(member, score) for member, score in window]
+        return [member for member, _ in window]
+
+    async def set(self, key, value, nx=False, ex=None):
+        if nx and key in self.strings:
+            return None
+        self.strings[key] = value
+        if ex is not None:
+            self.expiries[key] = ex
+        return True
+
+
+async def _seed_messages(redis, user_id: str, epochs: list[float]) -> None:
+    await record_directed_messages(
+        redis, user_id, {f"msg-{i}": epoch for i, epoch in enumerate(epochs)}
+    )
+
+
+@pytest.mark.asyncio
+async def test_record_adds_members_and_refreshes_window_ttl():
+    redis = _FakeRedis()
+    now = time.time()
+    await record_directed_messages(redis, "u1", {"1": now, "2": now})
+
+    key = limit_key("u1")
+    assert set(redis.zsets[key]) == {"1", "2"}
+    assert redis.expiries[key] == LIMIT_WINDOW_SECONDS
+
+
+@pytest.mark.asyncio
+async def test_record_same_message_id_never_double_counts():
+    redis = _FakeRedis()
+    now = time.time()
+    await record_directed_messages(redis, "u1", {"1": now})
+    await record_directed_messages(redis, "u1", {"1": now})
+    assert len(redis.zsets[limit_key("u1")]) == 1
+
+
+@pytest.mark.asyncio
+async def test_record_empty_mapping_is_noop():
+    redis = _FakeRedis()
+    await record_directed_messages(redis, "u1", {})
+    assert redis.zsets == {}
+
+
+@pytest.mark.asyncio
+async def test_under_limit_returns_none():
+    redis = _FakeRedis()
+    now = time.time()
+    await _seed_messages(redis, "u1", [now - i for i in range(USER_MESSAGE_LIMIT - 1)])
+    assert await over_limit_status(redis, "u1") is None
+
+
+@pytest.mark.asyncio
+async def test_at_limit_reports_oldest_message_and_retry_epoch():
+    redis = _FakeRedis()
+    now = time.time()
+    oldest_epoch = now - 600
+    epochs = [oldest_epoch + i for i in range(USER_MESSAGE_LIMIT)]
+    await _seed_messages(redis, "u1", epochs)
+
+    status = await over_limit_status(redis, "u1")
+    assert status is not None
+    assert status.window_started_epoch == pytest.approx(oldest_epoch)
+    assert status.retry_epoch == int(oldest_epoch) + LIMIT_WINDOW_SECONDS
+
+
+@pytest.mark.asyncio
+async def test_messages_older_than_the_window_age_out():
+    redis = _FakeRedis()
+    now = time.time()
+    stale = [now - LIMIT_WINDOW_SECONDS - 10 - i for i in range(USER_MESSAGE_LIMIT)]
+    await _seed_messages(redis, "u1", stale)
+
+    assert await over_limit_status(redis, "u1") is None
+    # The stale entries were trimmed, not just ignored.
+    assert redis.zsets[limit_key("u1")] == {}
+
+
+@pytest.mark.asyncio
+async def test_over_limit_frees_when_enough_messages_age_out():
+    """With 3 extra messages, the user unblocks when the 4th-oldest expires —
+    that entry is also the oldest of the LIMIT newest (the reported span)."""
+    redis = _FakeRedis()
+    now = time.time()
+    epochs = [now - 1000 + i for i in range(USER_MESSAGE_LIMIT + 3)]
+    await _seed_messages(redis, "u1", epochs)
+
+    status = await over_limit_status(redis, "u1")
+    assert status is not None
+    assert status.window_started_epoch == pytest.approx(epochs[3])
+    assert status.retry_epoch == int(epochs[3]) + LIMIT_WINDOW_SECONDS
+
+
+@pytest.mark.asyncio
+async def test_limits_are_per_user():
+    redis = _FakeRedis()
+    now = time.time()
+    await _seed_messages(redis, "u1", [now - i for i in range(USER_MESSAGE_LIMIT)])
+    assert await over_limit_status(redis, "u1") is not None
+    assert await over_limit_status(redis, "u2") is None
+
+
+def _status(window_started_epoch: float, retry_epoch: int = 1_800_000_000):
+    from smarter_dev.bot.services.user_message_limit import OverLimitStatus
+
+    return OverLimitStatus(
+        window_started_epoch=window_started_epoch, retry_epoch=retry_epoch
+    )
+
+
+def test_notice_spans_under_two_hours_read_in_minutes():
+    now = 1_700_000_000.0
+    notice = format_over_limit_notice("42", _status(now - 30 * 60), now)
+    assert notice.startswith("> -# <@42> ")
+    assert f"you've sent {USER_MESSAGE_LIMIT} messages to the bot" in notice
+    assert "in the last 30 minutes" in notice
+    assert "you can try again <t:1800000000:R>" in notice
+
+
+def test_notice_span_never_reads_below_one_minute():
+    now = 1_700_000_000.0
+    notice = format_over_limit_notice("42", _status(now - 5), now)
+    assert "in the last 1 minute," in notice
+
+
+def test_notice_span_just_under_the_hours_cutoff_stays_in_minutes():
+    now = 1_700_000_000.0
+    notice = format_over_limit_notice("42", _status(now - 119 * 60), now)
+    assert "in the last 119 minutes" in notice
+
+
+def test_notice_spans_of_two_plus_hours_read_in_hours():
+    now = 1_700_000_000.0
+    notice = format_over_limit_notice("42", _status(now - 2 * 60 * 60), now)
+    assert "in the last 2 hours" in notice
+
+
+def test_notice_hours_are_rounded():
+    now = 1_700_000_000.0
+    # 3h50m rounds to 4 hours.
+    notice = format_over_limit_notice("42", _status(now - (3 * 60 + 50) * 60), now)
+    assert "in the last 4 hours" in notice
+
+
+@pytest.mark.asyncio
+async def test_notice_throttle_claims_once_per_episode():
+    redis = _FakeRedis()
+    retry_epoch = int(time.time()) + 900
+    assert await claim_notice_throttle(redis, "u1", retry_epoch) is True
+    assert await claim_notice_throttle(redis, "u1", retry_epoch) is False
+    # The claim lives exactly until the limit frees.
+    assert redis.expiries[notice_throttle_key("u1")] == pytest.approx(900, abs=2)
+
+
+@pytest.mark.asyncio
+async def test_notice_throttle_ttl_never_drops_below_a_minute():
+    redis = _FakeRedis()
+    assert await claim_notice_throttle(redis, "u1", int(time.time()) - 50) is True
+    assert redis.expiries[notice_throttle_key("u1")] == 60

--- a/tests/bot/services/test_user_message_limit.py
+++ b/tests/bot/services/test_user_message_limit.py
@@ -10,6 +10,8 @@ from smarter_dev.bot.services.user_message_limit import (
     LIMIT_WINDOW_SECONDS,
     USER_MESSAGE_LIMIT,
     claim_notice_throttle,
+    counted_messages,
+    format_counted_window,
     format_over_limit_notice,
     limit_key,
     notice_throttle_key,
@@ -250,3 +252,59 @@ async def test_notice_throttle_ttl_never_drops_below_a_minute():
     redis = _FakeRedis()
     assert await claim_notice_throttle(redis, "u1", int(time.time()) - 50) is True
     assert redis.expiries[notice_throttle_key("u1")] == 60
+
+
+@pytest.mark.asyncio
+async def test_counted_messages_empty_counter_has_no_window():
+    redis = _FakeRedis()
+    assert await counted_messages(redis, "u1") == (0, None)
+
+
+@pytest.mark.asyncio
+async def test_counted_messages_reports_count_and_oldest():
+    redis = _FakeRedis()
+    now = time.time()
+    oldest_epoch = now - 900
+    await _seed_messages(redis, "u1", [oldest_epoch, now - 300, now - 30])
+
+    counted, window_started = await counted_messages(redis, "u1")
+    assert counted == 3
+    assert window_started == pytest.approx(oldest_epoch)
+
+
+@pytest.mark.asyncio
+async def test_counted_messages_trims_aged_out_entries():
+    redis = _FakeRedis()
+    now = time.time()
+    await _seed_messages(
+        redis, "u1", [now - LIMIT_WINDOW_SECONDS - 10, now - 60]
+    )
+
+    counted, window_started = await counted_messages(redis, "u1")
+    assert counted == 1
+    assert window_started == pytest.approx(now - 60)
+
+
+def test_counted_window_with_no_messages_names_the_full_window():
+    assert format_counted_window(None, 1_700_000_000.0) == "the last 4 hours"
+
+
+def test_counted_window_under_an_hour_reads_singular():
+    now = 1_700_000_000.0
+    assert format_counted_window(now - 30 * 60, now) == "the last hour"
+
+
+def test_counted_window_rounds_hours_up():
+    now = 1_700_000_000.0
+    assert format_counted_window(now - 61 * 60, now) == "the last 2 hours"
+    assert format_counted_window(now - 150 * 60, now) == "the last 3 hours"
+
+
+def test_counted_window_is_capped_at_the_window_length():
+    now = 1_700_000_000.0
+    assert format_counted_window(now - LIMIT_WINDOW_SECONDS, now) == "the last 4 hours"
+    # Defensive: an epoch slightly past the window still caps at 4.
+    assert (
+        format_counted_window(now - LIMIT_WINDOW_SECONDS - 90, now)
+        == "the last 4 hours"
+    )

--- a/tests/bot/test_bot_usage.py
+++ b/tests/bot/test_bot_usage.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import re
+import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
@@ -13,6 +15,7 @@ import pytest
 from redis.exceptions import RedisError
 
 from smarter_dev.bot.plugins import bot_usage as bot_usage_plugin
+from smarter_dev.bot.services.channel_token_budget import HOUR_WINDOW_SECONDS
 from smarter_dev.bot.plugins.bot_usage import build_usage_report
 from smarter_dev.bot.plugins.bot_usage import format_compact_tokens
 from smarter_dev.bot.services.exceptions import APIError
@@ -85,8 +88,6 @@ def test_format_compact_tokens(count, rendered):
 
 @pytest.mark.asyncio
 async def test_report_shows_counter_over_its_actual_span():
-    import time
-
     bot = _bot(redis=MagicMock(), override=_override(daily=1_000_000, hourly=100_000))
     counters = _patch_counters(
         counted=(32, time.time() - 30 * 60), window_usage=(76_000, 512_000)
@@ -111,16 +112,34 @@ async def test_report_zero_budget_reads_unlimited():
 
 
 @pytest.mark.asyncio
-async def test_report_without_override_says_not_metered():
+async def test_report_without_override_shows_usage_over_unlimited():
     bot = _bot(redis=MagicMock(), override=None)
-    counters = _patch_counters()
+    counters = _patch_counters(window_usage=(76_000, 512_000))
     with counters[0], counters[1]:
         report = await build_usage_report(bot, "200", "G", "C")
 
-    assert "not metered — this channel has no token budget" in report
+    assert "**Bot usage here:** 76k/unlimited this hour · 512k/unlimited today" in report
     # The personal counter still renders.
     assert f"**Your messages:** 0/{USER_MESSAGE_LIMIT}" in report
     assert "in the last 4 hours" in report
+
+
+@pytest.mark.asyncio
+async def test_report_maxed_budget_window_shows_its_reset_countdown():
+    bot = _bot(redis=MagicMock(), override=_override(daily=1_000_000, hourly=100_000))
+    counters = _patch_counters(window_usage=(100_000, 512_000))
+    with counters[0], counters[1]:
+        report = await build_usage_report(bot, "200", "G", "C")
+
+    match = re.search(r"100k/100k this hour \(resets <t:(\d+):R>\)", report)
+    assert match, report
+    reset_epoch = int(match.group(1))
+    # The countdown targets the next wall-clock hour boundary.
+    assert reset_epoch % HOUR_WINDOW_SECONDS == 0
+    assert time.time() < reset_epoch <= time.time() + HOUR_WINDOW_SECONDS
+    # The unmaxed day window carries no countdown.
+    assert "512k/1m today" in report
+    assert report.count("resets") == 1
 
 
 @pytest.mark.asyncio

--- a/tests/bot/test_bot_usage.py
+++ b/tests/bot/test_bot_usage.py
@@ -1,0 +1,182 @@
+"""Tests for the ``/bot-usage`` slash command."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import Mock
+from unittest.mock import patch
+
+import hikari
+import pytest
+from redis.exceptions import RedisError
+
+from smarter_dev.bot.plugins import bot_usage as bot_usage_plugin
+from smarter_dev.bot.plugins.bot_usage import build_usage_report
+from smarter_dev.bot.plugins.bot_usage import format_compact_tokens
+from smarter_dev.bot.services.exceptions import APIError
+from smarter_dev.bot.services.user_message_limit import USER_MESSAGE_LIMIT
+
+
+def _override(daily: int = 0, hourly: int = 0):
+    return SimpleNamespace(
+        model_key="gpt-5-4",
+        daily_token_budget=daily,
+        hourly_token_budget=hourly,
+        reasoning_level=None,
+    )
+
+
+def _bot(redis=None, override=None, override_error=None):
+    service = MagicMock()
+    if override_error is not None:
+        service.get_override = AsyncMock(side_effect=override_error)
+    else:
+        service.get_override = AsyncMock(return_value=override)
+    return SimpleNamespace(
+        d={
+            "chat_memory_redis": redis,
+            "model_override_service": service,
+        }
+    )
+
+
+def _patch_counters(counted=(0, None), window_usage=(0, 0)):
+    return (
+        patch(
+            "smarter_dev.bot.plugins.bot_usage.counted_messages",
+            new=AsyncMock(return_value=counted),
+        ),
+        patch(
+            "smarter_dev.bot.plugins.bot_usage.current_window_usage",
+            new=AsyncMock(return_value=window_usage),
+        ),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Compact token rendering
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("count", "rendered"),
+    [
+        (0, "0"),
+        (950, "950"),
+        (1_000, "1k"),
+        (76_000, "76k"),
+        (76_500, "76.5k"),
+        (100_000, "100k"),
+        (512_000, "512k"),
+        (1_000_000, "1m"),
+        (1_500_000, "1.5m"),
+    ],
+)
+def test_format_compact_tokens(count, rendered):
+    assert format_compact_tokens(count) == rendered
+
+
+# --------------------------------------------------------------------------- #
+# Report body
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_report_shows_counter_over_its_actual_span():
+    import time
+
+    bot = _bot(redis=MagicMock(), override=_override(daily=1_000_000, hourly=100_000))
+    counters = _patch_counters(
+        counted=(32, time.time() - 30 * 60), window_usage=(76_000, 512_000)
+    )
+    with counters[0], counters[1]:
+        report = await build_usage_report(bot, "200", "G", "C")
+
+    assert (
+        f"**Your messages:** 32/{USER_MESSAGE_LIMIT} in the last hour" in report
+    )
+    assert "**Bot usage here:** 76k/100k this hour · 512k/1m today" in report
+
+
+@pytest.mark.asyncio
+async def test_report_zero_budget_reads_unlimited():
+    bot = _bot(redis=MagicMock(), override=_override(daily=0, hourly=100_000))
+    counters = _patch_counters(window_usage=(500, 500))
+    with counters[0], counters[1]:
+        report = await build_usage_report(bot, "200", "G", "C")
+
+    assert "500/100k this hour · 500/unlimited today" in report
+
+
+@pytest.mark.asyncio
+async def test_report_without_override_says_not_metered():
+    bot = _bot(redis=MagicMock(), override=None)
+    counters = _patch_counters()
+    with counters[0], counters[1]:
+        report = await build_usage_report(bot, "200", "G", "C")
+
+    assert "not metered — this channel has no token budget" in report
+    # The personal counter still renders.
+    assert f"**Your messages:** 0/{USER_MESSAGE_LIMIT}" in report
+    assert "in the last 4 hours" in report
+
+
+@pytest.mark.asyncio
+async def test_report_degrades_when_redis_is_missing():
+    bot = _bot(redis=None, override=_override(hourly=100))
+    report = await build_usage_report(bot, "200", "G", "C")
+
+    assert "**Your messages:** unavailable right now" in report
+    assert "**Bot usage here:** unavailable right now" in report
+
+
+@pytest.mark.asyncio
+async def test_report_degrades_on_redis_errors():
+    bot = _bot(redis=MagicMock(), override=_override(hourly=100))
+    with patch(
+        "smarter_dev.bot.plugins.bot_usage.counted_messages",
+        new=AsyncMock(side_effect=RedisError("down")),
+    ), patch(
+        "smarter_dev.bot.plugins.bot_usage.current_window_usage",
+        new=AsyncMock(side_effect=RedisError("down")),
+    ):
+        report = await build_usage_report(bot, "200", "G", "C")
+
+    assert "**Your messages:** unavailable right now" in report
+    assert "**Bot usage here:** unavailable right now" in report
+
+
+@pytest.mark.asyncio
+async def test_report_degrades_on_override_api_error():
+    bot = _bot(redis=MagicMock(), override_error=APIError("api down"))
+    counters = _patch_counters(counted=(5, None))
+    with counters[0], counters[1]:
+        report = await build_usage_report(bot, "200", "G", "C")
+
+    assert "**Bot usage here:** unavailable right now" in report
+
+
+# --------------------------------------------------------------------------- #
+# Slash command
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_command_responds_ephemerally_with_the_report():
+    ctx = Mock()
+    ctx.author = SimpleNamespace(id=200)
+    ctx.guild_id = "G"
+    ctx.channel_id = "C"
+    ctx.bot = _bot(redis=MagicMock(), override=None)
+    ctx.respond = AsyncMock()
+
+    counters = _patch_counters(counted=(2, None))
+    with counters[0], counters[1]:
+        await bot_usage_plugin.bot_usage(ctx)
+
+    ctx.respond.assert_awaited_once()
+    args, kwargs = ctx.respond.await_args
+    assert f"2/{USER_MESSAGE_LIMIT}" in args[0]
+    assert kwargs["flags"] == hikari.MessageFlag.EPHEMERAL

--- a/tests/bot/test_mention_message_limit.py
+++ b/tests/bot/test_mention_message_limit.py
@@ -1,0 +1,151 @@
+"""Tests for the per-user message-limit gate in the mention plugin."""
+
+from __future__ import annotations
+
+from datetime import UTC
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+from redis.exceptions import RedisError
+
+from smarter_dev.bot.plugins.mention import _record_engaged_message
+from smarter_dev.bot.plugins.mention import _reject_when_over_limit
+from smarter_dev.bot.services.user_message_limit import LIMIT_WINDOW_SECONDS
+from smarter_dev.bot.services.user_message_limit import OverLimitStatus
+from smarter_dev.bot.services.user_message_limit import USER_MESSAGE_LIMIT
+
+
+def _bot(redis) -> SimpleNamespace:
+    rest = MagicMock()
+    rest.create_message = AsyncMock()
+    return SimpleNamespace(rest=rest, d={"chat_memory_redis": redis})
+
+
+def _event(user_id: int = 200, message_id: int = 555) -> SimpleNamespace:
+    message = SimpleNamespace(
+        id=message_id,
+        author=SimpleNamespace(id=user_id, is_bot=False),
+        created_at=datetime.now(UTC),
+    )
+    return SimpleNamespace(message=message, channel_id=42)
+
+
+def _over_limit_status() -> OverLimitStatus:
+    now_epoch = datetime.now(UTC).timestamp()
+    return OverLimitStatus(
+        window_started_epoch=now_epoch - 600,
+        retry_epoch=int(now_epoch - 600) + LIMIT_WINDOW_SECONDS,
+    )
+
+
+@pytest.mark.asyncio
+async def test_under_limit_allows_the_message():
+    bot = _bot(MagicMock())
+    with patch(
+        "smarter_dev.bot.plugins.mention.over_limit_status",
+        new=AsyncMock(return_value=None),
+    ):
+        assert await _reject_when_over_limit(bot, _event()) is False
+    bot.rest.create_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_over_limit_drops_and_pings_once():
+    bot = _bot(MagicMock())
+    status = _over_limit_status()
+    event = _event(user_id=200)
+    with patch(
+        "smarter_dev.bot.plugins.mention.over_limit_status",
+        new=AsyncMock(return_value=status),
+    ), patch(
+        "smarter_dev.bot.plugins.mention.claim_notice_throttle",
+        new=AsyncMock(return_value=True),
+    ):
+        assert await _reject_when_over_limit(bot, event) is True
+
+    bot.rest.create_message.assert_awaited_once()
+    args, kwargs = bot.rest.create_message.await_args
+    notice = args[1]
+    assert notice.startswith("> -# <@200> ")
+    assert f"you've sent {USER_MESSAGE_LIMIT} messages to the bot" in notice
+    assert f"<t:{status.retry_epoch}:R>" in notice
+    # The reply carries an explicit user mention so the ping always lands.
+    assert kwargs["user_mentions"] == [200]
+    assert kwargs["reply"] is event.message
+
+
+@pytest.mark.asyncio
+async def test_over_limit_stays_silent_once_the_episode_is_claimed():
+    bot = _bot(MagicMock())
+    with patch(
+        "smarter_dev.bot.plugins.mention.over_limit_status",
+        new=AsyncMock(return_value=_over_limit_status()),
+    ), patch(
+        "smarter_dev.bot.plugins.mention.claim_notice_throttle",
+        new=AsyncMock(return_value=False),
+    ):
+        assert await _reject_when_over_limit(bot, _event()) is True
+    bot.rest.create_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_missing_redis_never_blocks():
+    bot = SimpleNamespace(rest=MagicMock(), d={})
+    assert await _reject_when_over_limit(bot, _event()) is False
+
+
+@pytest.mark.asyncio
+async def test_redis_error_never_blocks():
+    bot = _bot(MagicMock())
+    with patch(
+        "smarter_dev.bot.plugins.mention.over_limit_status",
+        new=AsyncMock(side_effect=RedisError("down")),
+    ):
+        assert await _reject_when_over_limit(bot, _event()) is False
+
+
+@pytest.mark.asyncio
+async def test_notice_send_failure_still_drops_the_message():
+    bot = _bot(MagicMock())
+    bot.rest.create_message = AsyncMock(side_effect=RuntimeError("boom"))
+    with patch(
+        "smarter_dev.bot.plugins.mention.over_limit_status",
+        new=AsyncMock(return_value=_over_limit_status()),
+    ), patch(
+        "smarter_dev.bot.plugins.mention.claim_notice_throttle",
+        new=AsyncMock(return_value=True),
+    ):
+        assert await _reject_when_over_limit(bot, _event()) is True
+
+
+@pytest.mark.asyncio
+async def test_engaged_message_is_charged_to_its_author():
+    bot = _bot(MagicMock())
+    event = _event(user_id=200, message_id=555)
+    with patch(
+        "smarter_dev.bot.plugins.mention.record_directed_messages",
+        new=AsyncMock(),
+    ) as record_mock:
+        await _record_engaged_message(bot, event)
+
+    record_mock.assert_awaited_once()
+    _, user_id, message_epochs = record_mock.await_args.args
+    assert user_id == "200"
+    assert list(message_epochs) == ["555"]
+    assert message_epochs["555"] == pytest.approx(
+        event.message.created_at.timestamp()
+    )
+
+
+@pytest.mark.asyncio
+async def test_engaged_charge_survives_redis_error():
+    bot = _bot(MagicMock())
+    with patch(
+        "smarter_dev.bot.plugins.mention.record_directed_messages",
+        new=AsyncMock(side_effect=RedisError("down")),
+    ):
+        await _record_engaged_message(bot, _event())


### PR DESCRIPTION
## Summary

Four features for the chat bot, built in this branch:

- **Rolling per-user message limit (60 per 4h, all channels).** Bot-directed messages are counted in a per-user Redis sorted set (member = message id, so gate-time and post-run charges never double-count). Mentions/replies are charged at the gate; in-session follow-ups are charged from the agent's own directedness rankings (score ≥ 5). Over-limit users are dropped before the agent sees them and get one quoted-subtext ping per episode with the counted span and a live countdown to when the limit frees. All Redis paths fail soft.
- **`/bot-usage` command** (everyone, ephemeral): "**Your messages:** 32/60 in the last hour" — span is hours since the oldest counted message, rounded up, capped at 4 — plus "**Bot usage here:** 76k/100k this hour · 512k/1m today".
- **Universal token metering.** Every channel/thread's chat tokens are metered into hour/day windows regardless of `/setmodel` override (enforcement remains override-only). Maxed budget windows in `/bot-usage` show a live reset countdown; unbudgeted channels read `X/unlimited`.
- **English-only policy** in the chat agent system prompt: polite redirect on the first non-English message, silence if the user keeps going; non-English fragments (pasted errors, loanwords, code comments) explicitly exempt.

## Test plan

- 680 bot tests pass, full suite run before merge
- New coverage: rolling-window service math (trim/retry-epoch/span framing), mention-gate drop + notice throttling, engine ranking-based charging, /bot-usage rendering incl. maxed-window countdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Duuxkh4osn6uhuDtv2cMAX