### PR TITLE
Public /bot-usage-info with window and all-time totals

### DIFF
--- a/smarter_dev/bot/plugins/bot_usage.py
+++ b/smarter_dev/bot/plugins/bot_usage.py
@@ -1,6 +1,8 @@
-"""``/bot-usage`` slash command — personal message allowance + channel token usage.
+"""``/bot-usage`` and ``/bot-usage-info`` slash commands.
 
-Available to everyone; responds ephemerally. Shows two things:
+Both available to everyone. ``/bot-usage`` responds ephemerally with the
+invoker's personal numbers; ``/bot-usage-info`` posts its leaderboard
+publicly so the channel can discuss it. ``/bot-usage`` shows two things:
 
 - The invoker's rolling per-user message counter (see
   :mod:`~smarter_dev.bot.services.user_message_limit`), framed over the hours
@@ -216,12 +218,21 @@ async def build_usage_leaderboard(bot: Any, guild_id: str, range_key: str) -> st
         return f"Usage data is {_UNAVAILABLE}."
 
     entries = payload.get("entries", [])
+    window_total = format_compact_tokens(int(payload.get("total_tokens_in_window", 0)))
+    all_time_total = format_compact_tokens(
+        int(payload.get("total_tokens_all_time", 0))
+    )
     if not entries:
-        return f"No bot token usage recorded in the last {range_key}."
+        return (
+            f"No bot token usage recorded in the last {range_key} "
+            f"({all_time_total} tokens all time)."
+        )
 
     lines = [
         f"**Bot token usage — last {range_key}** "
-        f"(top {len(entries)} channels)"
+        f"(top {len(entries)} channels)",
+        f"-# {window_total} tokens in the last {range_key} · "
+        f"{all_time_total} all time",
     ]
     for position, entry in enumerate(entries, start=1):
         tokens = format_compact_tokens(int(entry["total_tokens"]))
@@ -244,11 +255,15 @@ async def build_usage_leaderboard(bot: Any, guild_id: str, range_key: str) -> st
 )
 @lightbulb.implements(lightbulb.SlashCommand)
 async def bot_usage_info(ctx: lightbulb.Context) -> None:
-    """Show the per-channel token leaderboard for the chosen range."""
+    """Show the per-channel token leaderboard for the chosen range.
+
+    Posts publicly (unlike ``/bot-usage``) so the channel can see and
+    discuss the leaderboard.
+    """
     report = await build_usage_leaderboard(
         ctx.bot, str(ctx.guild_id), ctx.options.range
     )
-    await ctx.respond(report, flags=hikari.MessageFlag.EPHEMERAL)
+    await ctx.respond(report)
 
 
 def load(bot: lightbulb.BotApp) -> None:

--- a/smarter_dev/web/api/routers/chat_conversations.py
+++ b/smarter_dev/web/api/routers/chat_conversations.py
@@ -291,6 +291,35 @@ async def channel_usage_leaderboard(
     return (await db.execute(stmt)).all()
 
 
+async def guild_total_tokens(
+    db: AsyncSession, *, guild_id: str, since: datetime | None = None
+) -> int:
+    """The guild's summed chat tokens (input+output) across every channel.
+
+    ``since`` bounds the window; None sums all time.
+    """
+    stmt = (
+        select(
+            func.coalesce(
+                func.sum(
+                    ChatAgentTurn.chat_tokens_input
+                    + ChatAgentTurn.chat_tokens_output
+                ),
+                0,
+            )
+        )
+        .select_from(ChatAgentTurn)
+        .join(
+            ChatAgentEngagement,
+            ChatAgentTurn.engagement_id == ChatAgentEngagement.id,
+        )
+        .where(ChatAgentEngagement.guild_id == guild_id)
+    )
+    if since is not None:
+        stmt = stmt.where(ChatAgentTurn.started_at >= since)
+    return int(await db.scalar(stmt) or 0)
+
+
 @router.get("/usage-leaderboard", response_model=ChatUsageLeaderboardResponse)
 async def usage_leaderboard(
     request: Request,
@@ -308,6 +337,10 @@ async def usage_leaderboard(
     return ChatUsageLeaderboardResponse(
         since=since,
         days=days,
+        total_tokens_all_time=await guild_total_tokens(db, guild_id=guild_id),
+        total_tokens_in_window=await guild_total_tokens(
+            db, guild_id=guild_id, since=since
+        ),
         entries=[
             ChatUsageLeaderboardEntry(
                 channel_id=row.channel_id,

--- a/smarter_dev/web/api/schemas.py
+++ b/smarter_dev/web/api/schemas.py
@@ -875,10 +875,17 @@ class ChatUsageLeaderboardEntry(BaseAPIModel):
 
 
 class ChatUsageLeaderboardResponse(BaseAPIModel):
-    """Top channels by chat-token usage since ``since`` (``days`` ago)."""
+    """Top channels by chat-token usage since ``since`` (``days`` ago).
+
+    ``total_tokens_in_window`` sums the whole window across every channel
+    (not just the listed top N); ``total_tokens_all_time`` is the guild's
+    summed chat tokens with no time filter.
+    """
 
     since: datetime
     days: int
+    total_tokens_all_time: int
+    total_tokens_in_window: int
     entries: list[ChatUsageLeaderboardEntry]
 
 

--- a/tests/bot/test_bot_usage.py
+++ b/tests/bot/test_bot_usage.py
@@ -202,16 +202,19 @@ def _leaderboard_bot(payload=None, status_code=200):
 async def test_leaderboard_renders_top_channels_for_the_range():
     bot, api = _leaderboard_bot(
         {
+            "total_tokens_all_time": 14_200_000,
+            "total_tokens_in_window": 2_100_000,
             "entries": [
                 {"channel_id": "111", "channel_name": "general", "total_tokens": 512_000},
                 {"channel_id": "222", "channel_name": None, "total_tokens": 76_000},
-            ]
+            ],
         }
     )
 
     report = await build_usage_leaderboard(bot, "G", "week")
 
     assert "**Bot token usage — last week** (top 2 channels)" in report
+    assert "-# 2.1m tokens in the last week · 14.2m all time" in report
     assert "1. <#111> — 512k" in report
     assert "2. <#222> — 76k" in report
     api.get.assert_awaited_once_with(
@@ -230,9 +233,13 @@ async def test_leaderboard_ranges_map_to_days():
 
 @pytest.mark.asyncio
 async def test_leaderboard_empty_window_says_so():
-    bot, _ = _leaderboard_bot({"entries": []})
+    bot, _ = _leaderboard_bot(
+        {"entries": [], "total_tokens_all_time": 14_200_000, "total_tokens_in_window": 0}
+    )
     report = await build_usage_leaderboard(bot, "G", "day")
-    assert report == "No bot token usage recorded in the last day."
+    assert report == (
+        "No bot token usage recorded in the last day (14.2m tokens all time)."
+    )
 
 
 @pytest.mark.asyncio
@@ -247,7 +254,7 @@ async def test_leaderboard_degrades_on_api_failure():
 
 
 @pytest.mark.asyncio
-async def test_leaderboard_command_responds_ephemerally():
+async def test_leaderboard_command_responds_publicly():
     ctx = Mock()
     ctx.guild_id = "G"
     ctx.respond = AsyncMock()
@@ -261,7 +268,8 @@ async def test_leaderboard_command_responds_ephemerally():
     ctx.respond.assert_awaited_once()
     args, kwargs = ctx.respond.await_args
     assert "last month" in args[0]
-    assert kwargs["flags"] == hikari.MessageFlag.EPHEMERAL
+    # No ephemeral flag — the leaderboard is a real message others can see.
+    assert "flags" not in kwargs
 
 
 @pytest.mark.asyncio

--- a/tests/web/chat_usage_leaderboard_test.py
+++ b/tests/web/chat_usage_leaderboard_test.py
@@ -8,6 +8,7 @@ from datetime import timedelta
 
 from smarter_dev.web.api.routers.chat_conversations import (
     channel_usage_leaderboard,
+    guild_total_tokens,
 )
 from smarter_dev.web.models import ChatAgentEngagement, ChatAgentTurn
 
@@ -127,3 +128,33 @@ async def test_channel_name_snapshot_is_surfaced(db_session):
 
     rows = await _leaderboard(db_session)
     assert rows[0].channel_name == "general"
+
+
+async def test_guild_total_sums_all_time_across_channels(db_session):
+    first = _engagement(channel_id="C1")
+    second = _engagement(channel_id="C2")
+    old = datetime.now(UTC) - timedelta(days=400)
+    db_session.add_all(
+        [
+            first,
+            second,
+            _turn(first, 100, 50),
+            _turn(second, 200, 0, started_at=old),
+        ]
+    )
+    await db_session.commit()
+
+    assert await guild_total_tokens(db_session, guild_id="G1") == 350
+    assert await guild_total_tokens(db_session, guild_id="other") == 0
+
+
+async def test_guild_total_respects_the_window(db_session):
+    engagement = _engagement(channel_id="C1")
+    old = datetime.now(UTC) - timedelta(days=10)
+    db_session.add_all(
+        [engagement, _turn(engagement, 100, 0), _turn(engagement, 900, 0, started_at=old)]
+    )
+    await db_session.commit()
+
+    since = datetime.now(UTC) - timedelta(days=7)
+    assert await guild_total_tokens(db_session, guild_id="G1", since=since) == 100


### PR DESCRIPTION
## Summary

- `/bot-usage-info` now posts as a real channel message (no ephemeral flag) so others can see and discuss it; `/bot-usage` stays ephemeral.
- A subtext line under the header shows the cumulative tokens for the selected window (summed across every channel, not just the listed top 20) and the guild's all-time total:

> **Bot token usage — last week** (top 20 channels)
> -# 2.1m tokens in the last week · 14.2m all time
> 1. <#…> — 512k

- The empty-window message carries the all-time total too.

## Test plan

- 685 bot tests + 8 web query tests pass (aggregates: all-time, windowed, guild isolation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Duuxkh4osn6uhuDtv2cMAX