### PR TITLE
feat(handlers): admin member/thread event triggers + thread scripting functions

### DIFF
--- a/alembic/main/versions/20260717_120000_b2e4f7a1c3d9_admin_member_thread_triggers.py
+++ b/alembic/main/versions/20260717_120000_b2e4f7a1c3d9_admin_member_thread_triggers.py
@@ -1,0 +1,65 @@
+"""Admin-tier member/thread triggers + handler_runs read/thread-op counters.
+
+Extends ``ck_admin_handlers_trigger_type`` to admit the five admin-only gateway
+triggers (member_join/leave/rules_accepted/role_change, thread_create).
+``ck_channel_handlers_trigger_type`` is deliberately UNCHANGED — the standard
+tier's vocabulary does not grow. Adds ``handler_runs.discord_reads`` and
+``handler_runs.thread_ops`` (metered list_threads reads and mutating thread ops),
+matching the existing counter columns.
+
+Revision ID: b2e4f7a1c3d9
+Revises: cfcaa2cbf2b0
+Create Date: 2026-07-17 12:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "b2e4f7a1c3d9"
+down_revision: Union[str, None] = "cfcaa2cbf2b0"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_ADMIN_TRIGGER_TYPES_EXTENDED = (
+    "trigger_type IN ('message', 'reaction', 'schedule', 'timer', "
+    "'member_join', 'member_leave', 'member_rules_accepted', "
+    "'member_role_change', 'thread_create')"
+)
+_ADMIN_TRIGGER_TYPES_ORIGINAL = (
+    "trigger_type IN ('message', 'reaction', 'schedule', 'timer')"
+)
+
+
+def upgrade() -> None:
+    op.drop_constraint(
+        op.f("ck_admin_handlers_trigger_type"), "admin_handlers", type_="check"
+    )
+    op.create_check_constraint(
+        op.f("ck_admin_handlers_trigger_type"),
+        "admin_handlers",
+        _ADMIN_TRIGGER_TYPES_EXTENDED,
+    )
+    op.add_column(
+        "handler_runs",
+        sa.Column("discord_reads", sa.Integer(), server_default="0", nullable=False),
+    )
+    op.add_column(
+        "handler_runs",
+        sa.Column("thread_ops", sa.Integer(), server_default="0", nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("handler_runs", "thread_ops")
+    op.drop_column("handler_runs", "discord_reads")
+    op.drop_constraint(
+        op.f("ck_admin_handlers_trigger_type"), "admin_handlers", type_="check"
+    )
+    op.create_check_constraint(
+        op.f("ck_admin_handlers_trigger_type"),
+        "admin_handlers",
+        _ADMIN_TRIGGER_TYPES_ORIGINAL,
+    )

--- a/docs/v2/feature-parity/index.md
+++ b/docs/v2/feature-parity/index.md
@@ -19,6 +19,7 @@ bot core.
 | [Member Lifecycle & Role Automation](member-lifecycle-and-role-automation.md) | codes-onboarding, codes-celebration-engagement, py-sus-command | Member-event trigger family (`member_join` / `member_rules_accepted` / `member_role_change`), `add_role`/`remove_role`, persisted one-shot timers |
 | [Engagement Loops & Server Stats](engagement-loops-and-server-stats.md) | codes-disboard-bumping, codes-server-stat-counter | Schedule-driven counters in handler memory; `rename_channel`; bot-core presence aggregator |
 | [Community Content Commands](community-content-commands.md) | py-rules, py-resources-command | Almost entirely handler-today; `edit_message` for the canonical rules post |
+| [Threads & Member Events](threads-and-member-events.md) | cross-group (approved design) | Five admin-only event triggers (`member_join` / `member_leave` / `member_rules_accepted` / `member_role_change` / `thread_create`), thread-aware message dispatch, thread scripting functions; amends lifecycle E1 to admin-tier-only |
 
 ## Cross-cutting handler-system extensions
 

--- a/docs/v2/feature-parity/staff-communication-channels.md
+++ b/docs/v2/feature-parity/staff-communication-channels.md
@@ -89,13 +89,21 @@ Seven extensions, ordered by how many capabilities consume them. All new emit fu
   ```
   REST mapping: `POST /channels/{parent}/threads` with `{"type": 12, "name": ..., "auto_archive_duration": ...}`; `PATCH /channels/{thread}`; `PUT`/`DELETE /channels/{thread}/thread-members/{user}`; `GET /channels/{thread}/thread-members?with_member=true` (the `with_member` flag returns member objects whose `roles` populate `role_ids`, so `!lock` needs no second fetch).
 - **Failure semantics:** `add/remove_thread_member` and `edit_thread` return `False` on 403/404 (unknown thread, missing perms) — expected outcomes the script branches on. `create_private_thread` raises on failure (nothing sensible to do without a thread id) and `get_thread_members` returns `[]` on 404. Infrastructure failures (rate-limit exhaustion, 5xx) raise as today.
-- **Budget:** new counter `thread_ops` on `HandlerBudget` with `spend_thread_op()`; `ADMIN_MAX_THREAD_OPS = 25` (default 0 for standard handlers, like mod actions). Every one of the five functions spends one — including `get_thread_members`, which keeps read amplification bounded without a second cap. 25 covers a `!lock` sweep of a realistically-sized mod thread; a giant thread breaches loud mid-sweep, which is the correct behavior.
-- **Windowed cap:** new `guild_thread_creates_key(guild_id)` with `GUILD_THREAD_CREATES_PER_MIN = 2` on `create_private_thread` only — thread creation is the spammy primitive; edits/membership are bounded by the per-fire counter.
-- **Run record:** add `thread_ops` column to `HandlerRun` (alembic migration) and to `HandlerBudget.usage()`.
+- **Budget (reconciled onto `threads-and-member-events.md` §5.3, which shipped first):** the `thread_ops` counter, `spend_thread_op()`, the `HandlerRun.thread_ops` column, and `usage()` wiring **already exist** — do not re-introduce them. This family's mutating functions (`create_private_thread`, `edit_thread`, `add/remove_thread_member`) spend the existing counter; `get_thread_members` is a read and spends `discord_reads` instead (consistent with `list_threads`; `ADMIN_MAX_DISCORD_READS = 5` covers the one membership fetch a `!lock` sweep needs). Shipping this family raises `ADMIN_MAX_THREAD_OPS` from 10 to 25 in the same change — a `!lock` sweep is 1 + N removals; a giant thread breaches loud mid-sweep, which is the correct behavior.
+- **Windowed cap (reconciled):** all mutating ops here ride the shipped `guild_thread_ops_key(guild_id)` / `GUILD_THREAD_OPS_PER_MIN = 30` window like every other thread mutation. `create_private_thread` **additionally** gets the tighter `guild_thread_creates_key(guild_id)` / `GUILD_THREAD_CREATES_PER_MIN = 2` — private-thread creation is the spammy primitive and the shared 30/min is too loose for it specifically.
+- **Verification rail (inherited):** `edit_thread`, `add/remove_thread_member`, and `get_thread_members` take script-supplied thread ids and go through `AdminActor._verify_thread_target` (is-a-thread + in-this-guild, cached per fire) exactly like the shipped close/lock/reopen/delete family. `close_thread`/`lock_thread`/`reopen_thread` already shipped — `edit_thread` adds only rename/auto-archive on top and shares `_patch_thread`'s 404 → `False` contract.
+- **Run record:** already shipped (`threads-and-member-events.md` §6); no new migration for the counter.
 - **Lint/judge:** admin author/judge prompts gain the vocabulary; judge guidance: membership loops must be bounded by the member list itself (never `while`), and `edit_thread(archived=True)` after posting the closing message, not before (a post into an archived thread 403s).
 - **Consumed by:** rows 13, 14, 15.
 
 ### E6 — Thread-aware message-trigger dispatch
+
+> **SHIPPED** by `threads-and-member-events.md` §4 (2026-07-17), with one context-shape
+> difference: the shipped fields are `thread_id`, `thread_name`, and `is_thread`
+> (boolean) — there is no `thread_parent_channel_id` field, because the dispatch
+> `channel_id` *is* the parent. Scripts written against this sketch should read
+> `is_thread` instead of null-checking `thread_parent_channel_id`. The rest of this
+> section is retained for the original rationale only.
 
 - **What:** `!archive`/`!lock` are typed *inside* a thread. Today `on_message` dispatches on the raw `event.channel_id`; a thread's id differs from its parent's, so channel-scoped handlers never fire and context can't distinguish threads.
 - **Design (bot-side, `handler_events.py`):** resolve the message channel from the gateway cache (`bot.cache.get_thread(channel_id)` / `get_guild_channel`); when it is a thread:
@@ -329,11 +337,11 @@ Ship in four phases, each independently valuable. Tests-first throughout; the ha
 - Pre-ship check: grep installed handler scripts for intentional role pings (expect none).
 
 **Phase 2 — Mod Chat** (no DM machinery needed, so it lands first of the two features).
-1. `HandlerBudget.spend_thread_op` + `thread_ops` in `usage()` — pure, test caps/breach/deadline interplay first.
-2. `HandlerRun.thread_ops` column + alembic migration (test upgrade/downgrade).
-3. Emitter/actor thread REST methods — tests with a fake `_request`: correct routes/payloads; 403/404 → `False`/`[]` (expected outcomes); 5xx → raises (fail fast); `get_thread_members` passes `with_member=true` and maps `role_ids`.
-4. Runtime wiring — tests: functions absent without `actor`; each spends `thread_ops`; breach mid-`!lock`-sweep yields `cap_exceeded` with prior removals kept ("effects stay"); `create_private_thread` hits the guild thread-create window.
-5. E6 thread-aware dispatch — pure context-builder tests: thread message → parent-channel dispatch key + `thread_id`/`thread_parent_channel_id`/`thread_name`; non-thread → fields absent; cache-miss on channel resolution → dispatch as plain message (never drop).
+1. ~~`HandlerBudget.spend_thread_op` + `thread_ops` in `usage()`~~ — **shipped** by `threads-and-member-events.md`; only the `ADMIN_MAX_THREAD_OPS` 10 → 25 raise remains (one-line change + test).
+2. ~~`HandlerRun.thread_ops` column + alembic migration~~ — **shipped**.
+3. Emitter/actor thread REST methods — tests with a fake `_request`: correct routes/payloads; 403/404 → `False`/`[]` (expected outcomes); 5xx → raises (fail fast); `get_thread_members` passes `with_member=true` and maps `role_ids`; all thread-id-taking methods go through the shipped `_verify_thread_target` rail.
+4. Runtime wiring — tests: functions absent without `actor`; mutations spend `thread_ops`, `get_thread_members` spends `discord_reads`; breach mid-`!lock`-sweep yields `cap_exceeded` with prior removals kept ("effects stay"); `create_private_thread` hits the shared guild thread-op window AND the tighter thread-create window.
+5. ~~E6 thread-aware dispatch~~ — **shipped** (`is_thread` context shape; see the E6 note above).
 6. E7 context fields — pure builder tests. **`author_role_ids` is load-bearing here** (the `!archive`/`!lock` invoker gate, rows 14/15/19) and must land before step 7; verify it is populated for thread messages too (`event.member` on the thread message). The mention fields remain the optional part.
 7. Prompt updates, then author the `mod-chat` handler in a test guild. Critical failure paths to cover in script-level tests (run the sketch through `run_handler_script` with a fake emitter): unconfigured keys → explanatory message, no thread ops; `!archive` outside a mod thread → no-op; **non-mod thread member (added via `!modchat` mention) types `!archive`/`!lock` → no-op, zero thread ops**; `edit_thread` ordering (message before archive); `!lock` with all-mods membership → zero removals.
 

--- a/docs/v2/feature-parity/threads-and-member-events.md
+++ b/docs/v2/feature-parity/threads-and-member-events.md
@@ -1,0 +1,407 @@
+# Threads & Member Events
+
+**Feature group:** cross-cutting handler-system extension — five new **admin-tier-only**
+event trigger types (`member_join`, `member_leave`, `member_rules_accepted`,
+`member_role_change`, `thread_create`), thread-aware message dispatch, and a thread
+scripting-function family. This document records an **approved design**; it amends
+[member-lifecycle-and-role-automation.md](member-lifecycle-and-role-automation.md) §3 E1
+(see §2) and is the build spec for the `feat/thread-member-triggers` work.
+
+**Related plans:**
+- `member-lifecycle-and-role-automation.md` — E1 context shapes (normative for the three
+  member triggers reproduced here), E2 role mutation, E3 timers, E5/E6 (all unchanged).
+- `staff-communication-channels.md` — E5 private-thread family and E6 thread dispatch
+  sketches; E6 is realized here (§4), E5's private-thread/membership ops remain follow-ups
+  to be reconciled with the `thread_ops` budget introduced here (§8).
+
+## 1. Overview
+
+Two capability families land together because they share every rail: **member gateway
+events as triggers** (the lifecycle plan's E1 family, plus `member_leave`) and **threads**
+— a `thread_create` trigger covering both regular threads and forum posts, dispatch of
+thread messages to parent-channel handlers, and metered thread read/write functions.
+Threads and member events are both guild-shaped rather than channel-shaped: a member event
+has no channel at all, and a thread's identity keys off its **parent** channel. That shared
+shape is why the whole family is **admin-tier only** (§2) — dispatch, scoping, and blast
+radius all reason about the guild, which is the admin tier's home turf.
+
+Everything here follows the existing chokepoints: triggers dispatch through
+`dispatch_event` (`smarter_dev/web/api_native/handlers.py:332`), scripts reach Discord
+only through `HandlerExecution.external_functions()`
+(`smarter_dev/web/handler_runtime.py:152`), spend is metered by `HandlerBudget`
+(`smarter_dev/web/handler_budget.py`) and the Redis `WindowedLimiter`
+(`smarter_dev/web/handler_caps.py`), and every fire is audited in `HandlerRun`.
+
+## 2. Amendment to E1 — member-event triggers are admin-only
+
+`member-lifecycle-and-role-automation.md` E1 ("Tier availability & routing") specified
+that the member-event trigger family would be available to **both** tiers, with a
+standard-tier dispatch branch matching `ChannelHandler.guild_id` and `active_channels`
+gaining `(guild_id, trigger)` entries for standard handlers. **That routing is
+superseded: all five trigger types in this document are admin-tier only** (this also
+resolves the sibling doc's Q1 in favor of its "gate admin-only initially" alternative).
+
+Consequences for E1's standard-tier consumers:
+
+- **`member-milestones`**, **`boost-announcement`**, and **`premium-member-announcement`**
+  (lifecycle §4.1/§4.2) are re-tiered: each becomes an **admin handler targeting its
+  output channel explicitly** — `send_message(content, channel_id=ANNOUNCE_CHANNEL)` with
+  the channel id as a script constant stated at authoring time (the admin cross-channel
+  send that already exists). "Placement = output binding" no longer applies to member
+  events; the explicit channel constant is the binding, visible to the judge.
+- The standard-tier guild-matching branch in `dispatch_event` and the standard
+  `(guild_id, trigger)` entries in `active_channels` from E1 are **not built**.
+- E1's context shapes, per-trigger cache-miss policies, delta computation, caps, and E6's
+  recovery design are all **unchanged** — only the tier routing moves.
+- **Standard create paths must reject the new triggers.** The standard-tier trigger
+  vocabulary remains exactly `message` / `reaction` / `schedule` / `timer`: the
+  `ChannelHandler` create/update endpoints and the standard authoring pipeline return a
+  validation error for any of the five new types, and `ck_channel_handlers_trigger_type`
+  is deliberately **not** extended (the DB enforces the tier split too, §6).
+
+## 3. E1 — Trigger family: five admin-only event triggers
+
+New listeners in `bot/plugins/handler_events.py` on `hikari.MemberCreateEvent`,
+`hikari.MemberDeleteEvent`, `hikari.MemberUpdateEvent`, and
+`hikari.GuildThreadCreateEvent`. All delta/selection logic is pure-function bot-side
+(lifecycle E1's `member_update_deltas` pattern), TDD-able without a gateway.
+
+### 3.1 Trigger types and context shapes
+
+All ids as strings, times ISO-8601 UTC, matching existing contexts. The three shapes
+carried over from lifecycle E1 are reproduced for convenience; **E1 remains normative**
+for them, including `member_join`'s guild-count fields and `member_role_change`'s
+boost/stat fields.
+
+```python
+# member_join  (hikari.MemberCreateEvent) — shape per lifecycle E1
+{
+    "trigger_type": "member_join",
+    "member_id": "...", "username": "...", "display_name": "...",
+    "is_bot": False,
+    "account_created_at": "...",
+    "has_custom_avatar": True,
+    "guild_member_count": 12345,
+    "guild_human_member_count": 11987,
+}
+
+# member_rules_accepted  (MemberUpdateEvent, pending true -> false) — per lifecycle E1
+{
+    "trigger_type": "member_rules_accepted",
+    "member_id": "...", "username": "...", "display_name": "...", "nickname": None,
+    "account_created_at": "...", "has_custom_avatar": True,
+    "joined_at": "...",
+}
+
+# member_role_change  (MemberUpdateEvent, role set changed) — per lifecycle E1
+{
+    "trigger_type": "member_role_change",
+    "member_id": "...", "member_display_name": "...",
+    "added_role_ids": ["..."], "added_role_names": ["..."],
+    "removed_role_ids": ["..."], "removed_role_names": ["..."],
+    "is_boost_role_added": True,
+    "premium_subscription_count": 14,
+    "boosting_member_count": 9,
+    "role_member_counts": {"role_id": 42},
+}
+
+# member_leave  (hikari.MemberDeleteEvent) — new in this document
+{
+    "trigger_type": "member_leave",
+    "member_id": "...", "username": "...", "display_name": "...",
+    "is_bot": False,
+    "account_created_at": "...",       # from the snowflake, always available
+    "joined_at": "...",                # from the cached old_member; None on cache miss
+    "role_ids": ["..."], "role_names": ["..."],  # from cache; may be empty
+    "cache_incomplete": False,         # True when old_member was not cached
+}
+
+# thread_create  (hikari.GuildThreadCreateEvent) — new in this document
+{
+    "trigger_type": "thread_create",
+    "thread_id": "...", "thread_name": "...",
+    "parent_channel_id": "...",
+    "creator_id": "...", "creator_username": "...", "creator_display_name": "...",
+    "is_forum_post": False,            # parent channel is a forum channel
+    "applied_tag_ids": ["..."], "applied_tag_names": ["..."],
+    "starter_message_content": "",     # forum posts; may be empty string
+    "created_at": "...",
+}
+```
+
+`thread_create` covers **both** regular threads and forum posts — Discord emits the same
+`THREAD_CREATE` gateway event for both; `is_forum_post` is how a script branches. For
+forum posts the starter message's id equals the thread's id (Discord contract), so the
+bot reads `starter_message_content` from its message cache best-effort; when the starter
+message is not yet cached the field is `""` — documented, never a skip. Discord also
+sends `THREAD_CREATE` when the bot merely *gains access* to an existing thread; the
+listener dispatches **only when the payload's `newly_created` flag is set**, so
+visibility changes never fire the trigger.
+
+### 3.2 Cache-miss / failure policy (per-trigger, fail-safe direction differs)
+
+- `member_role_change` — cache miss (no `old_member`) ⇒ **skip** (no delta ⇒ no fire),
+  exactly per lifecycle E1; this skip is what makes the boost re-fire guard structural.
+- `member_rules_accepted` — **at-least-once heuristic** per lifecycle E1: on cache miss,
+  fire iff the new member is not pending AND holds no roles beyond `@everyone`.
+  Duplicate fires are possible and documented; handlers must be idempotent (judge rail).
+- `member_leave` — **informational: fire always, never skip.** On cache miss the context
+  carries `joined_at: None`, empty `role_ids`/`role_names`, and
+  `cache_incomplete: True`; a leave notice with partial detail beats a silent drop, and
+  there is nothing fail-dangerous a leave handler can do with missing history.
+- `member_join` / `thread_create` — the event payload itself is sufficient; no cache
+  dependency beyond the best-effort count/starter-message fields already marked as such.
+
+### 3.3 Dispatch & routing
+
+- **Guild-scoped events** (the four `member_*` triggers): the bot calls `dispatch_event`
+  with `channel_id=""`. The standard-tier query is skipped entirely for these trigger
+  types (standard rows cannot exist — create paths reject, constraint unchanged), and
+  admin handlers match by **guild + trigger + enabled only**: the `channel_ids` scope
+  check is bypassed for `member_*` triggers, since a member event has no channel for a
+  scope to mean anything (the authoring agent leaves `channel_ids` empty for these). The
+  fire's `channel_id` is `""`, so the handler has **no home channel**:
+  `send_message(content)` without an explicit `channel_id` fails, and every send must
+  name its target channel constant — an authoring-prompt rule the judge can verify.
+- **`thread_create`**: dispatch keys off the **parent** channel — the bot calls
+  `dispatch_event` with `channel_id=parent_channel_id`, and an admin handler's
+  `channel_ids` scope matches against `parent_channel_id` via the existing scope check.
+  The fire's home channel is the parent, so `send_message(content)` posts to the parent
+  and `send_message(content, thread_id)` posts into the new thread (§5.1 relaxation).
+- **`active_channels`**: the admin query's trigger filter extends to the five new types.
+  `member_*` handlers always surface as `(guild_id, trigger)` entries in `guild_triggers`
+  regardless of `channel_ids` (the bot's dispatch guard is per-guild for them);
+  `thread_create` handlers follow the existing channel-scoped/guild-wide split, with the
+  bot matching the guard against the new thread's parent channel.
+
+### 3.4 Caps
+
+- `fires_per_min_for_trigger` returns **10** for all five new triggers (today's default
+  branch already returns 10 for non-reaction types — pinned by an explicit test so a
+  future refactor cannot silently tighten or loosen it).
+- **`GUILD_MEMBER_EVENTS_PER_MIN = 60`** on key `hcap:memberevt:{guild_id}`
+  (`guild_member_events_key` in `handler_caps.py`) — checked in `dispatch_event`
+  **before enqueueing** any `member_*` fire, so a raid degrades to declined dispatches
+  rather than a fire-queue explosion. Same constant and semantics as lifecycle E1;
+  `member_leave` fires draw from the same window (join and leave burst together in a
+  raid + ban wave). `thread_create` is **not** under this window — it is bounded by the
+  per-handler fire cap and the thread-op caps in §5.3.
+
+**Consumed by:** every lifecycle §4 admin handler (`join-gate`, `onboard-and-promote` —
+already admin-tier); the re-tiered milestone/boost/premium handlers (§2); moderation's
+rejoin alert (`member_join`/`member_leave`); thread/forum automation (auto-tag triage,
+forum-post greeters, thread-janitor handlers) via `thread_create`.
+
+## 4. E2 — Thread-aware message dispatch
+
+A `GuildMessageCreateEvent` inside a thread now **also dispatches to handlers registered
+on the thread's parent channel**. Bot-side (`handler_events.py`): resolve the message's
+channel from the gateway cache; when it is a thread, dispatch with
+`channel_id = parent_id` and enrich the message context:
+
+```python
+# message context, when the message is inside a thread
+{..., "thread_id": "...", "thread_name": "...", "is_thread": True}
+
+# message context, non-thread messages
+{..., "is_thread": False}
+```
+
+The fire's `channel_id` stays the **parent**, so home-channel semantics (default
+`send_message()` target, error notices) are unchanged; a script replies *into* the
+thread explicitly with `send_message(text, context["thread_id"])`, which the §5.1
+relaxation permits for standard handlers because the thread belongs to the home channel.
+Thread posts meter against the thread's own `channel_message_key` window (the limiter
+already keys on the actual target), exactly as cross-channel sends do today. This
+realizes staff-comms E6 with one context-shape change: `is_thread` replaces that
+sketch's `thread_parent_channel_id` (redundant — the dispatch `channel_id` *is* the
+parent).
+
+**Consumed by:** staff-comms rows 14/15 (`!archive`/`!lock` typed inside mod threads);
+any handler that should keep working when conversation moves into a thread of its
+channel.
+
+## 5. E3 — Thread scripting functions
+
+Registered in `HandlerExecution.external_functions()`
+(`smarter_dev/web/handler_runtime.py:152`), split exactly like moderation functions
+today: general functions always injected; admin functions injected only when
+`self.actor is not None`.
+
+### 5.1 General functions (both tiers, home-channel scoped)
+
+```python
+list_threads() -> list[dict]
+    # Active + recently archived threads/posts of the handler's HOME channel,
+    # hard cap 50 (active first, then newest-archived), each:
+    # {"thread_id": str, "name": str, "created_at": str, "archived": bool,
+    #  "locked": bool, "owner_id": str, "message_count": int,
+    #  "applied_tag_names": [str]}
+create_thread(name, message_id=None) -> str    # thread id
+    # message_id set: POST /channels/{home}/messages/{message_id}/threads
+    # message_id None: POST /channels/{home}/threads (public thread)
+create_post(title, content, tag_names=None) -> str    # thread id
+    # Forum channels only: POST /channels/{home}/threads with a message payload;
+    # tag_names resolved to ids against the channel's available_tags —
+    # an unknown tag name raises ValueError (loud, fail fast).
+```
+
+`list_threads` spends the new `discord_reads` budget (§5.3); the REST shape is the
+guild active-threads list filtered to the home channel plus
+`GET /channels/{home}/threads/archived/public`, merged under the 50-entry hard cap.
+`create_thread`/`create_post` spend the **existing message budget** (`spend_message`) —
+creating a thread is an emit, and reusing the counter keeps standard handlers bounded
+without new knobs — plus the guild thread-op window (§5.3).
+
+**`send_message` relaxation:** the standard-tier cross-channel gate
+(`handler_runtime.py:_send_message`) is relaxed to also allow posting into **threads of
+the home channel**: when a standard handler targets a channel id that is not its home
+channel, the runtime verifies host-side that the target is a thread whose `parent_id`
+equals the home channel before allowing it; otherwise the existing
+`cross_channel_send` `CapExceeded` is raised unchanged. The parent verification is a
+host rail (one cached channel fetch per fire), **not** metered against `discord_reads`.
+Admin handlers are unaffected (they already send anywhere in the guild).
+
+### 5.2 Admin-only functions (injected only when `actor` is set, like `ban_user`)
+
+```python
+list_threads(channel_id) -> list[dict]   # any channel in the handler's scope
+close_thread(thread_id) -> bool          # PATCH /channels/{id}  {"archived": true}
+lock_thread(thread_id) -> bool           # PATCH /channels/{id}  {"locked": true, "archived": true}
+reopen_thread(thread_id) -> bool         # PATCH /channels/{id}  {"archived": false}
+delete_thread(thread_id) -> bool         # DELETE /channels/{id}
+```
+
+For admin handlers, `list_threads` gains the optional `channel_id` argument (same
+injected name, admin variant shadows the general one): the target must be within the
+handler's `channel_ids` scope (empty scope = any channel in the guild; the runtime
+verifies the channel belongs to the guild). The four mutating functions are
+`AdminActor` REST methods (`smarter_dev/web/admin_actions.py`), spending `thread_ops`
+(§5.3) and the guild thread-op window.
+
+**Gone-target contract (explicit, tested — NOT a blanket except):** a 404 **Unknown
+Channel/Thread/Member** on `close_thread`/`lock_thread`/`reopen_thread`/`delete_thread`
+returns `False` instead of raising — a janitor sweeping stale threads must be a silent
+no-op on a thread someone already deleted. `list_threads(channel_id)` on a 404 Unknown
+Channel returns `[]` (informational read of a gone channel). Any **other** REST failure
+raises `AdminActionError` (fail fast), exactly the lifecycle-E2 `add_role`/`remove_role`
+semantics. `create_thread`/`create_post` **raise** on any failure — a create returns a
+thread id and has nothing sensible to return without one (mirrors staff-comms
+`create_private_thread`).
+
+### 5.3 Budgets & windowed caps
+
+Two new `HandlerBudget` counters (`smarter_dev/web/handler_budget.py`), following the
+existing spend-method pattern:
+
+- **`discord_reads`** / `spend_discord_read()` — spent by `list_threads` (both
+  variants). `DEFAULT_MAX_DISCORD_READS = 2`, `ADMIN_MAX_DISCORD_READS = 5`.
+- **`thread_ops`** / `spend_thread_op()` — spent by
+  `close_thread`/`lock_thread`/`reopen_thread`/`delete_thread`.
+  `DEFAULT_MAX_THREAD_OPS = 0` (standard handlers have no mutating thread ops, like
+  `mod_actions`), `ADMIN_MAX_THREAD_OPS = 10`.
+
+`usage()` and `HandlerRun` gain `discord_reads` and `thread_ops` (migration, §6);
+`admin_budget()` passes the admin maxima.
+
+Windowed cap (`smarter_dev/web/handler_caps.py`): **`GUILD_THREAD_OPS_PER_MIN = 30`**
+on key `hcap:threadop:{guild_id}` (`guild_thread_ops_key`), enforced **in the runtime
+wrapper before the REST call** — breaching raises `CapExceeded` mid-flight, like the
+channel-message window. It covers all six mutating thread operations (`create_thread`,
+`create_post`, close/lock/reopen/delete): creation is the spammy primitive and must not
+escape the guild window just because it spends the message budget.
+
+**Consumed by:** forum triage/janitor handlers (`thread_create` + close/lock/delete);
+staff-comms mod-chat archive/lock flows (via the follow-up reconciliation, §8);
+`create_post` FAQ/announcement flows; `list_threads` duplicate-post detection.
+
+## 6. Schema & migration
+
+**One alembic revision** (repo conventions per `alembic/main/versions/` — dated
+filename, module docstring stating intent, plain `op.*` calls, symmetric `downgrade`):
+
+- Drop and recreate **`ck_admin_handlers_trigger_type`** with the extended tuple:
+  `('message', 'reaction', 'schedule', 'timer', 'member_join', 'member_leave',
+  'member_rules_accepted', 'member_role_change', 'thread_create')`.
+  **`ck_channel_handlers_trigger_type` is UNCHANGED** — the standard tier's vocabulary
+  does not grow (this amends lifecycle E1's migration note, which extended both).
+- Add `handler_runs.discord_reads` and `handler_runs.thread_ops`
+  (`Integer, nullable=False, server_default="0"`), matching the existing counter
+  columns.
+
+`models.py`: `HANDLER_TRIGGER_TYPES` (the standard vocabulary) stays as-is; a new
+`ADMIN_ONLY_TRIGGER_TYPES = ("member_join", "member_leave", "member_rules_accepted",
+"member_role_change", "thread_create")` names the split — the admin constraint/creation
+paths accept the union, the standard create paths reject membership in it, and the
+`active_channels` admin query filters on the extended event-trigger tuple (the standard
+query keeps `HANDLER_EVENT_TRIGGERS` unchanged).
+
+## 7. Authoring & judge
+
+- **Admin author prompt** learns all five trigger types with their context shapes
+  (§3.1), the no-home-channel rule for `member_*` handlers (every `send_message` names a
+  channel constant), and the admin thread functions with the gone-target contract.
+- **Standard author prompt** learns only the general functions (§5.1): `list_threads()`,
+  `create_thread`, `create_post`, and the thread-of-home-channel `send_message`
+  relaxation. It does **not** learn the new triggers — they are not in its vocabulary.
+- **`describe_trigger`** (`smarter_dev/bot/agents/handler_authoring.py:349`) gains
+  honest frequency lines:
+  - `member_join` — "fires on EVERY member join — bursts hard during raids."
+  - `member_leave` — "fires on EVERY member leave — bursts during raids and ban waves."
+  - `member_rules_accepted` — "fires once per member on rules acceptance — may
+    duplicate after cache misses; the script must be idempotent."
+  - `member_role_change` — "fires only when a member's roles actually change — low
+    frequency."
+  - `thread_create` — "fires on EVERY new thread/post in the channel."
+- **Judge rails:**
+  - `delete_thread` targets must come from **trigger context or a `list_threads`
+    result** — never a constant or arithmetic on ids; a hardcoded delete target is an
+    unreviewable destructive action.
+  - A `member_join` handler that messages unconditionally is **spam at raid frequency**
+    and must be rejected unless the target channel is explicitly a join-log.
+  - `member_rules_accepted` handlers must be idempotent (at-least-once delivery, §3.2).
+  - Lifecycle E1's existing rails (role-id literals, etc.) apply unchanged to the
+    handlers that ride these triggers.
+
+## 8. Out of scope / follow-ups
+
+- **`member_ban` / `member_unban` triggers** — moderation-plan territory; not in this
+  family.
+- **`pin_post` / `unpin_post`** and **`set_post_tags`** — further forum ops; add when a
+  consumer demands them (they slot into `thread_ops` cleanly).
+- **Lifecycle E2 (role mutation) and E3 (durable timers)** — already fully specced in
+  `member-lifecycle-and-role-automation.md`; nothing here changes them.
+- **Staff-comms E5 reconciliation** — `create_private_thread`, thread membership ops
+  (`add/remove_thread_member`, `get_thread_members`), and that sketch's
+  `thread_ops`/`GUILD_THREAD_CREATES_PER_MIN` numbers must be reconciled onto this
+  document's `thread_ops` counter and `hcap:threadop` window before mod-chat is built
+  (per the index's build-once rule); this document's budgets and dispatch context are
+  the baseline.
+
+## 9. Implementation order & TDD notes
+
+Red-green per the repo norm; schema via one hand-reviewed alembic revision; semgrep +
+gitleaks before every commit.
+
+1. **Budgets & caps** — `spend_discord_read`/`spend_thread_op` raise at cap (defaults 0
+   thread ops for standard tier); `usage()` includes both; `fires_per_min_for_trigger`
+   pinned at 10 for the five new types; window keys/constants.
+2. **Migration** — extended admin constraint (standard constraint provably unchanged),
+   two `HandlerRun` columns.
+3. **Runtime functions** — general + admin injection split (admin `list_threads`
+   shadows); gone-target 404 ⇒ `False` / `[]`, other failures raise `AdminActionError`;
+   unknown forum tag raises `ValueError`; `send_message` thread relaxation (thread of
+   home channel allowed, unrelated thread still `cross_channel_send`); guild thread-op
+   window breach mid-fire records the cap name.
+4. **Bot dispatch** — pure-function tests for member deltas (per lifecycle E1's list)
+   plus: `member_leave` with cache miss fires with `cache_incomplete: True`;
+   `thread_create` only on `newly_created`; forum post carries tags + starter content
+   (empty string when uncached); thread message dispatches on the parent with
+   `is_thread: True`; non-thread message context carries `is_thread: False`.
+5. **Dispatch endpoint** — `member_*` with `channel_id=""` skips the standard query,
+   bypasses admin scope, and declines past `GUILD_MEMBER_EVENTS_PER_MIN` under a
+   simulated raid; `thread_create` scope-matches on `parent_channel_id`; standard
+   create/update paths reject the five new triggers; `active_channels` surfaces the new
+   guild/channel entries.
+6. **Authoring** — prompt + `describe_trigger` updates with eval cases: unconditional
+   member_join messaging rejected; hardcoded `delete_thread` target rejected.

--- a/docs/v2/feature-parity/threads-and-member-events.md
+++ b/docs/v2/feature-parity/threads-and-member-events.md
@@ -289,6 +289,17 @@ semantics. `create_thread`/`create_post` **raise** on any failure — a create r
 thread id and has nothing sensible to return without one (mirrors staff-comms
 `create_private_thread`).
 
+**Target verification rail (host-side, in `AdminActor`):** every mutating thread op
+first resolves its target with one `GET /channels/{id}` (`_verify_thread_target`,
+cached per fire so a close-then-lock sweep pays one fetch per thread) and requires a
+thread channel type (10/11/12) **in the actor's own guild**. A non-thread target (a
+laundered constant aiming `DELETE /channels/{id}` at a text channel would delete it
+wholesale) or a foreign-guild thread raises `AdminActionError` — loud, erroring the
+fire; a 404 on the verification fetch is the gone-target `False` no-op. Like the
+`send_message` parent check, the fetch is a host rail, **not** metered against
+`discord_reads`. The judge/lint targeting rails (§7) remain the first line; this is
+the structural backstop beneath them.
+
 ### 5.3 Budgets & windowed caps
 
 Two new `HandlerBudget` counters (`smarter_dev/web/handler_budget.py`), following the
@@ -371,12 +382,13 @@ query keeps `HANDLER_EVENT_TRIGGERS` unchanged).
   consumer demands them (they slot into `thread_ops` cleanly).
 - **Lifecycle E2 (role mutation) and E3 (durable timers)** — already fully specced in
   `member-lifecycle-and-role-automation.md`; nothing here changes them.
-- **Staff-comms E5 reconciliation** — `create_private_thread`, thread membership ops
-  (`add/remove_thread_member`, `get_thread_members`), and that sketch's
-  `thread_ops`/`GUILD_THREAD_CREATES_PER_MIN` numbers must be reconciled onto this
-  document's `thread_ops` counter and `hcap:threadop` window before mod-chat is built
-  (per the index's build-once rule); this document's budgets and dispatch context are
-  the baseline.
+- **Staff-comms E5 reconciliation** — **done (2026-07-17)**: that document's E5/E6 now
+  build on this one's `thread_ops` counter, `hcap:threadop` window, and
+  `_verify_thread_target` rail. Remaining deltas live there and ship with mod-chat:
+  the `ADMIN_MAX_THREAD_OPS` 10 → 25 raise, `get_thread_members` metering as
+  `discord_reads`, and the extra `GUILD_THREAD_CREATES_PER_MIN = 2` window on
+  `create_private_thread` (layered on top of the shared 30/min thread-op window). Its
+  E6 is shipped by §4 here (`is_thread` shape).
 
 ## 9. Implementation order & TDD notes
 

--- a/smarter_dev/bot/agents/handler_authoring.py
+++ b/smarter_dev/bot/agents/handler_authoring.py
@@ -30,7 +30,7 @@ from pydantic_ai.providers.google import GoogleProvider
 
 from smarter_dev.shared.config import get_settings
 from smarter_dev.web.handler_lint import lint_script
-from smarter_dev.web.models import HANDLER_TRIGGER_TYPES
+from smarter_dev.web.models import ADMIN_HANDLER_TRIGGER_TYPES, HANDLER_TRIGGER_TYPES
 
 logger = logging.getLogger(__name__)
 
@@ -191,7 +191,9 @@ class AdminHandlerPlan(BaseModel):
         default="", description="Short kebab-case name for a new handler (action='create')"
     )
     trigger_type: str = Field(
-        default="message", description="message | reaction | schedule | timer"
+        default="message",
+        description="message | reaction | schedule | timer | member_join | "
+        "member_leave | member_rules_accepted | member_role_change | thread_create",
     )
     channel_ids: list[str] = Field(
         default_factory=list, description="Channel scope; empty = all channels"
@@ -254,13 +256,16 @@ def _resolve_plan_target(
     trigger_type: str,
     settings: dict,
     existing_handlers: list[dict],
+    allowed_trigger_types: tuple[str, ...] = HANDLER_TRIGGER_TYPES,
 ) -> tuple[str, None] | tuple[None, _ResolvedTarget]:
     """Validate edit-vs-create against the handlers the author was shown.
 
     Returns ``(error, None)`` or ``(None, resolved)``. On edit the target's
     trigger wins (a handler cannot change trigger type) and its settings are
     kept unless the plan supplies new ones. On create the name must be new
-    (case-insensitive) among the existing handlers.
+    (case-insensitive) among the existing handlers, and the trigger must be in
+    ``allowed_trigger_types`` — the standard tier's four, or the admin tier's
+    extended vocabulary (which adds the member/thread event triggers).
     """
     if action == "edit":
         target = next(
@@ -288,7 +293,7 @@ def _resolve_plan_target(
     taken = {h["name"].casefold() for h in existing_handlers}
     if cleaned_name.casefold() in taken:
         return f"a handler named {cleaned_name!r} already exists — the author should edit it", None
-    if trigger_type not in HANDLER_TRIGGER_TYPES:
+    if trigger_type not in allowed_trigger_types:
         return f"the author chose an invalid trigger {trigger_type!r}", None
     return None, _ResolvedTarget(
         action="create",
@@ -374,6 +379,23 @@ def describe_trigger(trigger_type: str, settings: dict) -> str:
         if "fire_at" in settings:
             return f"One-shot: fires a single time at {settings['fire_at']}."
         return "One-shot: fires a single time."
+    if trigger_type == "member_join":
+        return (
+            "Fires on EVERY member join — bursts hard during raids. A handler that "
+            "messages unconditionally here is spam at raid frequency unless the "
+            "target channel is explicitly a join-log."
+        )
+    if trigger_type == "member_leave":
+        return "Fires on EVERY member leave — bursts during raids and ban waves."
+    if trigger_type == "member_rules_accepted":
+        return (
+            "Fires once per member on rules acceptance — may duplicate after cache "
+            "misses; the script must be idempotent."
+        )
+    if trigger_type == "member_role_change":
+        return "Fires only when a member's roles actually change — low frequency."
+    if trigger_type == "thread_create":
+        return "Fires on EVERY new thread/post in the channel."
     return f"Trigger: {trigger_type}."
 
 
@@ -722,6 +744,7 @@ async def run_admin_creation_pipeline(
         trigger_type=plan.trigger_type,
         settings=plan.settings,
         existing_handlers=existing_handlers,
+        allowed_trigger_types=ADMIN_HANDLER_TRIGGER_TYPES,
     )
     if error is not None:
         logger.info("admin plan rejected: %s", error)

--- a/smarter_dev/bot/agents/handler_tools.py
+++ b/smarter_dev/bot/agents/handler_tools.py
@@ -28,7 +28,10 @@ from smarter_dev.web.handler_schedule import ScheduleError, validate_interval
 
 logger = logging.getLogger(__name__)
 
-# The chatbot's trigger_type vocabulary mapped to canonical handler types.
+# The chatbot's trigger_type vocabulary mapped to canonical handler types. The
+# five member/thread event triggers are ADMIN-ONLY (see threads-and-member-events
+# spec) and deliberately absent here — a member cannot register them via the chat
+# tool; _admin_only_trigger routes them to a redirect instead of a bad mapping.
 _TRIGGER_ALIASES = {
     "new message": "message",
     "message": "message",
@@ -37,6 +40,29 @@ _TRIGGER_ALIASES = {
     "schedule": "schedule",
     "timer": "timer",
 }
+
+# Names (canonical and natural-language) for the admin-only member/thread
+# triggers. A member asking for one is pointed at /adminhandler, not told the
+# trigger is unknown — it exists, it's just not theirs to register.
+_ADMIN_ONLY_TRIGGERS = frozenset(
+    {
+        "member_join", "member join", "member joins",
+        "member_leave", "member leave", "member leaves",
+        "member_rules_accepted", "member rules accepted", "rules accepted",
+        "member_role_change", "member role change", "role change",
+        "thread_create", "thread create", "new thread", "forum post",
+    }
+)
+
+_ADMIN_ONLY_REDIRECT = (
+    "that trigger requires an admin handler — ask a server admin to set it up "
+    "via /adminhandler"
+)
+
+
+def _admin_only_trigger(trigger_type: str) -> bool:
+    """Whether this is one of the five admin-only member/thread triggers."""
+    return trigger_type.strip().lower() in _ADMIN_ONLY_TRIGGERS
 
 
 def _api_client(ctx: RunContext[ChatDeps]):
@@ -75,11 +101,15 @@ async def register_handler(
     system (which sees the channel's existing handlers) decides whether to
     edit or create one; you never write code or pick which handler to
     touch. Trigger types: "new message", "reaction add" (event);
-    "schedule", "timer" (time). Put timing in ``settings`` — schedule:
+    "schedule", "timer" (time). Member/thread events (someone joins,
+    leaves, a role changes, a thread is created) are admin-only — they
+    need /adminhandler, not this tool. Put timing in ``settings`` — schedule:
     {"interval_seconds": N} or {"daily_time": "HH:MM"} (UTC); timer:
     {"delay_seconds": N} or {"fire_at": "<ISO-8601 UTC>"}. Returns a
     success summary naming the handler, or an error to relay plainly.
     """
+    if _admin_only_trigger(trigger_type):
+        return f"error: {_ADMIN_ONLY_REDIRECT}"
     canonical = _canonical_trigger(trigger_type)
     if canonical is None:
         return f"error: unknown trigger type {trigger_type!r}"

--- a/smarter_dev/bot/agents/handler_tools.py
+++ b/smarter_dev/bot/agents/handler_tools.py
@@ -100,13 +100,19 @@ async def register_handler(
     Describe the behavior clearly and completely — a separate authoring
     system (which sees the channel's existing handlers) decides whether to
     edit or create one; you never write code or pick which handler to
-    touch. Trigger types: "new message", "reaction add" (event);
-    "schedule", "timer" (time). Member/thread events (someone joins,
-    leaves, a role changes, a thread is created) are admin-only — they
-    need /adminhandler, not this tool. Put timing in ``settings`` — schedule:
-    {"interval_seconds": N} or {"daily_time": "HH:MM"} (UTC); timer:
-    {"delay_seconds": N} or {"fire_at": "<ISO-8601 UTC>"}. Returns a
-    success summary naming the handler, or an error to relay plainly.
+    touch. Include every concrete Discord ID the behavior involves — the
+    user IDs behind any mentions or names, and the channel/thread IDs
+    behind any channel references visible in your context — written as
+    plain snowflakes in the description (e.g. "user 1234567890 (@zech)").
+    The authoring system targets by ID; usernames and channel names alone
+    are ambiguous and go stale. Trigger types: "new message", "reaction
+    add" (event); "schedule", "timer" (time). Member/thread events
+    (someone joins, leaves, a role changes, a thread is created) are
+    admin-only — they need /adminhandler, not this tool. Put timing in
+    ``settings`` — schedule: {"interval_seconds": N} or {"daily_time":
+    "HH:MM"} (UTC); timer: {"delay_seconds": N} or {"fire_at": "<ISO-8601
+    UTC>"}. Returns a success summary naming the handler, or an error to
+    relay plainly.
     """
     if _admin_only_trigger(trigger_type):
         return f"error: {_ADMIN_ONLY_REDIRECT}"

--- a/smarter_dev/bot/agents/prompts/admin_handler_author.md
+++ b/smarter_dev/bot/agents/prompts/admin_handler_author.md
@@ -175,6 +175,14 @@ a function but never call it, NOTHING happens. Example skeleton:
 - Decide channel scope. channel_ids = [] means ALL channels in the guild; otherwise the specific
   channel ids. Use the `list_channels` tool to resolve channel names (e.g. "mod-chat") to ids —
   for the scope AND for any send_message(channel_id=...) target. Never invent ids.
+- TARGET BY ID, NEVER BY NAME. When the behavior singles out a known user, channel, or thread,
+  compare snowflake ids — context["author_id"]/context["member_id"] == "1234567890", a channel id
+  resolved via list_channels — never usernames, display names, or channel names. Names change,
+  collide, and can be spoofed by renaming; ids are stable. The request should state user ids
+  (e.g. "user 1234567890 (@zech)"); if it targets a specific user but gives no id, set
+  feasible=false asking for the id rather than guessing from a name. This matters double for
+  moderation: a display-name gate on ban/kick/timeout targets the wrong person the day someone
+  renames.
 - Put CHEAP guards FIRST (e.g. check account/join age, keyword match) so expensive work
   (spawn_agent, web reads, deletes) only runs when warranted. A guild-wide message handler runs on
   every message — keep the common path cheap.

--- a/smarter_dev/bot/agents/prompts/admin_handler_author.md
+++ b/smarter_dev/bot/agents/prompts/admin_handler_author.md
@@ -50,8 +50,44 @@ One input variable `context: dict` describes the trigger:
               tracked message in this guild), context["author_days_since_last_message"] (whole
               days since their previous message; null on first),
               context["author_last_message_at"] (ISO or null).
+              THREADS: when the message was typed INSIDE a thread, context["is_thread"] is true and
+              context["thread_id"] / context["thread_name"] identify it; the handler still fires on
+              the thread's PARENT channel, so send_message() posts to the parent — reply into the
+              thread with send_message(text, context["thread_id"]). Non-thread messages carry
+              context["is_thread"] == false.
   "reaction": context["reaction_emoji"], context["reaction_message_id"], context["reaction_user_id"].
   "schedule"/"timer": no extra keys.
+
+MEMBER & THREAD EVENT TRIGGERS (admin-only — these five triggers exist ONLY for admin handlers).
+The four member_* triggers are GUILD-scoped and have NO home channel: send_message(content) with no
+channel_id FAILS on these, so every send MUST name a channel constant (resolve it with list_channels).
+Leave channel_ids EMPTY for the member_* triggers (a member event has no channel to scope to).
+  "member_join":  context["member_id"], context["username"], context["display_name"],
+              context["is_bot"], context["account_created_at"] (ISO), context["has_custom_avatar"],
+              context["guild_member_count"], context["guild_human_member_count"].
+  "member_leave": context["member_id"], context["username"], context["display_name"],
+              context["is_bot"], context["account_created_at"] (ISO, always present),
+              context["joined_at"] (ISO or null on cache miss), context["role_ids"],
+              context["role_names"] (may be empty), context["cache_incomplete"] (true when history
+              was not cached — a leave notice with partial detail, never a skip).
+  "member_rules_accepted": context["member_id"], context["username"], context["display_name"],
+              context["nickname"] (or null), context["account_created_at"], context["has_custom_avatar"],
+              context["joined_at"]. May fire more than once per member after a cache miss — the
+              handler MUST be idempotent (guard so a repeat fire is harmless).
+  "member_role_change": context["member_id"], context["member_display_name"],
+              context["added_role_ids"], context["added_role_names"], context["removed_role_ids"],
+              context["removed_role_names"], context["is_boost_role_added"],
+              context["premium_subscription_count"], context["boosting_member_count"],
+              context["role_member_counts"] (dict of role_id -> count).
+  "thread_create": context["thread_id"], context["thread_name"], context["parent_channel_id"],
+              context["creator_id"], context["creator_username"], context["creator_display_name"],
+              context["is_forum_post"] (true when the parent is a forum channel),
+              context["applied_tag_ids"], context["applied_tag_names"],
+              context["starter_message_content"] (forum posts; may be "" when uncached),
+              context["created_at"]. Fires for BOTH regular threads and forum posts; the fire's home
+              channel is the PARENT, so send_message(content) posts to the parent and
+              send_message(content, context["thread_id"]) posts into the new thread. Scope
+              thread_create handlers by channel_ids on the PARENT channel(s), or empty for all.
 
 Provided async functions — you MUST `await` every call:
   await send_message(content: str, channel_id: str = None) -> str
@@ -68,6 +104,24 @@ Provided async functions — you MUST `await` every call:
   await ban_user(user_id: str, reason: str = None) -> str
   await kick_user(user_id: str) -> str
   await timeout_user(user_id: str, duration_seconds: int = 600) -> str
+  THREADS:
+  await list_threads(channel_id: str = None) -> list[dict]
+      Active + recently-archived threads/posts of `channel_id` (any channel in your scope; omit for
+      the handler's home channel). Each: {"thread_id", "name", "created_at", "archived", "locked",
+      "owner_id", "message_count", "applied_tag_names"}. A gone channel returns []. Costs a
+      discord-read (cap 5/fire) — call it once and iterate, never per-item.
+  await create_thread(name: str, message_id: str = None) -> str   # returns the new thread id
+      message_id set: spins a thread off that message; omitted: a public thread on the home channel.
+  await create_post(title: str, content: str, tag_names: list = None) -> str   # forum post thread id
+      Forum channels only; tag_names must be real tags of the channel — an unknown name RAISES.
+  await close_thread(thread_id: str) -> bool     # archive it
+  await lock_thread(thread_id: str) -> bool      # lock + archive
+  await reopen_thread(thread_id: str) -> bool    # unarchive
+  await delete_thread(thread_id: str) -> bool    # PERMANENT — no undo
+      close/lock/reopen/delete return False (a silent no-op) when the thread is already gone (404), so
+      a janitor sweeping stale threads is safe; any OTHER failure raises. create_thread/create_post
+      RAISE on any failure (they must return an id). Thread mutations cost a thread-op (cap 10/fire)
+      and draw on the guild thread-op window; create_thread/create_post also spend the message budget.
   PERSISTENT MEMORY (survives across fires; private to this handler; starts empty):
   await memory_get(key: str, default=None)   -> stored value or default
   await memory_set(key: str, value) -> True  -> store JSON-serializable value (ONLY this persists)
@@ -83,6 +137,8 @@ Provided async functions — you MUST `await` every call:
 
 ## Per-fire limits (admin tier)
 - 5 messages, 25 moderation actions, 3 agent calls, 32 KB context into an agent, 120 s wall-clock.
+- 5 discord-reads (list_threads), 10 thread-ops (create/close/lock/reopen/delete thread). A guild
+  thread-op window also caps thread ops server-wide — don't fan out creates/deletes in a loop.
 - ~8 KB total script length.
 
 ## Script structure
@@ -100,7 +156,22 @@ a function but never call it, NOTHING happens. Example skeleton:
 - Decide the trigger_type. "read any message…", "when someone…" → "message". Reactions →
   "reaction". Recurring/at-a-time → "schedule"/"timer" (put timing in settings: schedule
   {"interval_seconds": N} or {"daily_time": "HH:MM"} UTC; timer {"delay_seconds": N} or
-  {"fire_at": ISO}).
+  {"fire_at": ISO}). "when someone joins" → "member_join"; "when someone leaves/is banned" →
+  "member_leave"; "when a member accepts the rules / passes the gate" → "member_rules_accepted";
+  "when someone gets/loses a role (or boosts)" → "member_role_change"; "when a thread or forum post
+  is created" → "thread_create". Leave channel_ids EMPTY for the four member_* triggers.
+- MEMBER EVENTS HAVE NO HOME CHANNEL. On a member_* trigger, send_message(content) with no
+  channel_id FAILS — every send must name a channel constant (resolve names via list_channels).
+- RAID FREQUENCY. member_join and member_leave fire on EVERY join/leave and burst during raids and
+  ban waves — never emit unconditionally on member_join. Only build an unconditional join message
+  when the admin explicitly wants a JOIN-LOG channel; otherwise guard hard (account age, no avatar,
+  a specific role) so the common join is silent.
+- IDEMPOTENCE. member_rules_accepted can fire more than once per member (cache misses). Make the
+  action safe to repeat — record what you've done in memory (a bounded, pruned set) or check
+  context so a duplicate fire is a no-op.
+- DELETE_THREAD DISCIPLINE. A delete_thread / close_thread / lock_thread target MUST come from
+  trigger context (context["thread_id"]) or a list_threads result — NEVER a hardcoded id literal or
+  id arithmetic. A hardcoded destructive target is unreviewable and will be rejected.
 - Decide channel scope. channel_ids = [] means ALL channels in the guild; otherwise the specific
   channel ids. Use the `list_channels` tool to resolve channel names (e.g. "mod-chat") to ids —
   for the scope AND for any send_message(channel_id=...) target. Never invent ids.

--- a/smarter_dev/bot/agents/prompts/admin_handler_judge.md
+++ b/smarter_dev/bot/agents/prompts/admin_handler_judge.md
@@ -12,12 +12,18 @@ still hide an unbounded memory key. Walk ALL categories even after finding a fai
    reset is NOT pruning if the structure can grow past the cap BETWEEN resets on a busy guild.
 4. `guards_effective` — cheap guards run before expensive work AND actually filter. Trace each
    guard: a condition that is true for essentially every message (e.g. `author_joined_at`, which
-   is set for every member) is a broken guard even if the code looks defensive.
+   is set for every member) is a broken guard even if the code looks defensive. On a `member_join`
+   handler (fires on EVERY join, bursts during raids) a handler that emits with no guard is
+   effectively unconditional — fail this unless the target is explicitly a join-log channel.
 5. `agent_verdict_safe` — if a spawn_agent reply gates any action: the check must be anchored
    (startswith/exact — reject `"X" in reply`), and member content must be delimited and marked
    untrusted. Set true when no agent reply gates anything.
 6. `actions_appropriate` — ban/kick only for new/untrusted accounts on clear evidence;
-   established members (including long-dormant ones) get delete/timeout + a mod report.
+   established members (including long-dormant ones) get delete/timeout + a mod report. Thread
+   ops fit the same test: `delete_thread` is irreversible, so its target MUST come from trigger
+   context or a `list_threads` result — a hardcoded thread-id literal or id arithmetic is an
+   unreviewable destructive action; fail this and say so. An unconditional emit on `member_join`
+   (raid frequency) is spam here unless the destination is explicitly a join-log.
 7. `transparent` — no encoded or opaque blobs anywhere.
 
 You are given a "Trigger context" line describing how often the handler runs. Judge the script
@@ -72,6 +78,22 @@ literal loops/fan-outs that blow these (e.g. banning in an unbounded loop, loopi
 - Disproportionate automation: auto-banning ESTABLISHED members (not new accounts / first-time
   posters) on a model verdict alone. For that cohort expect delete + timeout + a mod-channel
   report instead; reject and say so.
+
+## Reject unsafe member/thread-event handlers
+The five member/thread triggers (`member_join`, `member_leave`, `member_rules_accepted`,
+`member_role_change`, `thread_create`) are admin-only. Judge them against their frequency:
+- Raid-frequency spam: `member_join` (and `member_leave`) fire on EVERY join/leave and burst during
+  raids and ban waves. Reject a `member_join` handler that messages unconditionally — it floods a
+  channel during a raid — UNLESS the target is explicitly a join-log channel. Expect a real guard
+  (account age, missing avatar, a specific role) that makes the common join silent.
+- Non-idempotent rules handlers: `member_rules_accepted` uses at-least-once delivery and can fire
+  more than once per member after a cache miss. Reject a handler whose action isn't safe to repeat
+  (e.g. it hands out a one-time reward or posts a welcome with no dedupe guard).
+- Hardcoded destructive thread targets: a `delete_thread` (or close/lock) target must come from
+  trigger context or a `list_threads` result — reject a hardcoded thread-id literal or id
+  arithmetic as an unreviewable destructive action.
+- No home channel on member events: the four `member_*` triggers have no home channel, so a bare
+  `send_message(content)` with no channel_id would fail at runtime. Every send must name a channel.
 
 Approve only if you can read everything the script does, it stays within the admin limits, gates
 destructive actions on sensible conditions, and does nothing unsafe.

--- a/smarter_dev/bot/agents/prompts/admin_handler_judge.md
+++ b/smarter_dev/bot/agents/prompts/admin_handler_judge.md
@@ -92,6 +92,11 @@ The five member/thread triggers (`member_join`, `member_leave`, `member_rules_ac
 - Hardcoded destructive thread targets: a `delete_thread` (or close/lock) target must come from
   trigger context or a `list_threads` result — reject a hardcoded thread-id literal or id
   arithmetic as an unreviewable destructive action.
+- Name-based targeting of a specific person or channel: when the behavior singles out a known
+  user/channel, the script must compare snowflake ids (`context["author_id"]`,
+  `context["member_id"]`, a channel-id constant) — reject gates on usernames, display names, or
+  channel names (names change, collide, and can be spoofed by renaming). This is a hard fail when
+  the name gate feeds ban/kick/timeout/delete.
 - No home channel on member events: the four `member_*` triggers have no home channel, so a bare
   `send_message(content)` with no channel_id would fail at runtime. Every send must name a channel.
 

--- a/smarter_dev/bot/agents/prompts/chat_agent.md
+++ b/smarter_dev/bot/agents/prompts/chat_agent.md
@@ -288,7 +288,10 @@ write code; timing goes in `settings` for time triggers),
 - One message/reaction handler per channel (registering again merges with or
   replaces it); each schedule/timer registration is its own handler.
 - Pass a clear, complete description — the author only sees what you write,
-  not the conversation.
+  not the conversation. That includes IDs: resolve any mentioned users or
+  referenced channels/threads to their snowflake IDs from your context and
+  write them into the description (e.g. "user 1234567890 (@zech)") — the
+  author targets by ID and cannot look up who "@zech" is.
 - On error, tell the member what actually happened from the returned reason
   (own words fine) — never invent a different cause; the reason is ground
   truth.

--- a/smarter_dev/bot/agents/prompts/handler_author.md
+++ b/smarter_dev/bot/agents/prompts/handler_author.md
@@ -145,6 +145,12 @@ When a spawn_agent reply decides what the script does next:
 - Put any matching logic (does this message contain "huzzah"?) in the script itself, with cheap
   guards FIRST, before any expensive call, so an agent or web-read only runs when it should.
   This matters most for message/reaction triggers, which fire constantly.
+- TARGET BY ID, NEVER BY NAME. When the behavior singles out a known user or channel/thread,
+  compare snowflake ids — context["author_id"] == "1234567890", a channel/thread id constant —
+  never context["author_name"], display names, or channel names. Names change, collide, and can
+  be spoofed by renaming; ids are stable. The request should state the ids (e.g. "user
+  1234567890 (@zech)"); if it targets a specific user but gives no id, set feasible=false asking
+  for the id rather than guessing from a name.
 - Use only real emoji from the provided list (call list_channel_emojis to see them).
 - When editing, the returned script REPLACES the target's script wholesale — carry forward the
   behavior the edit doesn't touch, and the result must still satisfy every limit; if it can't,

--- a/smarter_dev/bot/agents/prompts/handler_author.md
+++ b/smarter_dev/bot/agents/prompts/handler_author.md
@@ -49,6 +49,11 @@ One input variable is provided:
                 context["author_id"], context["author_name"],
                 context["attachments"] — files posted with the message, each
                 {"url", "content_type", "filename"} (empty list if none)
+                THREADS: context["is_thread"] is true when the message was typed
+                inside a thread of this channel (with context["thread_id"] and
+                context["thread_name"]); false otherwise. The handler still runs
+                on the parent channel, so send_message() posts to the parent —
+                to reply INTO the thread, pass send_message(text, context["thread_id"]).
                 ACTIVITY FACTS (platform-tracked — use these instead of keeping
                 your own per-user records in memory):
                 context["author_is_first_message"] — true when this is the
@@ -62,11 +67,25 @@ One input variable is provided:
 
 These async functions are provided — you MUST `await` every call:
 
-  await send_message(content: str) -> str
+  await send_message(content: str, channel_id: str = None) -> str
       Post a message to the channel. Returns the new message's id (use it if you
-      then want to react to your own message).
+      then want to react to your own message). You may pass channel_id ONLY to
+      post into a THREAD of this channel (e.g. context["thread_id"], or a
+      thread id from list_threads) — any other channel is rejected. Omit
+      channel_id to post to the channel itself.
   await add_reaction(message_id: str, emoji: str) -> bool
       Add a reaction to a message. Custom emoji: pass "name:id". Unicode: pass the character.
+  await list_threads() -> list[dict]
+      Active + recently-archived threads/posts of THIS channel (hard cap 50), each
+      {"thread_id", "name", "created_at", "archived", "locked", "owner_id",
+      "message_count", "applied_tag_names"}. Use it to find a thread to post into
+      or to detect duplicates before creating one.
+  await create_thread(name: str, message_id: str = None) -> str   # returns the new thread id
+      Start a thread on this channel — off message_id if given, else a standalone
+      public thread. Counts as a message emit (see the caps).
+  await create_post(title: str, content: str, tag_names: list = None) -> str   # forum post id
+      FORUM channels only: open a forum post. tag_names must be real tags of the
+      channel — an unknown name errors. Counts as a message emit.
   await post_voice(text: str) -> bool
       Post a voice message (may be unavailable — prefer send_message).
   await spawn_agent(prompt: str, has_tools: bool = False) -> str
@@ -102,7 +121,7 @@ Only your script can emit to the channel (send_message / add_reaction / post_voi
 direct web access from the script — gather only by calling spawn_agent.
 
 ## Hard limits — a script may not exceed, per single firing:
-- 3 messages sent (send_message / add_reaction / post_voice all count)
+- 3 messages sent (send_message / add_reaction / post_voice / create_thread / create_post all count)
 - 3 web searches and 3 web reads — these are SHARED with any agents you spawn (an agent that
   reads 2 pages leaves you 1)
 - 2 agent calls (spawn_agent)

--- a/smarter_dev/bot/agents/prompts/handler_judge.md
+++ b/smarter_dev/bot/agents/prompts/handler_judge.md
@@ -48,7 +48,9 @@ is correct; do not flag them as undefined, and DO reject a script that does `imp
 ## Reject if the script would exceed the limits
 Per single firing: >3 messages, >3 searches, >3 reads (searches and reads are shared with spawned
 agents), more than 2 agent calls. Reject literal loops or fan-outs that blow these (sending in a
-loop, looping agent calls).
+loop, looping agent calls). `create_thread` and `create_post` are emits too — they count toward the
+3-message cap alongside send_message / add_reaction / post_voice, so a script that creates threads
+in a loop blows the cap the same way sending in a loop does.
 
 ## Reject if the script is abusive
 - Exfiltration: sending channel/message data to a hardcoded external destination (webhook/URL);

--- a/smarter_dev/bot/agents/prompts/handler_judge.md
+++ b/smarter_dev/bot/agents/prompts/handler_judge.md
@@ -72,6 +72,10 @@ in a loop blows the cap the same way sending in a loop does.
   anchored (`reply.strip().startswith(...)` or an exact match). Reject a substring test like
   `"MATCH" in reply` — the agent answering "no match" satisfies it and the script takes the
   wrong branch.
+- Name-based user gates: a script that singles out a specific known person must compare
+  `context["author_id"]` against a snowflake id constant, never `context["author_name"]` or a
+  display name — the day that person (or an impostor) renames, the gate targets the wrong
+  people. Reject name comparisons where a known individual is clearly intended.
 
 ## Reject if the handler would be annoying (frequency × value)
 Weigh how often it runs against how useful each run is. A member shares this channel with others.

--- a/smarter_dev/bot/plugins/handler_events.py
+++ b/smarter_dev/bot/plugins/handler_events.py
@@ -164,13 +164,351 @@ async def _dispatch(
         logger.debug("handler dispatch failed", exc_info=True)
 
 
+# Channel types that are threads (dispatch keys off their PARENT channel).
+_THREAD_CHANNEL_TYPES = (
+    hikari.ChannelType.GUILD_PUBLIC_THREAD,
+    hikari.ChannelType.GUILD_PRIVATE_THREAD,
+    hikari.ChannelType.GUILD_NEWS_THREAD,
+)
+
+
+def _has_custom_avatar(entity: Any) -> bool:
+    """True when the user set a non-default avatar (global or per-guild)."""
+    return (
+        getattr(entity, "avatar_hash", None) is not None
+        or getattr(entity, "guild_avatar_hash", None) is not None
+    )
+
+
+def _iso_or_none(value: Any) -> str | None:
+    """ISO-8601 string for a datetime, or None when absent."""
+    return value.isoformat() if value is not None else None
+
+
+def _roles_beyond_everyone(member: Any) -> list[str]:
+    """Role ids a member actually holds, excluding @everyone.
+
+    hikari always appends the @everyone role — whose id equals the guild id — to
+    ``Member.role_ids``, so it is never a real role for rules-acceptance or
+    leave-notice purposes and must be filtered out before either reasons about
+    "roles held".
+    """
+    everyone_role_id = str(getattr(member, "guild_id", "") or "")
+    return [str(role_id) for role_id in member.role_ids if str(role_id) != everyone_role_id]
+
+
+# ---------------------------------------------------------------------------
+# Member-event context builders (pure — unit-testable without a gateway)
+# ---------------------------------------------------------------------------
+
+
+def guild_member_counts(guild: Any) -> tuple[int | None, int | None]:
+    """(total, human) member counts from the gateway cache, best-effort.
+
+    Returns (None, None) when the guild is not cached; the human count is
+    derived from the cached member view and may lag a large guild.
+    """
+    if guild is None:
+        return None, None
+    total = getattr(guild, "member_count", None)
+    members = guild.get_members()
+    human = (
+        sum(1 for m in members.values() if not m.is_bot) if members else None
+    )
+    return total, human
+
+
+def member_join_context(
+    member: Any, guild_member_count: int | None, guild_human_member_count: int | None
+) -> dict:
+    """member_join context (fires for bots too, flagged is_bot)."""
+    return {
+        "trigger_type": "member_join",
+        "member_id": str(member.id),
+        "username": member.username,
+        "display_name": member.display_name,
+        "is_bot": bool(member.is_bot),
+        "account_created_at": _snowflake_created_at(int(member.id)),
+        "has_custom_avatar": _has_custom_avatar(member),
+        "guild_member_count": guild_member_count,
+        "guild_human_member_count": guild_human_member_count,
+    }
+
+
+def member_leave_context(user: Any, old_member: Any, role_names: list[str]) -> dict:
+    """member_leave context; informational — fires always, partial on cache miss.
+
+    On cache miss (``old_member`` is None) the join history and roles are
+    unknown, so ``joined_at``/``role_ids``/``role_names`` are empty and
+    ``cache_incomplete`` is True. ``account_created_at`` is always available
+    from the snowflake.
+    """
+    cache_incomplete = old_member is None
+    joined_at = None
+    role_ids: list[str] = []
+    if old_member is not None:
+        joined_at = _iso_or_none(old_member.joined_at)
+        role_ids = _roles_beyond_everyone(old_member)
+    return {
+        "trigger_type": "member_leave",
+        "member_id": str(user.id),
+        "username": user.username,
+        "display_name": getattr(user, "display_name", None) or user.username,
+        "is_bot": bool(user.is_bot),
+        "account_created_at": _snowflake_created_at(int(user.id)),
+        "joined_at": joined_at,
+        "role_ids": role_ids,
+        "role_names": role_names,
+        "cache_incomplete": cache_incomplete,
+    }
+
+
+def _rules_accepted_context(member: Any) -> dict:
+    return {
+        "trigger_type": "member_rules_accepted",
+        "member_id": str(member.id),
+        "username": member.username,
+        "display_name": member.display_name,
+        "nickname": member.nickname,
+        "account_created_at": _snowflake_created_at(int(member.id)),
+        "has_custom_avatar": _has_custom_avatar(member),
+        "joined_at": _iso_or_none(member.joined_at),
+    }
+
+
+def _became_rules_accepted(old_member: Any, new_member: Any) -> bool:
+    """Whether this update is the member's rules-acceptance moment.
+
+    With cached history: fires on the pending True -> False transition. On
+    cache miss uses the at-least-once heuristic — fire iff the member is not
+    pending and holds no roles beyond @everyone (role_ids excludes @everyone).
+    Duplicate fires are possible on cache misses; handlers must be idempotent.
+    """
+    if new_member.is_pending:
+        return False
+    if old_member is None:
+        return not _roles_beyond_everyone(new_member)
+    return bool(old_member.is_pending)
+
+
+def member_update_deltas(old_member: Any, new_member: Any) -> list[tuple[str, dict]]:
+    """Which member_* triggers a MemberUpdate fires, with pure (id-level) context.
+
+    Returns a list of (trigger_type, context) pairs. ``member_role_change``
+    contexts carry only the id-level delta here; the listener enriches them
+    with guild-derived role names, boost flags, and counts. A cache miss (no
+    ``old_member``) yields no role_change delta — the structural boost re-fire
+    guard.
+    """
+    deltas: list[tuple[str, dict]] = []
+    if _became_rules_accepted(old_member, new_member):
+        deltas.append(("member_rules_accepted", _rules_accepted_context(new_member)))
+    if old_member is not None:
+        old_ids = {str(r) for r in old_member.role_ids}
+        new_ids = {str(r) for r in new_member.role_ids}
+        added = [str(r) for r in new_member.role_ids if str(r) not in old_ids]
+        removed = [str(r) for r in old_member.role_ids if str(r) not in new_ids]
+        if added or removed:
+            deltas.append(
+                (
+                    "member_role_change",
+                    {
+                        "trigger_type": "member_role_change",
+                        "member_id": str(new_member.id),
+                        "member_display_name": new_member.display_name,
+                        "added_role_ids": added,
+                        "removed_role_ids": removed,
+                    },
+                )
+            )
+    return deltas
+
+
+def resolve_role_names(guild: Any, role_ids: list[str]) -> list[str]:
+    """Resolve role ids to names via the guild cache; empty when guild uncached.
+
+    An id whose role is not cached falls back to the id string so a name list
+    is never silently short.
+    """
+    if guild is None:
+        return []
+    names: list[str] = []
+    for role_id in role_ids:
+        role = guild.get_role(int(role_id))
+        names.append(role.name if role is not None else str(role_id))
+    return names
+
+
+def _includes_boost_role(guild: Any, role_ids: list[str]) -> bool:
+    if guild is None:
+        return False
+    for role_id in role_ids:
+        role = guild.get_role(int(role_id))
+        if role is not None and getattr(role, "is_premium_subscriber_role", False):
+            return True
+    return False
+
+
+def _boosting_member_count(guild: Any) -> int | None:
+    if guild is None:
+        return None
+    members = guild.get_members()
+    if not members:
+        return None
+    return sum(
+        1 for m in members.values() if getattr(m, "premium_since", None) is not None
+    )
+
+
+def _role_member_counts(guild: Any, role_ids: set[str]) -> dict[str, int]:
+    if guild is None:
+        return {}
+    members = guild.get_members()
+    counts: dict[str, int] = {}
+    for role_id in role_ids:
+        target = int(role_id)
+        counts[str(role_id)] = sum(
+            1 for m in members.values() if target in {int(r) for r in m.role_ids}
+        )
+    return counts
+
+
+def enrich_role_change_context(
+    context: dict, old_member: Any, new_member: Any, guild: Any
+) -> dict:
+    """Add guild-derived role names, boost flag, and counts to a role_change ctx.
+
+    Pure: returns a new dict, leaving ``context`` untouched.
+    """
+    added_ids = context["added_role_ids"]
+    removed_ids = context["removed_role_ids"]
+    return {
+        **context,
+        "added_role_names": resolve_role_names(guild, added_ids),
+        "removed_role_names": resolve_role_names(guild, removed_ids),
+        "is_boost_role_added": _includes_boost_role(guild, added_ids),
+        "premium_subscription_count": (
+            getattr(guild, "premium_subscription_count", None)
+            if guild is not None
+            else None
+        ),
+        "boosting_member_count": _boosting_member_count(guild),
+        "role_member_counts": _role_member_counts(
+            guild, set(added_ids) | set(removed_ids)
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
+# thread_create context + helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_forum_channel(channel: Any) -> bool:
+    return (
+        channel is not None
+        and getattr(channel, "type", None) == hikari.ChannelType.GUILD_FORUM
+    )
+
+
+def _is_thread_channel(channel: Any) -> bool:
+    return channel is not None and getattr(channel, "type", None) in _THREAD_CHANNEL_TYPES
+
+
+def _resolve_forum_tag_names(forum_channel: Any, tag_ids: list[str]) -> list[str]:
+    """Map applied tag ids to names against a forum channel's available tags."""
+    if forum_channel is None or not tag_ids:
+        return []
+    tag_names_by_id = {
+        str(tag.id): tag.name
+        for tag in getattr(forum_channel, "available_tags", None) or []
+    }
+    return [tag_names_by_id.get(tag_id, tag_id) for tag_id in tag_ids]
+
+
+def thread_create_context(
+    thread: Any,
+    creator: Any,
+    starter_message_content: str,
+    is_forum_post: bool,
+    applied_tag_names: list[str],
+) -> dict:
+    """thread_create context (regular threads and forum posts alike)."""
+    return {
+        "trigger_type": "thread_create",
+        "thread_id": str(thread.id),
+        "thread_name": thread.name,
+        "parent_channel_id": str(thread.parent_id),
+        "creator_id": str(thread.owner_id) if thread.owner_id is not None else "",
+        "creator_username": creator.username if creator is not None else "",
+        "creator_display_name": (
+            getattr(creator, "display_name", None) or creator.username
+            if creator is not None
+            else ""
+        ),
+        "is_forum_post": is_forum_post,
+        "applied_tag_ids": [str(t) for t in getattr(thread, "applied_tag_ids", None) or []],
+        "applied_tag_names": applied_tag_names,
+        "starter_message_content": starter_message_content,
+        "created_at": _iso_or_none(getattr(thread, "created_at", None)) or "",
+    }
+
+
+def message_thread_fields(thread_channel: Any) -> dict:
+    """Extra message-context fields naming the enclosing thread (or is_thread=False)."""
+    if thread_channel is None:
+        return {"is_thread": False}
+    return {
+        "is_thread": True,
+        "thread_id": str(thread_channel.id),
+        "thread_name": thread_channel.name,
+    }
+
+
+def _get_guild_channel(bot: Any, channel_id: Any) -> Any:
+    try:
+        return bot.cache.get_guild_channel(channel_id)
+    except Exception:  # noqa: BLE001 — a cache miss must never crash dispatch
+        return None
+
+
+def _get_thread_channel(bot: Any, channel_id: Any) -> Any:
+    # Threads live behind cache.get_thread() — get_guild_channel() never returns
+    # them — so a message's channel is resolved here, not via _get_guild_channel.
+    try:
+        channel = bot.cache.get_thread(channel_id)
+    except Exception:  # noqa: BLE001 — a cache miss must never crash dispatch
+        return None
+    return channel if _is_thread_channel(channel) else None
+
+
+def _get_thread_creator(bot: Any, guild_id: Any, owner_id: Any) -> Any:
+    if owner_id is None:
+        return None
+    try:
+        member = bot.cache.get_member(guild_id, owner_id)
+        if member is not None:
+            return member
+        return bot.cache.get_user(owner_id)
+    except Exception:  # noqa: BLE001 — best-effort creator resolution
+        return None
+
+
+def _get_starter_message_content(bot: Any, message_id: Any) -> str:
+    # For a forum post the starter message's id equals the thread's id.
+    try:
+        message = bot.cache.get_message(message_id)
+    except Exception:  # noqa: BLE001 — starter content is best-effort
+        return ""
+    return getattr(message, "content", None) or "" if message is not None else ""
+
+
 @plugin.listener(hikari.StartedEvent)
 async def start_activity_flush(_: hikari.StartedEvent) -> None:
     asyncio.create_task(_activity.run(_get_api_client()))
 
 
-@plugin.listener(hikari.GuildMessageCreateEvent)
-async def on_message(event: hikari.GuildMessageCreateEvent) -> None:
+async def dispatch_message(bot: Any, event: Any) -> None:
     # Only user actions fire triggers.
     if not event.is_human:
         return
@@ -191,24 +529,98 @@ async def on_message(event: hikari.GuildMessageCreateEvent) -> None:
         }
         for a in msg.attachments
     ]
-    await _dispatch(
-        str(event.channel_id),
-        str(event.guild_id),
-        "message",
-        {
-            "trigger_type": "message",
-            "message_content": msg.content or "",
-            "message_id": str(msg.id),
-            "author_id": str(msg.author.id),
-            "author_name": msg.author.username,
-            # For admin handlers that gate on new accounts / recent joiners.
-            "author_account_created_at": _snowflake_created_at(int(msg.author.id)),
-            "author_joined_at": joined_at,
-            # Files posted with the message — scripts can read these via the
-            # gathering agent's web_read tool (it handles image/pdf/audio urls).
-            "attachments": attachments,
-        },
+    thread_channel = _get_thread_channel(bot, event.channel_id)
+    context = {
+        "trigger_type": "message",
+        "message_content": msg.content or "",
+        "message_id": str(msg.id),
+        "author_id": str(msg.author.id),
+        "author_name": msg.author.username,
+        # For admin handlers that gate on new accounts / recent joiners.
+        "author_account_created_at": _snowflake_created_at(int(msg.author.id)),
+        "author_joined_at": joined_at,
+        # Files posted with the message — scripts can read these via the
+        # gathering agent's web_read tool (it handles image/pdf/audio urls).
+        "attachments": attachments,
+        **message_thread_fields(thread_channel),
+    }
+    # A message inside a thread dispatches to the thread's PARENT channel (a
+    # single fire whose home channel is the parent, §4); a non-thread message
+    # dispatches to its own channel. Either way it's exactly one dispatch.
+    dispatch_channel_id = (
+        str(thread_channel.parent_id)
+        if thread_channel is not None
+        else str(event.channel_id)
     )
+    await _dispatch(dispatch_channel_id, str(event.guild_id), "message", context)
+
+
+@plugin.listener(hikari.GuildMessageCreateEvent)
+async def on_message(event: hikari.GuildMessageCreateEvent) -> None:
+    await dispatch_message(plugin.bot, event)
+
+
+@plugin.listener(hikari.MemberCreateEvent)
+async def on_member_join(event: hikari.MemberCreateEvent) -> None:
+    total, human = guild_member_counts(event.get_guild())
+    context = member_join_context(event.member, total, human)
+    # Guild-scoped: no home channel (channel_id="").
+    await _dispatch("", str(event.guild_id), "member_join", context)
+
+
+@plugin.listener(hikari.MemberDeleteEvent)
+async def on_member_leave(event: hikari.MemberDeleteEvent) -> None:
+    guild = event.get_guild()
+    old_member = event.old_member
+    # Resolve names for the same @everyone-filtered set the context reports, so
+    # role_ids and role_names stay aligned.
+    role_names = (
+        resolve_role_names(guild, _roles_beyond_everyone(old_member))
+        if old_member is not None
+        else []
+    )
+    context = member_leave_context(event.user, old_member, role_names)
+    await _dispatch("", str(event.guild_id), "member_leave", context)
+
+
+@plugin.listener(hikari.MemberUpdateEvent)
+async def on_member_update(event: hikari.MemberUpdateEvent) -> None:
+    guild = event.get_guild()
+    for trigger_type, context in member_update_deltas(event.old_member, event.member):
+        if trigger_type == "member_role_change":
+            context = enrich_role_change_context(
+                context, event.old_member, event.member, guild
+            )
+        await _dispatch("", str(event.guild_id), trigger_type, context)
+
+
+async def dispatch_thread_create(bot: Any, event: Any) -> None:
+    # Discord re-sends THREAD_CREATE when the bot merely gains access to an
+    # existing thread; only a genuinely new thread carries newly_created.
+    if not getattr(event, "newly_created", True):
+        return
+    thread = event.thread
+    parent_channel = _get_guild_channel(bot, thread.parent_id)
+    is_forum_post = _is_forum_channel(parent_channel)
+    tag_ids = [str(t) for t in getattr(thread, "applied_tag_ids", None) or []]
+    applied_tag_names = _resolve_forum_tag_names(parent_channel, tag_ids)
+    creator = _get_thread_creator(bot, event.guild_id, thread.owner_id)
+    # A forum post's starter message shares the thread's id (Discord contract).
+    starter_content = (
+        _get_starter_message_content(bot, thread.id) if is_forum_post else ""
+    )
+    context = thread_create_context(
+        thread, creator, starter_content, is_forum_post, applied_tag_names
+    )
+    # Dispatch keys off the PARENT channel (§3.3).
+    await _dispatch(
+        str(thread.parent_id), str(event.guild_id), "thread_create", context
+    )
+
+
+@plugin.listener(hikari.GuildThreadCreateEvent)
+async def on_thread_create(event: hikari.GuildThreadCreateEvent) -> None:
+    await dispatch_thread_create(plugin.bot, event)
 
 
 @plugin.listener(hikari.GuildReactionAddEvent)

--- a/smarter_dev/web/admin_actions.py
+++ b/smarter_dev/web/admin_actions.py
@@ -8,12 +8,15 @@ any of this.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from typing import ClassVar
 from urllib.parse import quote
 
 from smarter_dev.web.discord_rest import DiscordBotClient, DiscordRestError
+
+# Discord channel types 10/11/12: announcement, public, and private threads.
+_THREAD_CHANNEL_TYPES = frozenset({10, 11, 12})
 
 
 class AdminActionError(DiscordRestError):
@@ -25,6 +28,7 @@ class AdminActor(DiscordBotClient):
     """Performs moderation actions for one guild via Discord REST."""
 
     guild_id: str
+    _verified_thread_ids: set[str] = field(default_factory=set, init=False)
 
     user_agent: ClassVar[str] = "SmarterDev-AdminHandlers/1.0"
     error_type: ClassVar[type[DiscordRestError]] = AdminActionError
@@ -77,6 +81,8 @@ class AdminActor(DiscordBotClient):
 
     async def delete_thread(self, thread_id: str) -> bool:
         """Delete a thread. A gone thread (404) is a silent no-op -> False."""
+        if not await self._verify_thread_target(thread_id):
+            return False
         try:
             await self._request("DELETE", f"/channels/{thread_id}")
         except AdminActionError as error:
@@ -87,10 +93,43 @@ class AdminActor(DiscordBotClient):
 
     async def _patch_thread(self, thread_id: str, payload: dict) -> bool:
         """PATCH a thread channel; 404 (gone) -> False, other failures raise."""
+        if not await self._verify_thread_target(thread_id):
+            return False
         try:
             await self._request("PATCH", f"/channels/{thread_id}", json=payload)
         except AdminActionError as error:
             if error.status_code == 404:
                 return False
             raise
+        return True
+
+    async def _verify_thread_target(self, thread_id: str) -> bool:
+        """Confirm the target is a thread in this actor's guild before mutating.
+
+        Scripts supply thread ids; without this rail a laundered constant could
+        aim PATCH/DELETE /channels/{id} at a regular channel (deleting it
+        wholesale) or at another guild the bot inhabits. A gone target (404)
+        -> False, matching the mutations' silent no-op contract; a non-thread
+        or foreign-guild target raises. Verified ids are cached for the fire so
+        sweeps pay one fetch per thread.
+        """
+        if thread_id in self._verified_thread_ids:
+            return True
+        try:
+            response = await self._request("GET", f"/channels/{thread_id}")
+        except AdminActionError as error:
+            if error.status_code == 404:
+                return False
+            raise
+        channel = response.json()
+        if channel.get("type") not in _THREAD_CHANNEL_TYPES:
+            raise AdminActionError(
+                f"thread op target {thread_id} is not a thread "
+                f"(channel type {channel.get('type')})"
+            )
+        if str(channel.get("guild_id")) != self.guild_id:
+            raise AdminActionError(
+                f"thread op target {thread_id} is outside guild {self.guild_id}"
+            )
+        self._verified_thread_ids.add(thread_id)
         return True

--- a/smarter_dev/web/admin_actions.py
+++ b/smarter_dev/web/admin_actions.py
@@ -60,3 +60,37 @@ class AdminActor(DiscordBotClient):
             "DELETE", f"/channels/{channel_id}/messages/{message_id}"
         )
         return f"deleted message {message_id}"
+
+    async def close_thread(self, thread_id: str) -> bool:
+        """Archive a thread. A gone thread (404) is a silent no-op -> False."""
+        return await self._patch_thread(thread_id, {"archived": True})
+
+    async def lock_thread(self, thread_id: str) -> bool:
+        """Lock and archive a thread. A gone thread (404) -> False."""
+        return await self._patch_thread(
+            thread_id, {"locked": True, "archived": True}
+        )
+
+    async def reopen_thread(self, thread_id: str) -> bool:
+        """Unarchive a thread. A gone thread (404) -> False."""
+        return await self._patch_thread(thread_id, {"archived": False})
+
+    async def delete_thread(self, thread_id: str) -> bool:
+        """Delete a thread. A gone thread (404) is a silent no-op -> False."""
+        try:
+            await self._request("DELETE", f"/channels/{thread_id}")
+        except AdminActionError as error:
+            if error.status_code == 404:
+                return False
+            raise
+        return True
+
+    async def _patch_thread(self, thread_id: str, payload: dict) -> bool:
+        """PATCH a thread channel; 404 (gone) -> False, other failures raise."""
+        try:
+            await self._request("PATCH", f"/channels/{thread_id}", json=payload)
+        except AdminActionError as error:
+            if error.status_code == 404:
+                return False
+            raise
+        return True

--- a/smarter_dev/web/admin_handlers_jobs.py
+++ b/smarter_dev/web/admin_handlers_jobs.py
@@ -73,7 +73,9 @@ async def run_admin_handler_fire(payload: AdminHandlerFirePayload) -> dict:
     from smarter_dev.web.handler_runtime import run_handler_script
 
     budget = admin_budget()
-    emitter = DiscordEmitter(bot_token=settings.discord_bot_token)
+    # The emitter carries the fire's guild so list_threads() can hit the
+    # guild-scoped active-threads endpoint; without it the URL is malformed.
+    emitter = DiscordEmitter(bot_token=settings.discord_bot_token, guild_id=guild_id)
     redis = get_redis_client()
     limiter = WindowedLimiter(redis=redis)
     actor = AdminActor(bot_token=settings.discord_bot_token, guild_id=guild_id)
@@ -83,6 +85,7 @@ async def run_admin_handler_fire(payload: AdminHandlerFirePayload) -> dict:
         payload.trigger_context,
         channel_id=channel_id,
         guild_id=guild_id,
+        channel_ids=channel_ids,
         emitter=emitter,
         limiter=limiter,
         agent_runner=run_gathering_agent,
@@ -105,6 +108,8 @@ async def run_admin_handler_fire(payload: AdminHandlerFirePayload) -> dict:
                 web_reads=result.usage["web_reads"],
                 agent_calls=result.usage["agent_calls"],
                 mod_actions=result.usage.get("mod_actions", 0),
+                discord_reads=result.usage.get("discord_reads", 0),
+                thread_ops=result.usage.get("thread_ops", 0),
                 duration_ms=result.duration_ms,
                 finished_at=datetime.now(timezone.utc),
             )

--- a/smarter_dev/web/api_native/admin_handlers.py
+++ b/smarter_dev/web/api_native/admin_handlers.py
@@ -49,7 +49,7 @@ from smarter_dev.web.api_native.errors import (
 )
 from smarter_dev.web.handler_caps import MAX_ADMIN_HANDLERS_PER_GUILD
 from smarter_dev.web.handler_schedule import ScheduleError, first_fire_at
-from smarter_dev.web.models import HANDLER_TRIGGER_TYPES, AdminHandler
+from smarter_dev.web.models import ADMIN_HANDLER_TRIGGER_TYPES, AdminHandler
 
 logger = logging.getLogger(__name__)
 
@@ -170,7 +170,7 @@ class AdminHandlerController(Controller):
         db_session: AsyncSession,
         data: CreateAdminHandlerRequest,
     ) -> AdminHandlerResponse:
-        if data.trigger_type not in HANDLER_TRIGGER_TYPES:
+        if data.trigger_type not in ADMIN_HANDLER_TRIGGER_TYPES:
             raise plain_error(422, "unknown trigger_type")
         name = _normalized_name(data.name)
 

--- a/smarter_dev/web/api_native/handlers.py
+++ b/smarter_dev/web/api_native/handlers.py
@@ -56,9 +56,11 @@ from smarter_dev.web.api_native.errors import (
 )
 from smarter_dev.web.handler_caps import (
     ADMIN_FIRES_PER_MIN,
+    GUILD_MEMBER_EVENTS_PER_MIN,
     MAX_HANDLERS_PER_CHANNEL,
     WindowedLimiter,
     fires_per_min_for_trigger,
+    guild_member_events_key,
     handler_fire_key,
 )
 from smarter_dev.web.handler_schedule import (
@@ -73,6 +75,8 @@ from smarter_dev.web.member_activity import (
     record_activity,
 )
 from smarter_dev.web.models import (
+    ADMIN_HANDLER_EVENT_TRIGGERS,
+    ADMIN_ONLY_TRIGGER_TYPES,
     HANDLER_EVENT_TRIGGERS,
     HANDLER_TRIGGER_TYPES,
     AdminHandler,
@@ -80,6 +84,15 @@ from smarter_dev.web.models import (
 )
 
 logger = logging.getLogger(__name__)
+
+# The guild-shaped member lifecycle triggers: dispatched with ``channel_id=""``
+# (a member event has no channel), matched admin-only by guild + trigger, and
+# gated by the per-guild ``GUILD_MEMBER_EVENTS_PER_MIN`` raid window. This is
+# ``ADMIN_ONLY_TRIGGER_TYPES`` minus ``thread_create`` — the odd one out, which
+# keys off a parent channel and is scope-matched like a normal channel trigger.
+MEMBER_EVENT_TRIGGERS = tuple(
+    trigger for trigger in ADMIN_ONLY_TRIGGER_TYPES if trigger != "thread_create"
+)
 
 # Permission granted to the bot's Skrift service key (see roles.py `bot-service`
 # role and the phase-01 key-mint runbook).
@@ -337,6 +350,18 @@ class HandlerController(Controller):
         limiter = WindowedLimiter(redis=get_redis_client())
         dispatched: list[str] = []
 
+        is_member_event = data.trigger_type in MEMBER_EVENT_TRIGGERS
+        is_admin_only = data.trigger_type in ADMIN_ONLY_TRIGGER_TYPES
+
+        # Member lifecycle events are gated by a per-guild raid window BEFORE any
+        # fire is enqueued, so a raid + ban wave degrades to declined dispatches
+        # rather than a fire-queue explosion (all four member_* triggers share the
+        # window). thread_create is not under this gate.
+        if is_member_event and not await limiter.hit(
+            guild_member_events_key(data.guild_id), GUILD_MEMBER_EVENTS_PER_MIN
+        ):
+            return {"dispatched": False, "handler_ids": []}
+
         # Message triggers carry the author: enrich the context with activity
         # facts ("first message ever", "days since last message") read BEFORE
         # recording this message, so scripts get platform truth instead of
@@ -350,32 +375,38 @@ class HandlerController(Controller):
             await record_activity(db_session, data.guild_id, str(author_id), now)
             await db_session.commit()
 
-        # Standard tier: every enabled handler for this (channel, trigger)
-        # fires, each behind its own windowed cap.
-        standard_rows = (
-            await db_session.execute(
-                select(ChannelHandler).where(
-                    ChannelHandler.channel_id == data.channel_id,
-                    ChannelHandler.trigger_type == data.trigger_type,
-                    ChannelHandler.enabled.is_(True),
+        # Standard tier: every enabled handler for this (channel, trigger) fires,
+        # each behind its own windowed cap. The five admin-only member/thread
+        # triggers are never in the standard vocabulary, so skip the query for
+        # them (no ChannelHandler can match).
+        if not is_admin_only:
+            standard_rows = (
+                await db_session.execute(
+                    select(ChannelHandler).where(
+                        ChannelHandler.channel_id == data.channel_id,
+                        ChannelHandler.trigger_type == data.trigger_type,
+                        ChannelHandler.enabled.is_(True),
+                    )
                 )
-            )
-        ).scalars().all()
-        for standard in standard_rows:
-            if not await limiter.hit(
-                handler_fire_key(str(standard.id)),
-                fires_per_min_for_trigger(standard.trigger_type),
-            ):
-                continue
-            await worker_submit(
-                HandlerFirePayload(
-                    handler_id=str(standard.id), trigger_context=trigger_context
+            ).scalars().all()
+            for standard in standard_rows:
+                if not await limiter.hit(
+                    handler_fire_key(str(standard.id)),
+                    fires_per_min_for_trigger(standard.trigger_type),
+                ):
+                    continue
+                await worker_submit(
+                    HandlerFirePayload(
+                        handler_id=str(standard.id), trigger_context=trigger_context
+                    )
                 )
-            )
-            dispatched.append(str(standard.id))
+                dispatched.append(str(standard.id))
 
-        # Admin tier: every enabled admin handler for this guild+trigger whose
-        # scope includes this channel ([] / null = all channels).
+        # Admin tier: every enabled admin handler for this guild+trigger. For
+        # member_* events (channel_id="") the scope check is bypassed — the event
+        # has no channel for a scope to mean anything, so they match by guild
+        # alone. Every other trigger (including thread_create, dispatched with the
+        # parent channel) matches when its scope includes the channel ([] = all).
         admin_rows = (
             await db_session.execute(
                 select(AdminHandler).where(
@@ -386,9 +417,10 @@ class HandlerController(Controller):
             )
         ).scalars().all()
         for admin_handler in admin_rows:
-            scope = admin_handler.channel_ids or []
-            if scope and data.channel_id not in scope:
-                continue
+            if not is_member_event:
+                scope = admin_handler.channel_ids or []
+                if scope and data.channel_id not in scope:
+                    continue
             if not await limiter.hit(
                 handler_fire_key(str(admin_handler.id)), ADMIN_FIRES_PER_MIN
             ):
@@ -434,13 +466,19 @@ class HandlerController(Controller):
                     AdminHandler.channel_ids,
                 ).where(
                     AdminHandler.enabled.is_(True),
-                    AdminHandler.trigger_type.in_(HANDLER_EVENT_TRIGGERS),
+                    AdminHandler.trigger_type.in_(ADMIN_HANDLER_EVENT_TRIGGERS),
                 )
             )
         ).all()
         guild_triggers: list[list[str]] = []
         for guild_id, trigger, channel_ids in admin_rows:
-            if channel_ids:
+            # member_* handlers always surface as (guild_id, trigger) — their
+            # dispatch guard is per-guild regardless of channel_ids. Everything
+            # else (message/reaction/thread_create) follows the scoped/guild-wide
+            # split: listed channels become channel entries, empty scope = guild.
+            if trigger in MEMBER_EVENT_TRIGGERS:
+                guild_triggers.append([guild_id, trigger])
+            elif channel_ids:
                 channels.extend([channel_id, trigger] for channel_id in channel_ids)
             else:
                 guild_triggers.append([guild_id, trigger])

--- a/smarter_dev/web/handler_budget.py
+++ b/smarter_dev/web/handler_budget.py
@@ -28,6 +28,10 @@ DEFAULT_MAX_AGENT_CONTEXT_BYTES = 32 * 1024
 DEFAULT_WALL_CLOCK_SECONDS = 60.0
 # Standard handlers have no moderation powers, so zero mod actions.
 DEFAULT_MAX_MOD_ACTIONS = 0
+# Metered Discord reads (list_threads). Standard handlers get a couple; mutating
+# thread ops are zero for them, exactly like mod actions.
+DEFAULT_MAX_DISCORD_READS = 2
+DEFAULT_MAX_THREAD_OPS = 0
 
 # Admin handlers are admin-created and trusted: looser per-fire caps, and a
 # moderation-action budget (bans/kicks/timeouts/deletes), e.g. cleaning up a
@@ -35,6 +39,8 @@ DEFAULT_MAX_MOD_ACTIONS = 0
 ADMIN_MAX_MESSAGES = 5
 ADMIN_MAX_AGENT_CALLS = 3
 ADMIN_MAX_MOD_ACTIONS = 25
+ADMIN_MAX_DISCORD_READS = 5
+ADMIN_MAX_THREAD_OPS = 10
 ADMIN_WALL_CLOCK_SECONDS = 120.0
 
 
@@ -66,12 +72,16 @@ class HandlerBudget:
     max_agent_context_bytes: int = DEFAULT_MAX_AGENT_CONTEXT_BYTES
     wall_clock_seconds: float = DEFAULT_WALL_CLOCK_SECONDS
     max_mod_actions: int = DEFAULT_MAX_MOD_ACTIONS
+    max_discord_reads: int = DEFAULT_MAX_DISCORD_READS
+    max_thread_ops: int = DEFAULT_MAX_THREAD_OPS
 
     messages_sent: int = 0
     web_searches: int = 0
     web_reads: int = 0
     agent_calls: int = 0
     mod_actions: int = 0
+    discord_reads: int = 0
+    thread_ops: int = 0
 
     started_at: float = field(default_factory=time.monotonic)
 
@@ -138,6 +148,26 @@ class HandlerBudget:
             )
         self.mod_actions += 1
 
+    def spend_discord_read(self) -> None:
+        """Account for one metered Discord read (e.g. list_threads)."""
+        self.check_deadline()
+        if self.discord_reads >= self.max_discord_reads:
+            raise CapExceeded(
+                "discord_reads",
+                f"handler hit its {self.max_discord_reads}-discord-read cap",
+            )
+        self.discord_reads += 1
+
+    def spend_thread_op(self) -> None:
+        """Account for one mutating thread op (create/close/lock/reopen/delete)."""
+        self.check_deadline()
+        if self.thread_ops >= self.max_thread_ops:
+            raise CapExceeded(
+                "thread_ops",
+                f"handler hit its {self.max_thread_ops}-thread-op cap",
+            )
+        self.thread_ops += 1
+
     def enforce_agent_context(self, argument: str) -> None:
         """Reject an agent argument larger than the context-bytes cap.
 
@@ -161,6 +191,8 @@ class HandlerBudget:
             "web_reads": self.web_reads,
             "agent_calls": self.agent_calls,
             "mod_actions": self.mod_actions,
+            "discord_reads": self.discord_reads,
+            "thread_ops": self.thread_ops,
         }
 
 
@@ -170,5 +202,7 @@ def admin_budget() -> "HandlerBudget":
         max_messages=ADMIN_MAX_MESSAGES,
         max_agent_calls=ADMIN_MAX_AGENT_CALLS,
         max_mod_actions=ADMIN_MAX_MOD_ACTIONS,
+        max_discord_reads=ADMIN_MAX_DISCORD_READS,
+        max_thread_ops=ADMIN_MAX_THREAD_OPS,
         wall_clock_seconds=ADMIN_WALL_CLOCK_SECONDS,
     )

--- a/smarter_dev/web/handler_caps.py
+++ b/smarter_dev/web/handler_caps.py
@@ -30,6 +30,15 @@ HANDLER_FIRES_PER_MIN_REACTION = 4
 # need a high fire ceiling; the global agent/min cap still bounds expensive work.
 ADMIN_FIRES_PER_MIN = 120
 
+# Guild-wide gate on member lifecycle events (join/leave/rules/role) before a
+# fire is even enqueued, so a raid degrades to declined dispatches rather than a
+# fire-queue explosion. member_leave draws from the same window (join and leave
+# burst together in a raid + ban wave).
+GUILD_MEMBER_EVENTS_PER_MIN = 60
+# Guild-wide gate on mutating thread ops (create/close/lock/reopen/delete),
+# enforced in the runtime wrapper before the REST call.
+GUILD_THREAD_OPS_PER_MIN = 30
+
 # Creation ceilings. Named handlers removed the single-listener bound, so the
 # number of handlers is capped outright — enforced at the create endpoints.
 MAX_HANDLERS_PER_CHANNEL = 10
@@ -59,8 +68,20 @@ def handler_error_notice_key(handler_id: str) -> str:
     return f"hcap:errnotice:{handler_id}"
 
 
+def guild_member_events_key(guild_id: str) -> str:
+    return f"hcap:memberevt:{guild_id}"
+
+
+def guild_thread_ops_key(guild_id: str) -> str:
+    return f"hcap:threadop:{guild_id}"
+
+
 def fires_per_min_for_trigger(trigger_type: str) -> int:
-    """Per-handler fire ceiling, tighter for reaction triggers."""
+    """Per-handler fire ceiling, tighter for reaction triggers.
+
+    The five admin-only member/thread triggers fall through to the default
+    message ceiling of 10 (§3.4) — no special-casing.
+    """
     return (
         HANDLER_FIRES_PER_MIN_REACTION
         if trigger_type == "reaction"

--- a/smarter_dev/web/handler_emitter.py
+++ b/smarter_dev/web/handler_emitter.py
@@ -27,14 +27,50 @@ _MESSAGE_MAX = 2000
 # explodes into a large preview card, flooding the channel.
 _SUPPRESS_EMBEDS = 1 << 2
 
+# Merged active + recently-archived thread list is capped so a script can't
+# fan a single read into an unbounded page of threads.
+_THREAD_LIST_MAX = 50
+# Discord channel ``type`` values that identify a thread (announcement,
+# public, private). Anything else is a regular channel with no parent thread.
+_THREAD_CHANNEL_TYPES = (10, 11, 12)
+# Discord channel ``type`` for a standalone public thread created via
+# POST /channels/{id}/threads (no starter message).
+_PUBLIC_THREAD_TYPE = 11
+
 
 class DiscordEmitError(DiscordRestError):
     """A Discord REST emit failed."""
 
 
+def _thread_summary(thread: dict, tag_names_by_id: dict[str, str]) -> dict:
+    """Flatten a raw Discord thread object into the scripting-surface shape."""
+    metadata = thread.get("thread_metadata") or {}
+    applied_tag_ids = thread.get("applied_tags") or []
+    return {
+        "thread_id": str(thread.get("id", "")),
+        "name": thread.get("name", ""),
+        "created_at": metadata.get("create_timestamp", ""),
+        "archived": bool(metadata.get("archived", False)),
+        "locked": bool(metadata.get("locked", False)),
+        "owner_id": str(thread.get("owner_id", "")),
+        "message_count": int(thread.get("message_count", 0)),
+        "applied_tag_names": [
+            tag_names_by_id[str(tag_id)]
+            for tag_id in applied_tag_ids
+            if str(tag_id) in tag_names_by_id
+        ],
+    }
+
+
 @dataclass(kw_only=True)
 class DiscordEmitter(DiscordBotClient):
     """Minimal bot-token REST emitter used by handler executions."""
+
+    # The active-threads endpoint is guild-scoped, so the emitter carries the
+    # fire's guild. Defaulted so existing callers that only send messages /
+    # reactions keep constructing with ``bot_token`` alone; ``list_threads``
+    # requires the runtime to pass the real guild id.
+    guild_id: str = ""
 
     user_agent: ClassVar[str] = "SmarterDev-Handlers/1.0"
     error_type: ClassVar[type[DiscordRestError]] = DiscordEmitError
@@ -59,3 +95,133 @@ class DiscordEmitter(DiscordBotClient):
             "PUT",
             f"/channels/{channel_id}/messages/{message_id}/reactions/{encoded}/@me",
         )
+
+    async def list_threads(self, channel_id: str, limit: int = 50) -> list[dict]:
+        """Active + recently-archived threads/posts of ``channel_id``.
+
+        The guild active-threads list is filtered to this parent channel and
+        merged (active first) with the channel's public archived threads under
+        a hard 50-entry cap. Forum tag ids are resolved to names via the
+        parent channel's ``available_tags`` only when a listed thread carries
+        tags. A 404 (gone channel) is an informational empty read; any other
+        failure raises.
+        """
+        try:
+            active_response = await self._request(
+                "GET", f"/guilds/{self.guild_id}/threads/active"
+            )
+            archived_response = await self._request(
+                "GET",
+                f"/channels/{channel_id}/threads/archived/public",
+                params={"limit": limit},
+            )
+        except DiscordEmitError as error:
+            if error.status_code == 404:
+                return []
+            raise
+        active_threads = [
+            thread
+            for thread in active_response.json().get("threads", [])
+            if str(thread.get("parent_id", "")) == channel_id
+        ]
+        archived_threads = archived_response.json().get("threads", [])
+        merged = (active_threads + archived_threads)[:_THREAD_LIST_MAX]
+        tag_names_by_id = await self._forum_tag_names(channel_id, merged)
+        return [_thread_summary(thread, tag_names_by_id) for thread in merged]
+
+    async def _forum_tag_names(
+        self, channel_id: str, threads: list[dict]
+    ) -> dict[str, str]:
+        """Map available forum tag id -> name, or ``{}`` when no thread has tags."""
+        if not any(thread.get("applied_tags") for thread in threads):
+            return {}
+        channel = await self._request("GET", f"/channels/{channel_id}")
+        return {
+            str(tag["id"]): tag.get("name", "")
+            for tag in channel.json().get("available_tags", [])
+        }
+
+    async def create_thread(
+        self, channel_id: str, name: str, message_id: str | None = None
+    ) -> str:
+        """Create a thread; return its id. Raises on any failure.
+
+        With ``message_id`` the thread hangs off that message; without it a
+        standalone public thread is created.
+        """
+        if message_id is not None:
+            endpoint = f"/channels/{channel_id}/messages/{message_id}/threads"
+            payload: dict = {"name": name}
+        else:
+            endpoint = f"/channels/{channel_id}/threads"
+            payload = {"name": name, "type": _PUBLIC_THREAD_TYPE}
+        response = await self._request("POST", endpoint, json=payload)
+        return str(response.json().get("id", ""))
+
+    async def create_post(
+        self,
+        channel_id: str,
+        title: str,
+        content: str,
+        tag_names: list[str] | None = None,
+    ) -> str:
+        """Create a forum post; return its thread id. Raises on any failure.
+
+        ``tag_names`` are resolved against the forum's ``available_tags``; an
+        unknown name raises ``ValueError`` listing the valid names (fail fast).
+        """
+        payload: dict = {"name": title, "message": {"content": content}}
+        if tag_names:
+            channel = await self._request("GET", f"/channels/{channel_id}")
+            id_by_name = {
+                tag.get("name", ""): str(tag["id"])
+                for tag in channel.json().get("available_tags", [])
+            }
+            unknown = [name for name in tag_names if name not in id_by_name]
+            if unknown:
+                valid = ", ".join(sorted(id_by_name)) or "(none)"
+                raise ValueError(
+                    f"unknown forum tag(s): {', '.join(unknown)}. valid tags: {valid}"
+                )
+            payload["applied_tags"] = [id_by_name[name] for name in tag_names]
+        response = await self._request(
+            "POST", f"/channels/{channel_id}/threads", json=payload
+        )
+        return str(response.json().get("id", ""))
+
+    async def get_channel_guild_id(self, channel_id: str) -> str | None:
+        """Guild id that owns ``channel_id``, or ``None`` when gone/not a guild
+        channel.
+
+        Supports the admin ``list_threads`` guild-scope rail: a guild-wide admin
+        handler (empty ``channel_ids``) may only read a channel that belongs to
+        its own guild, so a foreign-guild channel id can't leak archived threads.
+        A 404 (gone channel) returns ``None``; any other failure raises.
+        """
+        try:
+            response = await self._request("GET", f"/channels/{channel_id}")
+        except DiscordEmitError as error:
+            if error.status_code == 404:
+                return None
+            raise
+        guild_id = response.json().get("guild_id")
+        return str(guild_id) if guild_id else None
+
+    async def get_thread_parent_id(self, thread_id: str) -> str | None:
+        """Parent channel id of ``thread_id`` when it is a thread, else ``None``.
+
+        Supports the runtime's home-channel-thread send check. A 404 (gone
+        channel) returns ``None``; a non-thread channel returns ``None``; any
+        other failure raises.
+        """
+        try:
+            response = await self._request("GET", f"/channels/{thread_id}")
+        except DiscordEmitError as error:
+            if error.status_code == 404:
+                return None
+            raise
+        channel = response.json()
+        if channel.get("type") not in _THREAD_CHANNEL_TYPES:
+            return None
+        parent_id = channel.get("parent_id")
+        return str(parent_id) if parent_id else None

--- a/smarter_dev/web/handler_lint.py
+++ b/smarter_dev/web/handler_lint.py
@@ -48,6 +48,11 @@ _OPAQUE_MIN_LEN = 120
 _BASE64ISH = re.compile(r"^[A-Za-z0-9+/=_-]+$")
 _HEXISH = re.compile(r"^[0-9a-fA-F]+$")
 
+# delete_thread(...) whose first argument opens with a string quote — a
+# hardcoded destructive target. `f"..."` is not matched (the `f` precedes the
+# quote), so dynamic references are left for the judge.
+_DELETE_THREAD_LITERAL = re.compile(r"\bdelete_thread\s*\(\s*['\"]")
+
 
 def _string_literals(script: str) -> list[str]:
     out: list[str] = []
@@ -66,6 +71,13 @@ def check_static(script: str) -> str | None:
     for token in _BANNED_TOKENS:
         if re.search(rf"\b{re.escape(token)}\b", script):
             return f"script uses banned construct '{token}'"
+
+    # delete_thread is irreversible: its target must come from trigger context or
+    # a list_threads result, never a hardcoded id literal (an unreviewable
+    # destructive target). A quoted first argument is exactly that literal; a
+    # variable, subscript, or f-string reference passes through to the judge.
+    if _DELETE_THREAD_LITERAL.search(script):
+        return "script calls delete_thread() with a hardcoded thread id literal"
 
     for literal in _string_literals(script):
         compact = literal.strip()

--- a/smarter_dev/web/handler_runtime.py
+++ b/smarter_dev/web/handler_runtime.py
@@ -8,13 +8,25 @@ chokepoint is what makes "code is the only emitter" and "agents only gather"
 true in practice.
 
 Script-facing surface (Monty external functions):
-- ``send_message(content)`` -> message id
+- ``send_message(content)`` -> message id (may also target a thread of the
+  handler's home channel; admin handlers may target any channel in the guild)
 - ``add_reaction(message_id, emoji)`` -> True
 - ``post_voice(text)`` -> True
 - ``spawn_agent(prompt, has_tools=False)`` -> plaintext str
+- ``list_threads(channel_id=None)`` -> list[dict] of the channel's threads
+  (home channel when omitted; a foreign channel needs an admin handler). Spends
+  the discord_reads budget; a gone channel yields ``[]`` without erroring.
+- ``create_thread(name, message_id=None)`` -> thread id and
+  ``create_post(title, content, tag_names=None)`` -> thread id, both on the home
+  channel, spending the message budget + channel window like ``send_message``.
 - ``memory_get(key, default=None)`` / ``memory_set(key, value)`` /
   ``memory_all()`` / ``memory_delete(key)`` -> persistent per-handler key/value
   store that survives across fires.
+
+Admin handlers (``actor`` set) additionally get ``close_thread`` /
+``lock_thread`` / ``reopen_thread`` / ``delete_thread`` -> bool (each spends the
+thread_ops budget + guild thread-op window before the REST call; a gone thread
+yields ``False`` without erroring the fire).
 
 Script-facing data (Monty input): ``context`` — a plain dict describing the
 trigger (its keys depend on ``context["trigger_type"]``).
@@ -45,9 +57,11 @@ from smarter_dev.web.handler_budget import CapExceeded, HandlerBudget
 from smarter_dev.web.handler_caps import (
     CHANNEL_MESSAGES_PER_MIN,
     GLOBAL_AGENT_CALLS_PER_MIN,
+    GUILD_THREAD_OPS_PER_MIN,
     WindowedLimiter,
     channel_message_key,
     global_agent_key,
+    guild_thread_ops_key,
 )
 from smarter_dev.web.handler_emitter import DiscordEmitter
 from smarter_dev.web.handler_memory import HandlerMemory
@@ -138,6 +152,9 @@ class HandlerExecution:
     emitter: DiscordEmitter
     limiter: WindowedLimiter
     agent_runner: AgentRunner = _no_agent
+    # The admin handler's channel scope. Empty means guild-wide; a non-empty
+    # scope bounds which channels admin list_threads(channel_id) may read.
+    channel_ids: list[str] = field(default_factory=list)
     # Set only for admin handlers; presence enables the moderation functions and
     # lets send_message target any channel.
     actor: AdminActor | None = None
@@ -148,6 +165,10 @@ class HandlerExecution:
     # exception that crosses out of an external function (losing its type), so
     # we record the real CapExceeded on the host side before re-raising.
     breach: CapExceeded | None = None
+    # Per-execution cache of a thread's parent channel id, so the send_message
+    # home-thread relaxation verifies each target once per fire. This is a host
+    # rail (one cached fetch), NOT metered against discord_reads.
+    _thread_parent_cache: dict[str, str | None] = field(default_factory=dict)
 
     def external_functions(self) -> dict[str, Callable[..., Any]]:
         funcs = {
@@ -155,6 +176,9 @@ class HandlerExecution:
             "add_reaction": self._guard(self._add_reaction),
             "post_voice": self._guard(self._post_voice),
             "spawn_agent": self._guard(self._spawn_agent),
+            "list_threads": self._guard(self._list_threads),
+            "create_thread": self._guard(self._create_thread),
+            "create_post": self._guard(self._create_post),
             "memory_get": self._guard(self._memory_get),
             "memory_set": self._guard(self._memory_set),
             "memory_all": self._guard(self._memory_all),
@@ -169,6 +193,10 @@ class HandlerExecution:
                     "ban_user": self._guard(self._ban_user),
                     "kick_user": self._guard(self._kick_user),
                     "timeout_user": self._guard(self._timeout_user),
+                    "close_thread": self._guard(self._close_thread),
+                    "lock_thread": self._guard(self._lock_thread),
+                    "reopen_thread": self._guard(self._reopen_thread),
+                    "delete_thread": self._guard(self._delete_thread),
                 }
             )
         return funcs
@@ -188,13 +216,17 @@ class HandlerExecution:
 
     async def _send_message(self, content: str, channel_id: str | None = None) -> str:
         target = str(channel_id) if channel_id else self.channel_id
-        # Standard handlers may only post to their own channel; admin handlers
-        # (actor set) may post anywhere in the guild (e.g. mod-chat).
+        # Standard handlers may only post to their own channel or a thread OF
+        # that channel; admin handlers (actor set) may post anywhere in the guild
+        # (e.g. mod-chat). The thread-of-home verdict is cached per fire so
+        # repeated sends into the same thread don't re-fetch its parent.
         if self.actor is None and target != self.channel_id:
-            raise CapExceeded(
-                "cross_channel_send",
-                "standard handlers can only post to their own channel",
-            )
+            if not await self._is_home_channel_thread(target):
+                raise CapExceeded(
+                    "cross_channel_send",
+                    "standard handlers can only post to their own channel "
+                    "or a thread of it",
+                )
         self.budget.spend_message()
         within = await self.limiter.hit(
             channel_message_key(target), CHANNEL_MESSAGES_PER_MIN
@@ -205,6 +237,104 @@ class HandlerExecution:
                 f"channel hit its {CHANNEL_MESSAGES_PER_MIN} messages/min cap",
             )
         return await self.emitter.create_message(target, str(content))
+
+    async def _is_home_channel_thread(self, channel_id: str) -> bool:
+        """Whether ``channel_id`` is a thread whose parent is the home channel.
+
+        Host rail behind the ``send_message`` relaxation: cached per execution so
+        repeated sends into the same thread cost one parent fetch, and NOT metered
+        against the ``discord_reads`` budget.
+        """
+        if channel_id not in self._thread_parent_cache:
+            self._thread_parent_cache[channel_id] = (
+                await self.emitter.get_thread_parent_id(channel_id)
+            )
+        return self._thread_parent_cache[channel_id] == self.channel_id
+
+    # -- thread reads/creates (both tiers, home-channel scoped by default) --
+
+    async def _list_threads(self, channel_id: str | None = None) -> list[dict]:
+        """Active + recently-archived threads of a channel; spends a discord read.
+
+        ``channel_id`` omitted (or falsy) -> the handler's HOME channel, allowed
+        for both tiers. A foreign ``channel_id`` requires an admin handler (actor
+        set); a standard handler naming another channel raises the same
+        ``cross_channel_send`` cap ``send_message`` uses. For an admin handler the
+        target must be within its ``channel_ids`` scope (empty scope = guild-wide,
+        and the runtime still verifies the channel belongs to this guild so a
+        foreign-guild id can't leak archived threads) — otherwise
+        ``out_of_scope_channel`` is raised. The scope rail is a host check (not
+        metered) and runs before the read is spent. A gone channel (404) flows
+        through from the emitter as ``[]`` and does NOT error the fire.
+        """
+        target = str(channel_id) if channel_id else self.channel_id
+        if target != self.channel_id:
+            if self.actor is None:
+                raise CapExceeded(
+                    "cross_channel_send",
+                    "standard handlers can only list threads of their own channel",
+                )
+            if not await self._admin_channel_in_scope(target):
+                raise CapExceeded(
+                    "out_of_scope_channel",
+                    "admin list_threads target is outside the handler's channel "
+                    "scope / guild",
+                )
+        self.budget.spend_discord_read()
+        return await self.emitter.list_threads(target)
+
+    async def _admin_channel_in_scope(self, channel_id: str) -> bool:
+        """Whether an admin handler may read ``channel_id``'s threads.
+
+        A non-empty ``channel_ids`` scope is an exact allow-list (pure check). An
+        empty scope is guild-wide, so the channel is verified to belong to this
+        fire's guild via one host fetch (NOT metered against discord_reads).
+        """
+        if self.channel_ids:
+            return channel_id in self.channel_ids
+        return await self.emitter.get_channel_guild_id(channel_id) == self.guild_id
+
+    async def _create_thread(self, name: str, message_id: str | None = None) -> str:
+        """Create a thread on the HOME channel; return its id.
+
+        A create is an emit: it spends the message budget and the home channel's
+        per-minute message window exactly like ``send_message``. Raises on any
+        REST failure (a create has no sensible falsy return).
+        """
+        await self._spend_home_channel_emit()
+        message = str(message_id) if message_id else None
+        return await self.emitter.create_thread(self.channel_id, str(name), message)
+
+    async def _create_post(
+        self, title: str, content: str, tag_names: list[str] | None = None
+    ) -> str:
+        """Create a forum post on the HOME channel; return its thread id.
+
+        Spends the message budget and the home channel's message window like
+        ``send_message``. An unknown forum tag name raises ``ValueError`` from the
+        emitter (fail fast); any REST failure raises (no falsy return for a create).
+        """
+        await self._spend_home_channel_emit()
+        return await self.emitter.create_post(
+            self.channel_id, str(title), str(content), tag_names
+        )
+
+    async def _spend_home_channel_emit(self) -> None:
+        """Meter a thread create (create_thread/create_post): the message budget
+        and the channel's per-minute message window (matching ``send_message``),
+        then the guild thread-op window — creation is a mutating thread op and
+        must not escape the guild ceiling just because it spends the message
+        budget rather than the thread_ops counter (spec §5.3)."""
+        self.budget.spend_message()
+        within = await self.limiter.hit(
+            channel_message_key(self.channel_id), CHANNEL_MESSAGES_PER_MIN
+        )
+        if not within:
+            raise CapExceeded(
+                "channel_messages_per_min",
+                f"channel hit its {CHANNEL_MESSAGES_PER_MIN} messages/min cap",
+            )
+        await self._hit_guild_thread_ops_window()
 
     # -- admin-only moderation functions (only present when self.actor is set) --
 
@@ -224,6 +354,50 @@ class HandlerExecution:
     async def _timeout_user(self, user_id: str, duration_seconds: int = 600) -> str:
         self.budget.spend_mod_action()
         return await self.actor.timeout_user(str(user_id), int(duration_seconds))
+
+    # -- admin-only thread mutations (only present when self.actor is set) --
+
+    async def _close_thread(self, thread_id: str) -> bool:
+        """Archive a thread. A gone thread (404) is a silent no-op -> False."""
+        await self._spend_thread_op()
+        return await self.actor.close_thread(str(thread_id))
+
+    async def _lock_thread(self, thread_id: str) -> bool:
+        """Lock and archive a thread. A gone thread (404) -> False."""
+        await self._spend_thread_op()
+        return await self.actor.lock_thread(str(thread_id))
+
+    async def _reopen_thread(self, thread_id: str) -> bool:
+        """Unarchive a thread. A gone thread (404) -> False."""
+        await self._spend_thread_op()
+        return await self.actor.reopen_thread(str(thread_id))
+
+    async def _delete_thread(self, thread_id: str) -> bool:
+        """Delete a thread. A gone thread (404) is a silent no-op -> False."""
+        await self._spend_thread_op()
+        return await self.actor.delete_thread(str(thread_id))
+
+    async def _spend_thread_op(self) -> None:
+        """Meter a mutating thread op (close/lock/reopen/delete): per-fire
+        thread_ops budget then the guild thread-op window, before the REST call —
+        a breach of either fails the fire mid-flight, the same shape the
+        channel-message window uses."""
+        self.budget.spend_thread_op()
+        await self._hit_guild_thread_ops_window()
+
+    async def _hit_guild_thread_ops_window(self) -> None:
+        """Charge the guild thread-op window, raising ``CapExceeded`` on breach.
+
+        Shared by every mutating thread op (create/close/lock/reopen/delete) so
+        all six draw the one guild ceiling (spec §5.3)."""
+        within = await self.limiter.hit(
+            guild_thread_ops_key(self.guild_id), GUILD_THREAD_OPS_PER_MIN
+        )
+        if not within:
+            raise CapExceeded(
+                "guild_thread_ops_per_min",
+                f"guild hit its {GUILD_THREAD_OPS_PER_MIN} thread-ops/min cap",
+            )
 
     async def _add_reaction(self, message_id: str, emoji: str) -> bool:
         # Reactions are emits too — metered against the per-fire emit cap, but
@@ -281,6 +455,7 @@ async def run_handler_script(
     agent_runner: AgentRunner = _no_agent,
     budget: HandlerBudget | None = None,
     actor: AdminActor | None = None,
+    channel_ids: list[str] | None = None,
     memory: dict[str, Any] | None = None,
 ) -> HandlerResult:
     """Compile and run ``script`` in Monty with every rail enforced.
@@ -305,6 +480,7 @@ async def run_handler_script(
         limiter=limiter,
         agent_runner=agent_runner,
         actor=actor,
+        channel_ids=list(channel_ids or []),
         memory=handler_memory,
     )
     started = time.monotonic()

--- a/smarter_dev/web/handlers_jobs.py
+++ b/smarter_dev/web/handlers_jobs.py
@@ -72,7 +72,9 @@ async def run_handler_fire(payload: HandlerFirePayload) -> dict:
     from smarter_dev.web.handler_runtime import run_handler_script
 
     budget = HandlerBudget()
-    emitter = DiscordEmitter(bot_token=settings.discord_bot_token)
+    # The emitter carries the fire's guild so list_threads() can hit the
+    # guild-scoped active-threads endpoint; without it the URL is malformed.
+    emitter = DiscordEmitter(bot_token=settings.discord_bot_token, guild_id=guild_id)
     redis = get_redis_client()
     limiter = WindowedLimiter(redis=redis)
 
@@ -100,6 +102,8 @@ async def run_handler_fire(payload: HandlerFirePayload) -> dict:
                 web_searches=result.usage["web_searches"],
                 web_reads=result.usage["web_reads"],
                 agent_calls=result.usage["agent_calls"],
+                discord_reads=result.usage.get("discord_reads", 0),
+                thread_ops=result.usage.get("thread_ops", 0),
                 duration_ms=result.duration_ms,
                 finished_at=datetime.now(timezone.utc),
             )

--- a/smarter_dev/web/models.py
+++ b/smarter_dev/web/models.py
@@ -4301,10 +4301,27 @@ class AuthoringPipelineRun(Base):
 # Agentic handler system
 # ---------------------------------------------------------------------------
 
-# Allowed trigger families for a member-created handler.
+# Allowed trigger families for a member-created (standard-tier) handler. This
+# vocabulary does not grow — the five member/thread triggers below are admin-only.
 HANDLER_TRIGGER_TYPES = ("message", "reaction", "schedule", "timer")
-# Event triggers are single-listener per channel; time triggers coexist.
+# Event (gateway-dispatched) triggers for the standard tier; time triggers coexist.
 HANDLER_EVENT_TRIGGERS = ("message", "reaction")
+
+# Admin-tier-only gateway triggers: guild-shaped member lifecycle events plus
+# thread creation (see docs/v2/feature-parity/threads-and-member-events.md §6).
+# Standard create paths reject these; only the admin tier admits them.
+ADMIN_ONLY_TRIGGER_TYPES = (
+    "member_join",
+    "member_leave",
+    "member_rules_accepted",
+    "member_role_change",
+    "thread_create",
+)
+# The admin tier's full trigger vocabulary: the standard four plus the five above.
+ADMIN_HANDLER_TRIGGER_TYPES = HANDLER_TRIGGER_TYPES + ADMIN_ONLY_TRIGGER_TYPES
+# Admin event (gateway-dispatched) triggers: standard events plus the five new
+# ones, used by the admin active-channels query. Time triggers stay excluded.
+ADMIN_HANDLER_EVENT_TRIGGERS = HANDLER_EVENT_TRIGGERS + ADMIN_ONLY_TRIGGER_TYPES
 
 
 class ChannelHandler(Base):
@@ -4400,6 +4417,10 @@ class HandlerRun(Base):
     agent_calls: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     # Moderation actions (ban/kick/timeout/delete) — admin handlers only.
     mod_actions: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    # Metered Discord reads (list_threads) and mutating thread ops
+    # (create/close/lock/reopen/delete thread).
+    discord_reads: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    thread_ops: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     duration_ms: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
 
 
@@ -4418,7 +4439,9 @@ class AdminHandler(Base):
     __tablename__ = "admin_handlers"
     __table_args__ = (
         CheckConstraint(
-            "trigger_type IN ('message', 'reaction', 'schedule', 'timer')",
+            "trigger_type IN ('message', 'reaction', 'schedule', 'timer', "
+            "'member_join', 'member_leave', 'member_rules_accepted', "
+            "'member_role_change', 'thread_create')",
             name="ck_admin_handlers_trigger_type",
         ),
         Index("ix_admin_handlers_guild_id", "guild_id"),

--- a/tests/bot/admin_handlers_plugin_test.py
+++ b/tests/bot/admin_handlers_plugin_test.py
@@ -97,6 +97,35 @@ async def test_install_edits_existing_admin_handler():
     assert payload["channel_ids"] == ["MODCHAT"]
 
 
+async def test_install_creates_member_event_handler():
+    # The install step is trigger-agnostic: a member_join admin handler installs
+    # exactly like a message one, carrying the new trigger type to the API.
+    api = _FakeAPI()
+    api.post_response = _Resp(
+        201,
+        {
+            "handler_id": "AH3",
+            "name": "join-alert",
+            "trigger_type": "member_join",
+            "channel_ids": [],
+            "description": "alerts mods on join",
+        },
+    )
+    line = await install_admin_result(
+        api,
+        "G1",
+        "A1",
+        _result(
+            trigger_type="member_join",
+            name="join-alert",
+            description="alerts mods on join",
+        ),
+    )
+    assert "join-alert" in line and "Created" in line
+    _, payload = api.posted[0]
+    assert payload["trigger_type"] == "member_join"
+
+
 async def test_install_relays_api_failure():
     api = _FakeAPI()
     api.post_response = _Resp(409, text="name taken")

--- a/tests/bot/handler_authoring_test.py
+++ b/tests/bot/handler_authoring_test.py
@@ -305,6 +305,19 @@ def test_describe_trigger_cadence_phrasing():
     assert "One-shot" in describe_trigger("timer", {"delay_seconds": 120})
 
 
+def test_describe_trigger_member_and_thread_cadence():
+    join = describe_trigger("member_join", {})
+    assert "EVERY member join" in join and "raid" in join.lower()
+    leave = describe_trigger("member_leave", {})
+    assert "EVERY member leave" in leave and "ban wave" in leave.lower()
+    rules = describe_trigger("member_rules_accepted", {})
+    assert "idempotent" in rules
+    role = describe_trigger("member_role_change", {})
+    assert "actually change" in role and "low frequency" in role.lower()
+    thread = describe_trigger("thread_create", {})
+    assert "EVERY new thread/post" in thread
+
+
 # -- admin creation pipeline ---------------------------------------------------
 
 from smarter_dev.bot.agents.handler_authoring import (
@@ -448,6 +461,47 @@ async def test_admin_pipeline_judge_reject():
     )
     assert not result.ok
     assert "no condition" in result.error
+
+
+async def test_admin_pipeline_accepts_member_trigger():
+    # The admin vocabulary includes the five member/thread triggers; a
+    # member_join create plan is accepted and its cadence reaches the judge.
+    seen = {}
+
+    async def judge(script, trigger_context):
+        seen["ctx"] = trigger_context
+        return _verdict(reason="ok")
+
+    result = await run_admin_creation_pipeline(
+        request="alert mods when someone joins",
+        existing_handlers=[],
+        author=_admin_author_returning(
+            _admin_plan(
+                trigger_type="member_join",
+                name="join-alert",
+                script='await send_message("welcome", "MODCHAT")\n',
+            )
+        ),
+        judge=judge,
+    )
+    assert result.ok
+    assert result.trigger_type == "member_join"
+    assert "EVERY member join" in seen["ctx"]
+
+
+async def test_standard_pipeline_rejects_admin_only_trigger():
+    # Even if the standard author mistakenly emits an admin-only trigger, the
+    # standard pipeline rejects it — the vocabulary stays the four base types.
+    result = await run_creation_pipeline(
+        request="alert on join",
+        trigger_type="message",
+        settings={},
+        existing_handlers=[],
+        author=_author_returning(_plan(trigger_type="member_join")),
+        judge=_judge_approving(),
+    )
+    assert not result.ok
+    assert "invalid trigger" in result.error
 
 
 # -- checklist verdict + dual-judge merge --------------------------------------

--- a/tests/bot/handler_member_thread_events_test.py
+++ b/tests/bot/handler_member_thread_events_test.py
@@ -1,0 +1,617 @@
+"""Tests for the admin-only member/thread event dispatch (pure functions + wiring).
+
+Covers the five new admin-tier triggers (member_join, member_leave,
+member_rules_accepted, member_role_change, thread_create) and thread-aware
+message dispatch. Delta/context logic is pure-function bot-side so it is
+TDD-able without a live gateway.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import hikari
+import pytest
+
+from smarter_dev.bot.plugins import handler_events
+from smarter_dev.bot.plugins.handler_events import (
+    _has_custom_avatar,
+    dispatch_message,
+    dispatch_thread_create,
+    enrich_role_change_context,
+    guild_member_counts,
+    member_join_context,
+    member_leave_context,
+    member_update_deltas,
+    message_thread_fields,
+    on_member_join,
+    on_member_leave,
+    on_member_update,
+    resolve_role_names,
+    thread_create_context,
+)
+
+# A real 2015+ Discord snowflake so account_created_at resolves sanely.
+SNOWFLAKE = 733364234141827073
+
+
+def make_member(
+    *,
+    member_id=SNOWFLAKE,
+    username="alice",
+    display_name="Alice",
+    nickname=None,
+    is_bot=False,
+    is_pending=False,
+    role_ids=(),
+    guild_id=None,
+    avatar_hash="abc",
+    guild_avatar_hash=None,
+    joined_at=datetime(2021, 1, 1, tzinfo=timezone.utc),
+    premium_since=None,
+):
+    return SimpleNamespace(
+        id=member_id,
+        username=username,
+        display_name=display_name,
+        nickname=nickname,
+        is_bot=is_bot,
+        is_pending=is_pending,
+        role_ids=tuple(role_ids),
+        guild_id=guild_id,
+        avatar_hash=avatar_hash,
+        guild_avatar_hash=guild_avatar_hash,
+        joined_at=joined_at,
+        premium_since=premium_since,
+    )
+
+
+def make_user(*, user_id=SNOWFLAKE, username="alice", is_bot=False, avatar_hash="abc"):
+    return SimpleNamespace(
+        id=user_id,
+        username=username,
+        display_name=username.title(),
+        is_bot=is_bot,
+        avatar_hash=avatar_hash,
+        guild_avatar_hash=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# member_update_deltas — the pure delta/selection logic
+# ---------------------------------------------------------------------------
+
+
+def test_rules_accepted_fires_on_pending_transition():
+    old = make_member(is_pending=True)
+    new = make_member(is_pending=False)
+    deltas = member_update_deltas(old, new)
+    assert [t for t, _ in deltas] == ["member_rules_accepted"]
+    _, ctx = deltas[0]
+    assert ctx["trigger_type"] == "member_rules_accepted"
+    assert ctx["member_id"] == str(SNOWFLAKE)
+
+
+def test_rules_accepted_does_not_fire_when_still_pending():
+    old = make_member(is_pending=True)
+    new = make_member(is_pending=True)
+    assert member_update_deltas(old, new) == []
+
+
+def test_role_change_fires_with_added_and_removed_ids():
+    old = make_member(role_ids=(10, 20))
+    new = make_member(role_ids=(20, 30))
+    deltas = member_update_deltas(old, new)
+    assert [t for t, _ in deltas] == ["member_role_change"]
+    _, ctx = deltas[0]
+    assert ctx["added_role_ids"] == ["30"]
+    assert ctx["removed_role_ids"] == ["10"]
+    assert ctx["member_display_name"] == "Alice"
+
+
+def test_rules_accepted_and_role_change_both_fire():
+    old = make_member(is_pending=True, role_ids=())
+    new = make_member(is_pending=False, role_ids=(30,))
+    triggers = [t for t, _ in member_update_deltas(old, new)]
+    assert set(triggers) == {"member_rules_accepted", "member_role_change"}
+
+
+def test_no_deltas_when_nothing_changes():
+    old = make_member(is_pending=False, role_ids=(10,))
+    new = make_member(is_pending=False, role_ids=(10,))
+    assert member_update_deltas(old, new) == []
+
+
+def test_role_change_skips_on_cache_miss():
+    # No old_member => no delta => no role_change fire (structural boost guard).
+    new = make_member(role_ids=(10, 20))
+    triggers = [t for t, _ in member_update_deltas(None, new)]
+    assert "member_role_change" not in triggers
+
+
+def test_rules_accepted_heuristic_fires_on_cache_miss_when_clean():
+    # Cache miss: fire iff not pending AND no roles beyond @everyone (empty).
+    new = make_member(is_pending=False, role_ids=())
+    triggers = [t for t, _ in member_update_deltas(None, new)]
+    assert triggers == ["member_rules_accepted"]
+
+
+def test_rules_accepted_heuristic_skips_on_cache_miss_when_has_roles():
+    new = make_member(is_pending=False, role_ids=(10,))
+    assert member_update_deltas(None, new) == []
+
+
+def test_rules_accepted_heuristic_skips_on_cache_miss_when_pending():
+    new = make_member(is_pending=True, role_ids=())
+    assert member_update_deltas(None, new) == []
+
+
+def test_rules_accepted_heuristic_fires_when_only_everyone_role_held():
+    # hikari always appends @everyone (id == guild id) to role_ids; a member who
+    # just accepted the rules holds ONLY @everyone, so the heuristic must fire.
+    new = make_member(is_pending=False, guild_id=42, role_ids=(42,))
+    triggers = [t for t, _ in member_update_deltas(None, new)]
+    assert triggers == ["member_rules_accepted"]
+
+
+def test_rules_accepted_heuristic_skips_when_real_role_beyond_everyone():
+    new = make_member(is_pending=False, guild_id=42, role_ids=(42, 10))
+    assert member_update_deltas(None, new) == []
+
+
+# ---------------------------------------------------------------------------
+# context builders
+# ---------------------------------------------------------------------------
+
+
+def test_member_join_context_shape():
+    member = make_member(is_bot=False)
+    ctx = member_join_context(member, 12345, 11987)
+    assert ctx["trigger_type"] == "member_join"
+    assert ctx["member_id"] == str(SNOWFLAKE)
+    assert ctx["is_bot"] is False
+    assert ctx["has_custom_avatar"] is True
+    assert ctx["guild_member_count"] == 12345
+    assert ctx["guild_human_member_count"] == 11987
+    assert ctx["account_created_at"].startswith("20")
+
+
+def test_member_join_context_flags_bot():
+    ctx = member_join_context(make_member(is_bot=True), 1, 0)
+    assert ctx["is_bot"] is True
+
+
+def test_member_leave_context_with_cached_old_member():
+    user = make_user()
+    old = make_member(role_ids=(10, 20))
+    ctx = member_leave_context(user, old, ["Mod", "Helper"])
+    assert ctx["trigger_type"] == "member_leave"
+    assert ctx["cache_incomplete"] is False
+    assert ctx["joined_at"] is not None
+    assert ctx["role_ids"] == ["10", "20"]
+    assert ctx["role_names"] == ["Mod", "Helper"]
+
+
+def test_member_leave_context_excludes_everyone_role():
+    # @everyone (id == guild id) must not leak into the reported role ids/names.
+    user = make_user()
+    old = make_member(guild_id=42, role_ids=(42, 10, 20))
+    ctx = member_leave_context(user, old, ["Mod", "Helper"])
+    assert ctx["role_ids"] == ["10", "20"]
+    assert ctx["role_names"] == ["Mod", "Helper"]
+
+
+def test_member_leave_context_on_cache_miss_is_partial():
+    user = make_user()
+    ctx = member_leave_context(user, None, [])
+    assert ctx["cache_incomplete"] is True
+    assert ctx["joined_at"] is None
+    assert ctx["role_ids"] == []
+    assert ctx["role_names"] == []
+    # account_created_at always available from the snowflake.
+    assert ctx["account_created_at"].startswith("20")
+
+
+def test_has_custom_avatar():
+    assert _has_custom_avatar(make_member(avatar_hash="x")) is True
+    assert _has_custom_avatar(make_member(avatar_hash=None)) is False
+    assert (
+        _has_custom_avatar(make_member(avatar_hash=None, guild_avatar_hash="g")) is True
+    )
+
+
+# ---------------------------------------------------------------------------
+# thread_create_context
+# ---------------------------------------------------------------------------
+
+
+def make_thread(
+    *,
+    thread_id=999,
+    name="help me",
+    parent_id=555,
+    owner_id=SNOWFLAKE,
+    applied_tag_ids=(),
+    created_at=datetime(2024, 6, 1, tzinfo=timezone.utc),
+):
+    return SimpleNamespace(
+        id=thread_id,
+        name=name,
+        parent_id=parent_id,
+        owner_id=owner_id,
+        applied_tag_ids=tuple(applied_tag_ids),
+        created_at=created_at,
+    )
+
+
+def test_thread_create_context_forum_post():
+    thread = make_thread(applied_tag_ids=(1, 2))
+    creator = make_user(username="bob")
+    ctx = thread_create_context(
+        thread,
+        creator,
+        starter_message_content="how do I foo?",
+        is_forum_post=True,
+        applied_tag_names=["Question", "Python"],
+    )
+    assert ctx["trigger_type"] == "thread_create"
+    assert ctx["thread_id"] == "999"
+    assert ctx["parent_channel_id"] == "555"
+    assert ctx["is_forum_post"] is True
+    assert ctx["applied_tag_ids"] == ["1", "2"]
+    assert ctx["applied_tag_names"] == ["Question", "Python"]
+    assert ctx["starter_message_content"] == "how do I foo?"
+    assert ctx["creator_username"] == "bob"
+
+
+def test_thread_create_context_regular_thread():
+    ctx = thread_create_context(
+        make_thread(),
+        make_user(),
+        starter_message_content="",
+        is_forum_post=False,
+        applied_tag_names=[],
+    )
+    assert ctx["is_forum_post"] is False
+    assert ctx["starter_message_content"] == ""
+    assert ctx["applied_tag_names"] == []
+
+
+# ---------------------------------------------------------------------------
+# message thread fields
+# ---------------------------------------------------------------------------
+
+
+def test_message_thread_fields_non_thread():
+    assert message_thread_fields(None) == {"is_thread": False}
+
+
+def test_message_thread_fields_thread():
+    thread = SimpleNamespace(id=999, name="side chat", parent_id=555)
+    fields = message_thread_fields(thread)
+    assert fields == {"is_thread": True, "thread_id": "999", "thread_name": "side chat"}
+
+
+# ---------------------------------------------------------------------------
+# role-change enrichment (guild-derived names/counts/boost)
+# ---------------------------------------------------------------------------
+
+
+def make_guild(*, roles=None, members=None, premium_subscription_count=0):
+    roles = roles or {}
+    members = members or {}
+
+    def get_role(role_id):
+        return roles.get(int(role_id))
+
+    def get_members():
+        return members
+
+    return SimpleNamespace(
+        get_role=get_role,
+        get_members=get_members,
+        premium_subscription_count=premium_subscription_count,
+        member_count=len(members),
+    )
+
+
+def make_role(role_id, name, is_boost=False):
+    return SimpleNamespace(
+        id=role_id, name=name, is_premium_subscriber_role=is_boost
+    )
+
+
+def test_resolve_role_names_uses_guild_cache():
+    guild = make_guild(roles={10: make_role(10, "Mod"), 20: make_role(20, "Helper")})
+    assert resolve_role_names(guild, ["10", "20"]) == ["Mod", "Helper"]
+
+
+def test_resolve_role_names_none_guild_is_empty():
+    assert resolve_role_names(None, ["10"]) == []
+
+
+def test_enrich_role_change_context_adds_names_and_boost():
+    boost_role = make_role(30, "Server Booster", is_boost=True)
+    booster = make_member(role_ids=(30,), premium_since=datetime.now(timezone.utc))
+    guild = make_guild(
+        roles={10: make_role(10, "Old"), 30: boost_role},
+        members={1: booster},
+        premium_subscription_count=14,
+    )
+    base = {
+        "trigger_type": "member_role_change",
+        "member_id": "1",
+        "member_display_name": "Alice",
+        "added_role_ids": ["30"],
+        "removed_role_ids": ["10"],
+    }
+    ctx = enrich_role_change_context(base, None, None, guild)
+    assert ctx["added_role_names"] == ["Server Booster"]
+    assert ctx["removed_role_names"] == ["Old"]
+    assert ctx["is_boost_role_added"] is True
+    assert ctx["premium_subscription_count"] == 14
+    assert ctx["boosting_member_count"] == 1
+    assert ctx["role_member_counts"]["30"] == 1
+    # pure: original dict is untouched
+    assert "added_role_names" not in base
+
+
+def test_guild_member_counts_counts_humans():
+    members = {
+        1: make_member(is_bot=False),
+        2: make_member(is_bot=False),
+        3: make_member(is_bot=True),
+    }
+    guild = make_guild(members=members)
+    total, human = guild_member_counts(guild)
+    assert total == 3
+    assert human == 2
+
+
+def test_guild_member_counts_none_guild():
+    assert guild_member_counts(None) == (None, None)
+
+
+# ---------------------------------------------------------------------------
+# dispatch wiring — capture calls via monkeypatched _dispatch
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def captured(monkeypatch):
+    calls = []
+
+    async def fake_dispatch(channel_id, guild_id, trigger_type, context):
+        calls.append((channel_id, guild_id, trigger_type, context))
+
+    monkeypatch.setattr(handler_events, "_dispatch", fake_dispatch)
+    return calls
+
+
+async def test_member_join_listener_dispatches_guild_scoped(captured):
+    member = make_member()
+    event = SimpleNamespace(
+        member=member,
+        guild_id=42,
+        get_guild=lambda: make_guild(members={1: member}),
+    )
+    await on_member_join(event)
+    assert len(captured) == 1
+    channel_id, guild_id, trigger, ctx = captured[0]
+    assert channel_id == ""  # member events have no home channel
+    assert guild_id == "42"
+    assert trigger == "member_join"
+
+
+async def test_member_leave_listener_fires_on_cache_miss(captured):
+    event = SimpleNamespace(
+        user=make_user(),
+        old_member=None,
+        guild_id=42,
+        get_guild=lambda: None,
+    )
+    await on_member_leave(event)
+    assert len(captured) == 1
+    _, _, trigger, ctx = captured[0]
+    assert trigger == "member_leave"
+    assert ctx["cache_incomplete"] is True
+
+
+async def test_member_leave_listener_excludes_everyone_from_names(captured):
+    old = make_member(guild_id=42, role_ids=(42, 10))
+    guild = make_guild(
+        roles={42: make_role(42, "@everyone"), 10: make_role(10, "Mod")}
+    )
+    event = SimpleNamespace(
+        user=make_user(), old_member=old, guild_id=42, get_guild=lambda: guild
+    )
+    await on_member_leave(event)
+    _, _, trigger, ctx = captured[0]
+    assert trigger == "member_leave"
+    assert ctx["role_ids"] == ["10"]
+    assert ctx["role_names"] == ["Mod"]  # @everyone filtered before name resolve
+
+
+async def test_member_update_listener_enriches_role_change(captured):
+    old = make_member(role_ids=(10,))
+    new = make_member(role_ids=(10, 30))
+    guild = make_guild(
+        roles={30: make_role(30, "VIP")},
+        members={1: new},
+        premium_subscription_count=3,
+    )
+    event = SimpleNamespace(
+        old_member=old, member=new, guild_id=42, get_guild=lambda: guild
+    )
+    await on_member_update(event)
+    assert len(captured) == 1
+    channel_id, guild_id, trigger, ctx = captured[0]
+    assert channel_id == ""
+    assert trigger == "member_role_change"
+    assert ctx["added_role_names"] == ["VIP"]
+
+
+# ---------------------------------------------------------------------------
+# thread_create dispatch
+# ---------------------------------------------------------------------------
+
+
+class FakeCache:
+    def __init__(
+        self, channels=None, threads=None, members=None, users=None, messages=None
+    ):
+        self._channels = channels or {}
+        self._threads = threads or {}
+        self._members = members or {}
+        self._users = users or {}
+        self._messages = messages or {}
+
+    def get_guild_channel(self, channel_id):
+        # Regular guild channels only — hikari's get_guild_channel never returns
+        # threads, so a thread id here resolves to None (like production).
+        return self._channels.get(int(channel_id))
+
+    def get_thread(self, thread_id):
+        return self._threads.get(int(thread_id))
+
+    def get_member(self, guild_id, user_id):
+        return self._members.get(int(user_id))
+
+    def get_user(self, user_id):
+        return self._users.get(int(user_id))
+
+    def get_message(self, message_id):
+        return self._messages.get(int(message_id))
+
+
+def make_forum_channel(channel_id=555, tags=None):
+    tags = tags or []
+    return SimpleNamespace(
+        id=channel_id,
+        type=hikari.ChannelType.GUILD_FORUM,
+        available_tags=tags,
+    )
+
+
+async def test_thread_create_only_fires_when_newly_created(captured):
+    bot = SimpleNamespace(cache=FakeCache())
+    event = SimpleNamespace(
+        thread=make_thread(), guild_id=42, newly_created=False
+    )
+    await dispatch_thread_create(bot, event)
+    assert captured == []
+
+
+async def test_thread_create_dispatches_on_parent_channel(captured):
+    parent = SimpleNamespace(id=555, type=hikari.ChannelType.GUILD_TEXT)
+    bot = SimpleNamespace(cache=FakeCache(channels={555: parent}))
+    event = SimpleNamespace(
+        thread=make_thread(parent_id=555), guild_id=42, newly_created=True
+    )
+    await dispatch_thread_create(bot, event)
+    assert len(captured) == 1
+    channel_id, guild_id, trigger, ctx = captured[0]
+    assert channel_id == "555"  # keyed off the PARENT channel
+    assert trigger == "thread_create"
+    assert ctx["is_forum_post"] is False
+
+
+async def test_thread_create_forum_post_carries_tags_and_starter(captured):
+    tag = SimpleNamespace(id=1, name="Question")
+    forum = make_forum_channel(555, tags=[tag])
+    starter = SimpleNamespace(content="how do I foo?")
+    bot = SimpleNamespace(
+        cache=FakeCache(channels={555: forum}, messages={999: starter})
+    )
+    event = SimpleNamespace(
+        thread=make_thread(thread_id=999, parent_id=555, applied_tag_ids=(1,)),
+        guild_id=42,
+        newly_created=True,
+    )
+    await dispatch_thread_create(bot, event)
+    _, _, _, ctx = captured[0]
+    assert ctx["is_forum_post"] is True
+    assert ctx["applied_tag_names"] == ["Question"]
+    assert ctx["starter_message_content"] == "how do I foo?"
+
+
+async def test_thread_create_forum_post_empty_starter_when_uncached(captured):
+    forum = make_forum_channel(555)
+    bot = SimpleNamespace(cache=FakeCache(channels={555: forum}))
+    event = SimpleNamespace(
+        thread=make_thread(thread_id=999, parent_id=555),
+        guild_id=42,
+        newly_created=True,
+    )
+    await dispatch_thread_create(bot, event)
+    _, _, _, ctx = captured[0]
+    assert ctx["is_forum_post"] is True
+    assert ctx["starter_message_content"] == ""
+
+
+# ---------------------------------------------------------------------------
+# thread-aware message dispatch
+# ---------------------------------------------------------------------------
+
+
+def make_message_event(*, channel_id, thread_channel=None):
+    author = SimpleNamespace(id=SNOWFLAKE, username="alice")
+    message = SimpleNamespace(
+        id=1234,
+        content="hello",
+        author=author,
+        attachments=[],
+    )
+    # A thread message's channel id resolves through cache.get_thread(), NOT
+    # get_guild_channel() — so register the thread under threads (as production
+    # does), proving the dispatch path reads threads from the right cache view.
+    threads = {}
+    if thread_channel is not None:
+        threads[int(channel_id)] = thread_channel
+    bot = SimpleNamespace(cache=FakeCache(threads=threads))
+    event = SimpleNamespace(
+        is_human=True,
+        guild_id=42,
+        channel_id=channel_id,
+        message=message,
+        member=None,
+    )
+    return bot, event
+
+
+async def test_message_in_thread_dispatches_to_parent_only(captured):
+    # §4: a single dispatch, keyed on the PARENT channel (home-channel semantics
+    # unchanged) — never a second dispatch on the thread id.
+    thread = SimpleNamespace(
+        id=999,
+        name="side chat",
+        parent_id=555,
+        type=hikari.ChannelType.GUILD_PUBLIC_THREAD,
+    )
+    bot, event = make_message_event(channel_id=999, thread_channel=thread)
+    await dispatch_message(bot, event)
+    assert len(captured) == 1
+    channel_id, _, trigger, ctx = captured[0]
+    assert channel_id == "555"  # the parent, not the thread id
+    assert trigger == "message"
+    assert ctx["is_thread"] is True
+    assert ctx["thread_id"] == "999"
+    assert ctx["thread_name"] == "side chat"
+
+
+async def test_non_thread_message_single_dispatch(captured):
+    bot, event = make_message_event(channel_id=555, thread_channel=None)
+    await dispatch_message(bot, event)
+    assert len(captured) == 1
+    channel_id, _, trigger, ctx = captured[0]
+    assert channel_id == "555"
+    assert ctx["is_thread"] is False
+    assert "thread_id" not in ctx
+
+
+async def test_message_from_bot_is_ignored(captured):
+    bot, event = make_message_event(channel_id=555)
+    event.is_human = False
+    await dispatch_message(bot, event)
+    assert captured == []

--- a/tests/bot/handler_tools_test.py
+++ b/tests/bot/handler_tools_test.py
@@ -80,6 +80,19 @@ async def test_register_unknown_trigger(monkeypatch):
     assert out.startswith("error: unknown trigger")
 
 
+@pytest.mark.parametrize(
+    "trigger",
+    ["member_join", "member join", "thread_create", "new thread", "member_role_change"],
+)
+async def test_register_admin_only_trigger_redirects(monkeypatch, trigger):
+    # The five member/thread triggers are admin-only: a member registering one
+    # here gets pointed at /adminhandler, not a generic "unknown trigger".
+    api = _FakeAPI()
+    out = await ht.register_handler(_ctx(api), "alert on it", trigger)
+    assert "admin handler" in out and "/adminhandler" in out
+    assert api.posted == [] and api.updated == []
+
+
 async def test_register_creates_named_handler(monkeypatch):
     seen = {}
 

--- a/tests/web/admin_actions_test.py
+++ b/tests/web/admin_actions_test.py
@@ -87,53 +87,115 @@ async def test_error_status_raises_admin_action_error():
 # -- thread operations ------------------------------------------------------
 
 
-async def test_close_thread_archives():
+def _thread_actor(
+    requests: list[httpx.Request],
+    channel_payload: dict | None = None,
+    get_status: int = 200,
+    mutate_status: int = 200,
+) -> AdminActor:
+    """Actor whose transport answers GET /channels/{id} with a channel object.
+
+    Every mutating thread op first verifies its target through that GET; the
+    default payload is a public thread in the actor's own guild.
+    """
+
+    payload = channel_payload or {"type": 11, "guild_id": "G1"}
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if request.method == "GET":
+            if get_status >= 400:
+                return httpx.Response(get_status)
+            return httpx.Response(get_status, json=payload)
+        return httpx.Response(mutate_status)
+
+    return AdminActor(
+        bot_token="t", guild_id="G1", transport=httpx.MockTransport(handle)
+    )
+
+
+async def test_close_thread_verifies_then_archives():
     requests: list[httpx.Request] = []
-    result = await _actor(requests, status_code=200).close_thread("T1")
+    result = await _thread_actor(requests).close_thread("T1")
     assert result is True
-    request = requests[0]
-    assert request.method == "PATCH"
-    assert request.url.path.endswith("/channels/T1")
-    assert json.loads(request.content) == {"archived": True}
+    verify, mutate = requests
+    assert verify.method == "GET"
+    assert verify.url.path.endswith("/channels/T1")
+    assert mutate.method == "PATCH"
+    assert mutate.url.path.endswith("/channels/T1")
+    assert json.loads(mutate.content) == {"archived": True}
 
 
 async def test_lock_thread_locks_and_archives():
     requests: list[httpx.Request] = []
-    result = await _actor(requests, status_code=200).lock_thread("T1")
+    result = await _thread_actor(requests).lock_thread("T1")
     assert result is True
-    assert json.loads(requests[0].content) == {"locked": True, "archived": True}
+    assert json.loads(requests[-1].content) == {"locked": True, "archived": True}
 
 
 async def test_reopen_thread_unarchives():
     requests: list[httpx.Request] = []
-    result = await _actor(requests, status_code=200).reopen_thread("T1")
+    result = await _thread_actor(requests).reopen_thread("T1")
     assert result is True
-    request = requests[0]
-    assert request.method == "PATCH"
-    assert json.loads(request.content) == {"archived": False}
+    mutate = requests[-1]
+    assert mutate.method == "PATCH"
+    assert json.loads(mutate.content) == {"archived": False}
 
 
 async def test_delete_thread_deletes():
     requests: list[httpx.Request] = []
-    result = await _actor(requests, status_code=200).delete_thread("T1")
+    result = await _thread_actor(requests).delete_thread("T1")
     assert result is True
-    request = requests[0]
-    assert request.method == "DELETE"
-    assert request.url.path.endswith("/channels/T1")
+    mutate = requests[-1]
+    assert mutate.method == "DELETE"
+    assert mutate.url.path.endswith("/channels/T1")
 
 
-async def test_thread_ops_return_false_on_404():
+async def test_thread_ops_return_false_on_gone_target():
     """A janitor sweeping an already-deleted thread is a silent no-op."""
-    for status in (404,):
-        assert await _actor([], status_code=status).close_thread("T1") is False
-        assert await _actor([], status_code=status).lock_thread("T1") is False
-        assert await _actor([], status_code=status).reopen_thread("T1") is False
-        assert await _actor([], status_code=status).delete_thread("T1") is False
+    for op in ("close_thread", "lock_thread", "reopen_thread", "delete_thread"):
+        requests: list[httpx.Request] = []
+        actor = _thread_actor(requests, get_status=404)
+        assert await getattr(actor, op)("T1") is False
+        assert [r.method for r in requests] == ["GET"], "must not mutate a gone target"
+
+
+async def test_thread_ops_return_false_when_mutation_hits_404():
+    """Thread deleted between verification and mutation: still a no-op."""
+    requests: list[httpx.Request] = []
+    assert await _thread_actor(requests, mutate_status=404).close_thread("T1") is False
 
 
 async def test_thread_ops_raise_on_non_404_error():
     for status in (403, 500):
         with pytest.raises(AdminActionError):
-            await _actor([], status_code=status).close_thread("T1")
+            await _thread_actor([], mutate_status=status).close_thread("T1")
         with pytest.raises(AdminActionError):
-            await _actor([], status_code=status).delete_thread("T1")
+            await _thread_actor([], mutate_status=status).delete_thread("T1")
+
+
+async def test_thread_ops_reject_non_thread_channel():
+    """DELETE /channels/{id} on a text channel would delete it wholesale."""
+    for op in ("close_thread", "lock_thread", "reopen_thread", "delete_thread"):
+        requests: list[httpx.Request] = []
+        actor = _thread_actor(requests, channel_payload={"type": 0, "guild_id": "G1"})
+        with pytest.raises(AdminActionError, match="not a thread"):
+            await getattr(actor, op)("C1")
+        assert [r.method for r in requests] == ["GET"], "must not touch a non-thread"
+
+
+async def test_thread_ops_reject_thread_outside_guild():
+    requests: list[httpx.Request] = []
+    actor = _thread_actor(requests, channel_payload={"type": 11, "guild_id": "G2"})
+    with pytest.raises(AdminActionError, match="outside guild"):
+        await actor.delete_thread("T1")
+    assert [r.method for r in requests] == ["GET"]
+
+
+async def test_thread_verification_cached_across_ops():
+    """A close-then-lock sweep fetches the channel once, not per mutation."""
+    requests: list[httpx.Request] = []
+    actor = _thread_actor(requests)
+    await actor.close_thread("T1")
+    await actor.lock_thread("T1")
+    assert [r.method for r in requests] == ["GET", "PATCH", "PATCH"]

--- a/tests/web/admin_actions_test.py
+++ b/tests/web/admin_actions_test.py
@@ -82,3 +82,58 @@ async def test_error_status_raises_admin_action_error():
     requests: list[httpx.Request] = []
     with pytest.raises(AdminActionError):
         await _actor(requests, status_code=403).kick_user("U1")
+
+
+# -- thread operations ------------------------------------------------------
+
+
+async def test_close_thread_archives():
+    requests: list[httpx.Request] = []
+    result = await _actor(requests, status_code=200).close_thread("T1")
+    assert result is True
+    request = requests[0]
+    assert request.method == "PATCH"
+    assert request.url.path.endswith("/channels/T1")
+    assert json.loads(request.content) == {"archived": True}
+
+
+async def test_lock_thread_locks_and_archives():
+    requests: list[httpx.Request] = []
+    result = await _actor(requests, status_code=200).lock_thread("T1")
+    assert result is True
+    assert json.loads(requests[0].content) == {"locked": True, "archived": True}
+
+
+async def test_reopen_thread_unarchives():
+    requests: list[httpx.Request] = []
+    result = await _actor(requests, status_code=200).reopen_thread("T1")
+    assert result is True
+    request = requests[0]
+    assert request.method == "PATCH"
+    assert json.loads(request.content) == {"archived": False}
+
+
+async def test_delete_thread_deletes():
+    requests: list[httpx.Request] = []
+    result = await _actor(requests, status_code=200).delete_thread("T1")
+    assert result is True
+    request = requests[0]
+    assert request.method == "DELETE"
+    assert request.url.path.endswith("/channels/T1")
+
+
+async def test_thread_ops_return_false_on_404():
+    """A janitor sweeping an already-deleted thread is a silent no-op."""
+    for status in (404,):
+        assert await _actor([], status_code=status).close_thread("T1") is False
+        assert await _actor([], status_code=status).lock_thread("T1") is False
+        assert await _actor([], status_code=status).reopen_thread("T1") is False
+        assert await _actor([], status_code=status).delete_thread("T1") is False
+
+
+async def test_thread_ops_raise_on_non_404_error():
+    for status in (403, 500):
+        with pytest.raises(AdminActionError):
+            await _actor([], status_code=status).close_thread("T1")
+        with pytest.raises(AdminActionError):
+            await _actor([], status_code=status).delete_thread("T1")

--- a/tests/web/handler_budget_test.py
+++ b/tests/web/handler_budget_test.py
@@ -6,7 +6,15 @@ import time
 
 import pytest
 
-from smarter_dev.web.handler_budget import CapExceeded, HandlerBudget
+from smarter_dev.web.handler_budget import (
+    ADMIN_MAX_DISCORD_READS,
+    ADMIN_MAX_THREAD_OPS,
+    CapExceeded,
+    DEFAULT_MAX_DISCORD_READS,
+    DEFAULT_MAX_THREAD_OPS,
+    HandlerBudget,
+    admin_budget,
+)
 
 
 def test_messages_cap_raises_on_breach():
@@ -78,4 +86,68 @@ def test_usage_snapshot():
         "web_reads": 0,
         "agent_calls": 1,
         "mod_actions": 0,
+        "discord_reads": 0,
+        "thread_ops": 0,
     }
+
+
+def test_discord_read_cap_raises_on_breach():
+    budget = HandlerBudget(max_discord_reads=2)
+    budget.spend_discord_read()
+    budget.spend_discord_read()
+    with pytest.raises(CapExceeded) as exc:
+        budget.spend_discord_read()
+    assert exc.value.cap == "discord_reads"
+    assert budget.discord_reads == 2
+
+
+def test_default_thread_ops_budget_is_zero_for_standard_tier():
+    # Standard handlers have no mutating thread ops, like mod_actions.
+    assert DEFAULT_MAX_THREAD_OPS == 0
+    budget = HandlerBudget()
+    with pytest.raises(CapExceeded) as exc:
+        budget.spend_thread_op()
+    assert exc.value.cap == "thread_ops"
+    assert budget.thread_ops == 0
+
+
+def test_default_discord_reads_budget():
+    assert DEFAULT_MAX_DISCORD_READS == 2
+    budget = HandlerBudget()
+    budget.spend_discord_read()
+    budget.spend_discord_read()
+    with pytest.raises(CapExceeded):
+        budget.spend_discord_read()
+
+
+def test_admin_budget_raises_thread_and_read_ceilings():
+    assert ADMIN_MAX_DISCORD_READS == 5
+    assert ADMIN_MAX_THREAD_OPS == 10
+    budget = admin_budget()
+    for _ in range(ADMIN_MAX_THREAD_OPS):
+        budget.spend_thread_op()
+    with pytest.raises(CapExceeded) as exc:
+        budget.spend_thread_op()
+    assert exc.value.cap == "thread_ops"
+    for _ in range(ADMIN_MAX_DISCORD_READS):
+        budget.spend_discord_read()
+    with pytest.raises(CapExceeded):
+        budget.spend_discord_read()
+
+
+def test_new_counters_appear_in_usage_after_spend():
+    budget = admin_budget()
+    budget.spend_discord_read()
+    budget.spend_thread_op()
+    usage = budget.usage()
+    assert usage["discord_reads"] == 1
+    assert usage["thread_ops"] == 1
+
+
+def test_thread_op_checks_deadline_first():
+    budget = admin_budget()
+    budget.wall_clock_seconds = 0.0
+    budget.started_at = time.monotonic() - 1.0
+    with pytest.raises(CapExceeded) as exc:
+        budget.spend_thread_op()
+    assert exc.value.cap == "wall_clock"

--- a/tests/web/handler_caps_test.py
+++ b/tests/web/handler_caps_test.py
@@ -3,8 +3,12 @@
 from __future__ import annotations
 
 from smarter_dev.web.handler_caps import (
+    GUILD_MEMBER_EVENTS_PER_MIN,
+    GUILD_THREAD_OPS_PER_MIN,
     WindowedLimiter,
     fires_per_min_for_trigger,
+    guild_member_events_key,
+    guild_thread_ops_key,
     HANDLER_FIRES_PER_MIN_MESSAGE,
     HANDLER_FIRES_PER_MIN_REACTION,
 )
@@ -79,3 +83,27 @@ def test_reaction_triggers_have_tighter_fire_ceiling():
     assert fires_per_min_for_trigger("reaction") == HANDLER_FIRES_PER_MIN_REACTION
     assert fires_per_min_for_trigger("message") == HANDLER_FIRES_PER_MIN_MESSAGE
     assert HANDLER_FIRES_PER_MIN_REACTION < HANDLER_FIRES_PER_MIN_MESSAGE
+
+
+def test_new_triggers_pinned_at_ten_fires_per_min():
+    # §3.4: the five new triggers use the default (non-reaction) fire ceiling of
+    # 10 — pinned so a future refactor cannot silently move it.
+    for trigger in (
+        "member_join",
+        "member_leave",
+        "member_rules_accepted",
+        "member_role_change",
+        "thread_create",
+    ):
+        assert fires_per_min_for_trigger(trigger) == 10
+        assert fires_per_min_for_trigger(trigger) == HANDLER_FIRES_PER_MIN_MESSAGE
+
+
+def test_guild_member_events_window():
+    assert GUILD_MEMBER_EVENTS_PER_MIN == 60
+    assert guild_member_events_key("G1") == "hcap:memberevt:G1"
+
+
+def test_guild_thread_ops_window():
+    assert GUILD_THREAD_OPS_PER_MIN == 30
+    assert guild_thread_ops_key("G1") == "hcap:threadop:G1"

--- a/tests/web/handler_emitter_test.py
+++ b/tests/web/handler_emitter_test.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Callable
 
 import httpx
 import pytest
@@ -18,6 +19,15 @@ def _emitter(
         return httpx.Response(status_code, text=body)
 
     return DiscordEmitter(bot_token="t", transport=httpx.MockTransport(handle))
+
+
+def _routed_emitter(
+    handle: Callable[[httpx.Request], httpx.Response], guild_id: str = "G1"
+) -> DiscordEmitter:
+    """An emitter whose responses vary by request (multi-call methods)."""
+    return DiscordEmitter(
+        bot_token="t", guild_id=guild_id, transport=httpx.MockTransport(handle)
+    )
 
 
 async def test_create_message_posts_content_and_returns_id():
@@ -60,4 +70,315 @@ async def test_error_status_raises_emit_error():
     with pytest.raises(DiscordEmitError):
         await _emitter(requests, status_code=403, body="nope").create_message(
             "C1", "hello"
+        )
+
+
+# -- list_threads -----------------------------------------------------------
+
+_ACTIVE_THREADS_BODY = json.dumps(
+    {
+        "threads": [
+            {
+                "id": "T1",
+                "name": "active-here",
+                "parent_id": "C1",
+                "owner_id": "U1",
+                "message_count": 4,
+                "thread_metadata": {
+                    "archived": False,
+                    "locked": False,
+                    "create_timestamp": "2026-07-01T00:00:00+00:00",
+                },
+                "applied_tags": ["TAG1"],
+            },
+            {
+                # different parent channel — must be filtered out
+                "id": "T2",
+                "name": "elsewhere",
+                "parent_id": "C9",
+                "owner_id": "U2",
+                "message_count": 1,
+                "thread_metadata": {"archived": False, "locked": False},
+            },
+        ]
+    }
+)
+_ARCHIVED_THREADS_BODY = json.dumps(
+    {
+        "threads": [
+            {
+                "id": "T3",
+                "name": "archived-here",
+                "parent_id": "C1",
+                "owner_id": "U3",
+                "message_count": 9,
+                "thread_metadata": {
+                    "archived": True,
+                    "locked": True,
+                    "create_timestamp": "2026-06-01T00:00:00+00:00",
+                },
+            }
+        ],
+        "has_more": False,
+    }
+)
+_PARENT_CHANNEL_BODY = json.dumps(
+    {
+        "id": "C1",
+        "type": 15,
+        "available_tags": [
+            {"id": "TAG1", "name": "bug"},
+            {"id": "TAG2", "name": "feature"},
+        ],
+    }
+)
+
+
+def _thread_list_handler(
+    requests: list[httpx.Request],
+) -> Callable[[httpx.Request], httpx.Response]:
+    def handle(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        path = request.url.path
+        if path.endswith("/guilds/G1/threads/active"):
+            return httpx.Response(200, text=_ACTIVE_THREADS_BODY)
+        if path.endswith("/channels/C1/threads/archived/public"):
+            return httpx.Response(200, text=_ARCHIVED_THREADS_BODY)
+        if path.endswith("/channels/C1"):
+            return httpx.Response(200, text=_PARENT_CHANNEL_BODY)
+        return httpx.Response(404, text="{}")
+
+    return handle
+
+
+async def test_list_threads_merges_active_and_archived_filtered_to_parent():
+    requests: list[httpx.Request] = []
+    threads = await _routed_emitter(_thread_list_handler(requests)).list_threads("C1")
+
+    # T2 (parent C9) filtered out; active first, then archived.
+    assert [t["thread_id"] for t in threads] == ["T1", "T3"]
+    active = threads[0]
+    assert active == {
+        "thread_id": "T1",
+        "name": "active-here",
+        "created_at": "2026-07-01T00:00:00+00:00",
+        "archived": False,
+        "locked": False,
+        "owner_id": "U1",
+        "message_count": 4,
+        "applied_tag_names": ["bug"],
+    }
+    archived = threads[1]
+    assert archived["archived"] is True
+    assert archived["locked"] is True
+    assert archived["applied_tag_names"] == []
+
+
+async def test_list_threads_passes_limit_to_archived_request():
+    requests: list[httpx.Request] = []
+    await _routed_emitter(_thread_list_handler(requests)).list_threads("C1", limit=7)
+    archived_request = next(
+        r for r in requests if r.url.path.endswith("/threads/archived/public")
+    )
+    assert archived_request.url.params["limit"] == "7"
+
+
+async def test_list_threads_skips_tag_fetch_when_no_thread_has_tags():
+    requests: list[httpx.Request] = []
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        path = request.url.path
+        if path.endswith("/guilds/G1/threads/active"):
+            return httpx.Response(200, text=json.dumps({"threads": []}))
+        if path.endswith("/channels/C1/threads/archived/public"):
+            return httpx.Response(
+                200,
+                text=json.dumps(
+                    {
+                        "threads": [
+                            {
+                                "id": "T3",
+                                "name": "plain",
+                                "parent_id": "C1",
+                                "owner_id": "U3",
+                                "message_count": 0,
+                                "thread_metadata": {
+                                    "archived": True,
+                                    "locked": False,
+                                },
+                            }
+                        ]
+                    }
+                ),
+            )
+        return httpx.Response(500, text="parent channel should not be fetched")
+
+    threads = await _routed_emitter(handle).list_threads("C1")
+    assert threads[0]["applied_tag_names"] == []
+    # No bare GET /channels/C1 was issued (only the archived sub-path).
+    assert not any(
+        r.url.path.endswith("/channels/C1") for r in requests
+    )
+
+
+async def test_list_threads_caps_at_fifty():
+    requests: list[httpx.Request] = []
+    many = [
+        {
+            "id": f"A{i}",
+            "name": "x",
+            "parent_id": "C1",
+            "owner_id": "U",
+            "message_count": 0,
+            "thread_metadata": {"archived": False, "locked": False},
+        }
+        for i in range(60)
+    ]
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        path = request.url.path
+        if path.endswith("/guilds/G1/threads/active"):
+            return httpx.Response(200, text=json.dumps({"threads": many}))
+        return httpx.Response(200, text=json.dumps({"threads": []}))
+
+    threads = await _routed_emitter(handle).list_threads("C1")
+    assert len(threads) == 50
+
+
+async def test_list_threads_returns_empty_on_404():
+    requests: list[httpx.Request] = []
+    threads = await _routed_emitter(
+        lambda r: (requests.append(r), httpx.Response(404, text="gone"))[1]
+    ).list_threads("C1")
+    assert threads == []
+
+
+async def test_list_threads_raises_on_non_404_error():
+    with pytest.raises(DiscordEmitError):
+        await _routed_emitter(
+            lambda r: httpx.Response(403, text="forbidden")
+        ).list_threads("C1")
+
+
+# -- create_thread ----------------------------------------------------------
+
+
+async def test_create_thread_from_message():
+    requests: list[httpx.Request] = []
+    thread_id = await _emitter(requests, body='{"id": "T7"}').create_thread(
+        "C1", "discussion", message_id="M5"
+    )
+    assert thread_id == "T7"
+    request = requests[0]
+    assert request.method == "POST"
+    assert request.url.path.endswith("/channels/C1/messages/M5/threads")
+    assert json.loads(request.content) == {"name": "discussion"}
+
+
+async def test_create_thread_standalone_is_public_type_11():
+    requests: list[httpx.Request] = []
+    thread_id = await _emitter(requests, body='{"id": "T8"}').create_thread(
+        "C1", "standalone"
+    )
+    assert thread_id == "T8"
+    request = requests[0]
+    assert request.method == "POST"
+    assert request.url.path.endswith("/channels/C1/threads")
+    payload = json.loads(request.content)
+    assert payload == {"name": "standalone", "type": 11}
+
+
+async def test_create_thread_raises_on_any_failure_including_404():
+    requests: list[httpx.Request] = []
+    with pytest.raises(DiscordEmitError):
+        await _emitter(requests, status_code=404, body="gone").create_thread(
+            "C1", "x"
+        )
+
+
+# -- create_post ------------------------------------------------------------
+
+
+async def test_create_post_resolves_tag_names_to_ids():
+    requests: list[httpx.Request] = []
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if request.method == "GET":
+            return httpx.Response(200, text=_PARENT_CHANNEL_BODY)
+        return httpx.Response(201, text='{"id": "P1"}')
+
+    post_id = await _routed_emitter(handle).create_post(
+        "C1", "How do I?", "help me", tag_names=["feature"]
+    )
+    assert post_id == "P1"
+    post_request = next(r for r in requests if r.method == "POST")
+    assert post_request.url.path.endswith("/channels/C1/threads")
+    payload = json.loads(post_request.content)
+    assert payload["name"] == "How do I?"
+    assert payload["message"] == {"content": "help me"}
+    assert payload["applied_tags"] == ["TAG2"]
+
+
+async def test_create_post_without_tags_sends_no_applied_tags():
+    requests: list[httpx.Request] = []
+    post_id = await _emitter(requests, body='{"id": "P2"}').create_post(
+        "C1", "title", "body"
+    )
+    assert post_id == "P2"
+    # Only the create POST — no channel fetch to resolve tags.
+    assert len(requests) == 1
+    payload = json.loads(requests[0].content)
+    assert "applied_tags" not in payload
+
+
+async def test_create_post_unknown_tag_raises_value_error_listing_valid():
+    def handle(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, text=_PARENT_CHANNEL_BODY)
+
+    with pytest.raises(ValueError) as exc_info:
+        await _routed_emitter(handle).create_post(
+            "C1", "title", "body", tag_names=["nonsense"]
+        )
+    message = str(exc_info.value)
+    assert "nonsense" in message
+    assert "bug" in message and "feature" in message
+
+
+# -- get_thread_parent_id ---------------------------------------------------
+
+
+async def test_get_thread_parent_id_returns_parent_for_thread_type():
+    requests: list[httpx.Request] = []
+    parent = await _emitter(
+        requests, body='{"id": "T1", "type": 11, "parent_id": "C1"}'
+    ).get_thread_parent_id("T1")
+    assert parent == "C1"
+    assert requests[0].method == "GET"
+    assert requests[0].url.path.endswith("/channels/T1")
+
+
+async def test_get_thread_parent_id_returns_none_for_non_thread_channel():
+    requests: list[httpx.Request] = []
+    parent = await _emitter(
+        requests, body='{"id": "C1", "type": 0, "parent_id": "CAT1"}'
+    ).get_thread_parent_id("C1")
+    assert parent is None
+
+
+async def test_get_thread_parent_id_returns_none_on_404():
+    requests: list[httpx.Request] = []
+    parent = await _emitter(
+        requests, status_code=404, body="gone"
+    ).get_thread_parent_id("T1")
+    assert parent is None
+
+
+async def test_get_thread_parent_id_raises_on_non_404_error():
+    requests: list[httpx.Request] = []
+    with pytest.raises(DiscordEmitError):
+        await _emitter(requests, status_code=403, body="nope").get_thread_parent_id(
+            "T1"
         )

--- a/tests/web/handler_lint_test.py
+++ b/tests/web/handler_lint_test.py
@@ -68,3 +68,24 @@ def test_allows_function_that_is_called():
 
 def test_allows_plain_toplevel_script():
     assert check_static('await send_message("hi")\n') is None
+
+
+def test_rejects_hardcoded_delete_thread_target():
+    # A delete target must come from trigger context or a list_threads result —
+    # a hardcoded id literal is an unreviewable destructive action.
+    reason = check_static('await delete_thread("123456789012345678")\n')
+    assert reason and "delete_thread" in reason
+
+
+def test_allows_delete_thread_from_context():
+    ok = 'await delete_thread(context["thread_id"])\n'
+    assert check_static(ok) is None
+
+
+def test_allows_delete_thread_over_list_threads_result():
+    script = (
+        "for t in await list_threads(context['parent_channel_id']):\n"
+        "    if t['archived']:\n"
+        "        await delete_thread(t['thread_id'])\n"
+    )
+    assert check_static(script) is None

--- a/tests/web/handler_models_test.py
+++ b/tests/web/handler_models_test.py
@@ -5,7 +5,15 @@ from __future__ import annotations
 import pytest
 from sqlalchemy.exc import IntegrityError
 
-from smarter_dev.web.models import AdminHandler, ChannelHandler
+from smarter_dev.web.models import (
+    ADMIN_HANDLER_EVENT_TRIGGERS,
+    ADMIN_HANDLER_TRIGGER_TYPES,
+    ADMIN_ONLY_TRIGGER_TYPES,
+    HANDLER_EVENT_TRIGGERS,
+    HANDLER_TRIGGER_TYPES,
+    AdminHandler,
+    ChannelHandler,
+)
 
 
 def _handler(
@@ -41,6 +49,79 @@ async def test_same_name_in_different_channels(db_session):
     db_session.add(_handler("message", channel_id="C1", name="greeter"))
     db_session.add(_handler("message", channel_id="C2", name="greeter"))
     await db_session.commit()  # uniqueness is per channel
+
+
+def test_standard_trigger_vocabulary_unchanged():
+    # The standard tier's four triggers must not grow (§2, §6).
+    assert HANDLER_TRIGGER_TYPES == ("message", "reaction", "schedule", "timer")
+    assert HANDLER_EVENT_TRIGGERS == ("message", "reaction")
+
+
+def test_admin_only_trigger_types_are_the_five_new_ones():
+    assert ADMIN_ONLY_TRIGGER_TYPES == (
+        "member_join",
+        "member_leave",
+        "member_rules_accepted",
+        "member_role_change",
+        "thread_create",
+    )
+
+
+def test_admin_trigger_tuple_is_the_union_of_standard_and_new():
+    assert ADMIN_HANDLER_TRIGGER_TYPES == HANDLER_TRIGGER_TYPES + ADMIN_ONLY_TRIGGER_TYPES
+    # Every standard trigger and every new admin-only trigger is admissible.
+    for trigger in HANDLER_TRIGGER_TYPES + ADMIN_ONLY_TRIGGER_TYPES:
+        assert trigger in ADMIN_HANDLER_TRIGGER_TYPES
+
+
+def test_admin_event_triggers_extend_the_gateway_subset():
+    # Gateway-dispatched (event) triggers: message/reaction plus the five new
+    # ones; the time triggers (schedule/timer) stay out.
+    assert ADMIN_HANDLER_EVENT_TRIGGERS == HANDLER_EVENT_TRIGGERS + ADMIN_ONLY_TRIGGER_TYPES
+    assert "schedule" not in ADMIN_HANDLER_EVENT_TRIGGERS
+    assert "timer" not in ADMIN_HANDLER_EVENT_TRIGGERS
+
+
+@pytest.mark.parametrize("trigger", ADMIN_ONLY_TRIGGER_TYPES)
+async def test_admin_handler_accepts_new_trigger_types(db_session, trigger):
+    db_session.add(
+        AdminHandler(
+            guild_id="G1",
+            name=f"{trigger}-handler",
+            trigger_type=trigger,
+            settings={},
+            channel_ids=[],
+            description="d",
+            script="pass\n",
+            created_by_admin="A1",
+        )
+    )
+    await db_session.commit()  # extended CHECK constraint admits it
+
+
+@pytest.mark.parametrize("trigger", ADMIN_ONLY_TRIGGER_TYPES)
+async def test_channel_handler_rejects_new_trigger_types(db_session, trigger):
+    # The standard-tier CHECK constraint is deliberately NOT extended (§6).
+    db_session.add(_handler(trigger, name="nope"))
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+
+
+async def test_handler_run_has_discord_reads_and_thread_ops(db_session):
+    from smarter_dev.web.models import HandlerRun
+    from uuid import uuid4
+
+    run = HandlerRun(
+        handler_id=uuid4(),
+        trigger_context={},
+        outcome="ok",
+        discord_reads=3,
+        thread_ops=2,
+    )
+    db_session.add(run)
+    await db_session.commit()
+    assert run.discord_reads == 3
+    assert run.thread_ops == 2
 
 
 async def test_admin_handler_name_is_unique_per_guild(db_session):

--- a/tests/web/handler_runtime_test.py
+++ b/tests/web/handler_runtime_test.py
@@ -12,6 +12,18 @@ from smarter_dev.web.handler_runtime import run_handler_script
 class _FakeEmitter:
     messages: list[tuple[str, str]] = field(default_factory=list)
     reactions: list[tuple[str, str, str]] = field(default_factory=list)
+    # channel_id -> list[dict] returned by list_threads (missing key -> [], the
+    # emitter's gone-channel (404) shape).
+    threads_by_channel: dict = field(default_factory=dict)
+    created_threads: list = field(default_factory=list)
+    created_posts: list = field(default_factory=list)
+    # thread_id -> parent channel id (None models a non-thread / gone channel).
+    parent_by_thread: dict = field(default_factory=dict)
+    parent_calls: list = field(default_factory=list)
+    # channel_id -> owning guild id (None models a gone channel). Backs the admin
+    # list_threads guild-scope rail.
+    guild_by_channel: dict = field(default_factory=dict)
+    guild_calls: list = field(default_factory=list)
 
     async def create_message(self, channel_id: str, content: str) -> str:
         self.messages.append((channel_id, content))
@@ -19,6 +31,25 @@ class _FakeEmitter:
 
     async def add_reaction(self, channel_id: str, message_id: str, emoji: str) -> None:
         self.reactions.append((channel_id, message_id, emoji))
+
+    async def list_threads(self, channel_id: str, limit: int = 50) -> list:
+        return self.threads_by_channel.get(channel_id, [])
+
+    async def get_channel_guild_id(self, channel_id: str):
+        self.guild_calls.append(channel_id)
+        return self.guild_by_channel.get(channel_id)
+
+    async def create_thread(self, channel_id, name, message_id=None) -> str:
+        self.created_threads.append((channel_id, name, message_id))
+        return f"thread{len(self.created_threads)}"
+
+    async def create_post(self, channel_id, title, content, tag_names=None) -> str:
+        self.created_posts.append((channel_id, title, content, tag_names))
+        return f"post{len(self.created_posts)}"
+
+    async def get_thread_parent_id(self, thread_id: str):
+        self.parent_calls.append(thread_id)
+        return self.parent_by_thread.get(thread_id)
 
 
 @dataclass
@@ -34,6 +65,8 @@ class _StubLimiter:
 @dataclass
 class _FakeActor:
     calls: list = field(default_factory=list)
+    # Thread ids that model a gone target (404): the mutation returns False.
+    gone: set = field(default_factory=set)
 
     async def ban_user(self, user_id, reason=None):
         self.calls.append(("ban", user_id, reason)); return f"banned {user_id}"
@@ -47,8 +80,23 @@ class _FakeActor:
     async def delete_message(self, channel_id, message_id):
         self.calls.append(("delete", channel_id, message_id)); return "ok"
 
+    async def close_thread(self, thread_id):
+        self.calls.append(("close", thread_id)); return thread_id not in self.gone
 
-async def _run(script, *, budget=None, emitter=None, limiter=None, agent_runner=None, actor=None):
+    async def lock_thread(self, thread_id):
+        self.calls.append(("lock", thread_id)); return thread_id not in self.gone
+
+    async def reopen_thread(self, thread_id):
+        self.calls.append(("reopen", thread_id)); return thread_id not in self.gone
+
+    async def delete_thread(self, thread_id):
+        self.calls.append(("delete_thread", thread_id)); return thread_id not in self.gone
+
+
+async def _run(
+    script, *, budget=None, emitter=None, limiter=None, agent_runner=None,
+    actor=None, channel_ids=None,
+):
     emitter = emitter or _FakeEmitter()
     limiter = limiter or _StubLimiter()
     kwargs = {}
@@ -56,6 +104,8 @@ async def _run(script, *, budget=None, emitter=None, limiter=None, agent_runner=
         kwargs["agent_runner"] = agent_runner
     if actor is not None:
         kwargs["actor"] = actor
+    if channel_ids is not None:
+        kwargs["channel_ids"] = channel_ids
     result = await run_handler_script(
         script,
         {
@@ -291,3 +341,271 @@ async def test_filesystem_still_blocked_with_clock_wired():
     result, emitter, _ = await _run(script)
     assert result.outcome == "error"
     assert emitter.messages == []
+
+
+# -- thread reads / creates (general, both tiers) ------------------------------
+
+from smarter_dev.web.handler_caps import (
+    CHANNEL_MESSAGES_PER_MIN,
+    GUILD_THREAD_OPS_PER_MIN,
+    channel_message_key,
+    guild_thread_ops_key,
+)
+
+
+async def test_list_threads_home_channel_spends_discord_read():
+    emitter = _FakeEmitter(threads_by_channel={"C1": [{"thread_id": "T1"}]})
+    script = (
+        "threads = await list_threads()\n"
+        'await send_message(f"{len(threads)}:{threads[0][\'thread_id\']}")\n'
+    )
+    result, emitter, _ = await _run(script, emitter=emitter)
+    assert result.outcome == "ok", result.error
+    assert emitter.messages[0][1] == "1:T1"
+    assert result.usage["discord_reads"] == 1
+
+
+async def test_list_threads_gone_channel_returns_empty_without_error():
+    # A gone channel is [] from the emitter; the script sees [] and does not error.
+    script = (
+        "threads = await list_threads()\n"
+        'await send_message("empty" if threads == [] else "nonempty")\n'
+    )
+    result, emitter, _ = await _run(script)  # no threads registered -> []
+    assert result.outcome == "ok", result.error
+    assert emitter.messages[0][1] == "empty"
+
+
+async def test_list_threads_discord_read_cap_breaches():
+    script = "for i in range(3):\n    await list_threads()\n"
+    result, _, _ = await _run(script, budget=HandlerBudget(max_discord_reads=2))
+    assert result.outcome == "cap_exceeded"
+    assert result.cap == "discord_reads"
+
+
+async def test_standard_list_threads_foreign_channel_denied():
+    result, emitter, _ = await _run('await list_threads("OTHER")\n')
+    assert result.outcome == "cap_exceeded"
+    assert result.cap == "cross_channel_send"
+    assert result.usage["discord_reads"] == 0  # denied before spending
+
+
+async def test_create_thread_spends_message_and_channel_window():
+    script = 'tid = await create_thread("help")\nawait send_message(tid)\n'
+    result, emitter, limiter = await _run(script)
+    assert result.outcome == "ok", result.error
+    assert emitter.created_threads == [("C1", "help", None)]
+    assert emitter.messages[0][1] == "thread1"  # returned id flows to the script
+    assert result.usage["messages_sent"] == 2  # create + the send_message
+    assert (channel_message_key("C1"), CHANNEL_MESSAGES_PER_MIN) in limiter.calls
+    # §5.3: a create is a mutating thread op and draws the guild thread-op window
+    # too — but it spends the message budget, not the thread_ops counter.
+    assert (guild_thread_ops_key("G1"), GUILD_THREAD_OPS_PER_MIN) in limiter.calls
+    assert result.usage["thread_ops"] == 0
+
+
+async def test_create_thread_guild_window_denied_fails_loud():
+    # Channel window passes, guild thread-op window denies -> the create is
+    # stopped before the REST call with the guild cap named.
+    class _GuildWindowLimiter(_StubLimiter):
+        async def hit(self, key, limit):
+            self.calls.append((key, limit))
+            return key != guild_thread_ops_key("G1")
+
+    result, emitter, _ = await _run(
+        'await create_thread("t")\n', limiter=_GuildWindowLimiter()
+    )
+    assert result.outcome == "cap_exceeded"
+    assert result.cap == "guild_thread_ops_per_min"
+    assert emitter.created_threads == []
+
+
+async def test_create_thread_with_message_id_hangs_off_message():
+    result, emitter, _ = await _run('await create_thread("t", "M9")\n')
+    assert result.outcome == "ok", result.error
+    assert emitter.created_threads == [("C1", "t", "M9")]
+
+
+async def test_create_thread_window_denied_fails_loud():
+    result, emitter, _ = await _run(
+        'await create_thread("t")\n', limiter=_StubLimiter(allow=False)
+    )
+    assert result.outcome == "cap_exceeded"
+    assert result.cap == "channel_messages_per_min"
+    assert emitter.created_threads == []  # window denied before the REST create
+
+
+async def test_create_post_spends_message_and_window():
+    script = 'pid = await create_post("Title", "body", ["news"])\nawait send_message(pid)\n'
+    result, emitter, limiter = await _run(script)
+    assert result.outcome == "ok", result.error
+    assert emitter.created_posts == [("C1", "Title", "body", ["news"])]
+    assert emitter.messages[0][1] == "post1"
+    assert (channel_message_key("C1"), CHANNEL_MESSAGES_PER_MIN) in limiter.calls
+    assert (guild_thread_ops_key("G1"), GUILD_THREAD_OPS_PER_MIN) in limiter.calls
+
+
+# -- send_message thread-of-home relaxation (standard tier) --------------------
+
+
+async def test_standard_send_into_home_thread_allowed():
+    emitter = _FakeEmitter(parent_by_thread={"T1": "C1"})
+    result, emitter, _ = await _run(
+        'await send_message("in thread", "T1")\n', emitter=emitter
+    )
+    assert result.outcome == "ok", result.error
+    assert emitter.messages == [("T1", "in thread")]
+
+
+async def test_standard_send_into_foreign_thread_denied():
+    # A thread whose parent is a different channel is still a cross-channel send.
+    emitter = _FakeEmitter(parent_by_thread={"T2": "OTHER"})
+    result, emitter, _ = await _run(
+        'await send_message("nope", "T2")\n', emitter=emitter
+    )
+    assert result.outcome == "cap_exceeded"
+    assert result.cap == "cross_channel_send"
+    assert emitter.messages == []
+
+
+async def test_home_thread_parent_lookup_cached_across_sends():
+    emitter = _FakeEmitter(parent_by_thread={"T1": "C1"})
+    script = (
+        'await send_message("one", "T1")\n'
+        'await send_message("two", "T1")\n'
+    )
+    result, emitter, _ = await _run(
+        script, budget=HandlerBudget(max_messages=5), emitter=emitter
+    )
+    assert result.outcome == "ok", result.error
+    assert emitter.parent_calls == ["T1"]  # verified once, then cached
+
+
+# -- admin thread ops (actor set) ----------------------------------------------
+
+
+async def test_admin_list_threads_foreign_channel_in_guild_allowed():
+    # Empty scope = guild-wide: a channel in THIS guild is readable.
+    emitter = _FakeEmitter(
+        threads_by_channel={"OTHER": [{"thread_id": "TX"}]},
+        guild_by_channel={"OTHER": "G1"},
+    )
+    script = (
+        'threads = await list_threads("OTHER")\n'
+        'await send_message(f"{len(threads)}", "OTHER")\n'
+    )
+    result, emitter, _ = await _run(
+        script, budget=admin_budget(), actor=_FakeActor(), emitter=emitter
+    )
+    assert result.outcome == "ok", result.error
+    assert result.usage["discord_reads"] == 1
+    assert ("OTHER", "1") in emitter.messages
+
+
+async def test_admin_list_threads_foreign_guild_channel_denied():
+    # Empty scope but the channel belongs to a DIFFERENT guild the bot inhabits:
+    # the guild-scope rail denies the read before spending a discord read.
+    emitter = _FakeEmitter(
+        threads_by_channel={"OTHER": [{"thread_id": "TX"}]},
+        guild_by_channel={"OTHER": "OTHER_GUILD"},
+    )
+    result, emitter, _ = await _run(
+        'await list_threads("OTHER")\n',
+        budget=admin_budget(), actor=_FakeActor(), emitter=emitter,
+    )
+    assert result.outcome == "cap_exceeded"
+    assert result.cap == "out_of_scope_channel"
+    assert result.usage["discord_reads"] == 0  # denied before spending
+
+
+async def test_admin_list_threads_out_of_channel_scope_denied():
+    # A non-empty scope is an exact allow-list; a channel outside it is denied
+    # purely (no guild fetch needed).
+    emitter = _FakeEmitter(threads_by_channel={"OTHER": [{"thread_id": "TX"}]})
+    result, emitter, _ = await _run(
+        'await list_threads("OTHER")\n',
+        budget=admin_budget(), actor=_FakeActor(), emitter=emitter,
+        channel_ids=["C2", "C3"],
+    )
+    assert result.outcome == "cap_exceeded"
+    assert result.cap == "out_of_scope_channel"
+    assert result.usage["discord_reads"] == 0
+    assert emitter.guild_calls == []  # scope allow-list resolved without a fetch
+
+
+async def test_admin_list_threads_in_channel_scope_allowed():
+    emitter = _FakeEmitter(threads_by_channel={"C2": [{"thread_id": "TX"}]})
+    result, emitter, _ = await _run(
+        'threads = await list_threads("C2")\nawait send_message(f"{len(threads)}", "C2")\n',
+        budget=admin_budget(), actor=_FakeActor(), emitter=emitter,
+        channel_ids=["C2", "C3"],
+    )
+    assert result.outcome == "ok", result.error
+    assert result.usage["discord_reads"] == 1
+    assert emitter.guild_calls == []  # in-scope: no guild fetch
+    assert ("C2", "1") in emitter.messages
+
+
+async def test_admin_close_thread_spends_thread_op_and_guild_window():
+    actor = _FakeActor()
+    result, _, limiter = await _run(
+        'ok = await close_thread("T1")\nawait send_message(f"{ok}")\n',
+        budget=admin_budget(),
+        actor=actor,
+    )
+    assert result.outcome == "ok", result.error
+    assert ("close", "T1") in actor.calls
+    assert result.usage["thread_ops"] == 1
+    assert (guild_thread_ops_key("G1"), GUILD_THREAD_OPS_PER_MIN) in limiter.calls
+
+
+async def test_admin_lock_reopen_thread_metered():
+    actor = _FakeActor()
+    script = 'await lock_thread("T1")\nawait reopen_thread("T2")\n'
+    result, _, _ = await _run(script, budget=admin_budget(), actor=actor)
+    assert result.outcome == "ok", result.error
+    assert ("lock", "T1") in actor.calls and ("reopen", "T2") in actor.calls
+    assert result.usage["thread_ops"] == 2
+
+
+async def test_admin_thread_op_budget_cap_breaches():
+    actor = _FakeActor()
+    script = "for i in range(5):\n    await delete_thread(str(i))\n"
+    result, _, _ = await _run(
+        script, budget=HandlerBudget(max_thread_ops=2), actor=actor
+    )
+    assert result.outcome == "cap_exceeded"
+    assert result.cap == "thread_ops"
+    assert len(actor.calls) == 2  # two ops before the third breaches
+
+
+async def test_admin_thread_op_guild_window_denied_fails_loud():
+    actor = _FakeActor()
+    result, _, _ = await _run(
+        'await close_thread("T1")\n',
+        budget=admin_budget(),
+        actor=actor,
+        limiter=_StubLimiter(allow=False),
+    )
+    assert result.outcome == "cap_exceeded"
+    assert result.cap == "guild_thread_ops_per_min"
+    assert actor.calls == []  # window denied before the REST mutation
+
+
+async def test_admin_delete_gone_thread_returns_false_without_error():
+    actor = _FakeActor(gone={"T1"})
+    script = (
+        'gone = await delete_thread("T1")\n'
+        'await send_message("noop" if gone is False else "deleted")\n'
+    )
+    result, emitter, _ = await _run(
+        script, budget=admin_budget(), actor=actor, emitter=None
+    )
+    assert result.outcome == "ok", result.error
+    assert emitter.messages[0][1] == "noop"
+
+
+async def test_standard_handler_has_no_thread_op_functions():
+    # No actor -> close_thread is undefined in the sandbox -> NameError -> error.
+    result, _, _ = await _run('await close_thread("T1")\n')
+    assert result.outcome == "error"

--- a/tests/web/handlers_jobs_test.py
+++ b/tests/web/handlers_jobs_test.py
@@ -1,0 +1,131 @@
+"""Regression tests: the fire jobs wire the fire's guild into the DiscordEmitter.
+
+Without a guild id the emitter's ``list_threads()`` hits
+``GET /guilds//threads/active`` — a malformed URL Discord 404s — so the
+gone-channel policy would swallow it and every deployed ``list_threads()`` would
+silently return ``[]``. These tests pin that both the standard and admin fire
+jobs construct their emitter with the handler's guild id.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+import smarter_dev.web.admin_handlers_jobs as admin_handlers_jobs
+import smarter_dev.web.handler_agent as handler_agent
+import smarter_dev.web.handlers_jobs as handlers_jobs
+import smarter_dev.web.handler_runtime as handler_runtime
+from smarter_dev.web.admin_handlers_jobs import AdminHandlerFirePayload
+from smarter_dev.web.handler_runtime import HandlerResult
+from smarter_dev.web.handlers_jobs import HandlerFirePayload
+
+_USAGE = {
+    "messages_sent": 0,
+    "web_searches": 0,
+    "web_reads": 0,
+    "agent_calls": 0,
+    "mod_actions": 0,
+    "discord_reads": 0,
+    "thread_ops": 0,
+}
+
+
+class _FakeSession:
+    async def get(self, model, id_):
+        return _FakeSession.record
+
+    def add(self, obj):
+        pass
+
+    async def commit(self):
+        pass
+
+
+class _FakeSessionCtx:
+    def __init__(self, record):
+        _FakeSession.record = record
+
+    async def __aenter__(self):
+        return _FakeSession()
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+def _ok_result():
+    return HandlerResult(outcome="ok", usage=dict(_USAGE), duration_ms=1)
+
+
+@pytest.fixture
+def capture_emitter(monkeypatch):
+    captured = {}
+
+    async def fake_run(script, context, **kwargs):
+        captured["emitter"] = kwargs["emitter"]
+        return _ok_result()
+
+    async def fake_agent(*args, **kwargs):
+        return ""
+
+    monkeypatch.setattr(handler_runtime, "run_handler_script", fake_run)
+    monkeypatch.setattr(handler_agent, "run_gathering_agent", fake_agent)
+    return captured
+
+
+async def test_standard_fire_sets_emitter_guild_id(monkeypatch, capture_emitter):
+    record = SimpleNamespace(
+        enabled=True,
+        script="pass",
+        channel_id="C1",
+        guild_id="G99",
+        trigger_type="message",
+        settings={},
+        memory={},
+    )
+    monkeypatch.setattr(
+        handlers_jobs,
+        "get_settings",
+        lambda: SimpleNamespace(handlers_enabled=True, discord_bot_token="tok"),
+    )
+    monkeypatch.setattr(
+        handlers_jobs, "get_db_session_context", lambda: _FakeSessionCtx(record)
+    )
+    monkeypatch.setattr(handlers_jobs, "get_redis_client", lambda: object())
+    monkeypatch.setattr(handlers_jobs, "WindowedLimiter", lambda **kwargs: object())
+
+    await handlers_jobs.run_handler_fire(HandlerFirePayload(handler_id=str(uuid4())))
+    assert capture_emitter["emitter"].guild_id == "G99"
+
+
+async def test_admin_fire_sets_emitter_guild_id(monkeypatch, capture_emitter):
+    record = SimpleNamespace(
+        enabled=True,
+        script="pass",
+        guild_id="G77",
+        trigger_type="message",
+        channel_ids=["C1"],
+        settings={},
+        memory={},
+    )
+    monkeypatch.setattr(
+        admin_handlers_jobs,
+        "get_settings",
+        lambda: SimpleNamespace(handlers_enabled=True, discord_bot_token="tok"),
+    )
+    monkeypatch.setattr(
+        admin_handlers_jobs,
+        "get_db_session_context",
+        lambda: _FakeSessionCtx(record),
+    )
+    monkeypatch.setattr(admin_handlers_jobs, "get_redis_client", lambda: object())
+    monkeypatch.setattr(
+        admin_handlers_jobs, "WindowedLimiter", lambda **kwargs: object()
+    )
+
+    await admin_handlers_jobs.run_admin_handler_fire(
+        AdminHandlerFirePayload(admin_handler_id=str(uuid4()), channel_id="C1")
+    )
+    assert capture_emitter["emitter"].guild_id == "G77"

--- a/tests/web/test_api_native/test_admin_handlers.py
+++ b/tests/web/test_api_native/test_admin_handlers.py
@@ -240,3 +240,25 @@ def test_create_scheduled_admin_handler_schedules_fire(client):
     resp = client.post("/api/admin/handlers", json=body)
     assert resp.status_code == 201
     assert resp.json()["channel_ids"] == ["MODCHAT"]
+
+
+@pytest.mark.parametrize(
+    "trigger",
+    [
+        "member_join",
+        "member_leave",
+        "member_rules_accepted",
+        "member_role_change",
+        "thread_create",
+    ],
+)
+def test_create_admin_accepts_new_event_triggers(client, trigger):
+    """Admin tier admits the five member/thread triggers; they are event
+    triggers, so no first fire is scheduled (unlike ``schedule``/``timer``)."""
+    resp = client.post(
+        "/api/admin/handlers",
+        json=_body(trigger_type=trigger, script="await send_message('hi', 'LOG')\n"),
+    )
+    assert resp.status_code == 201
+    assert resp.json()["trigger_type"] == trigger
+    assert len(client.submitted) == 0  # type: ignore[attr-defined]

--- a/tests/web/test_api_native/test_handlers.py
+++ b/tests/web/test_api_native/test_handlers.py
@@ -379,3 +379,229 @@ def test_active_channels(client):
     channels = resp.json()["channels"]
     assert ["C1", "message"] in channels
     assert ["C1", "reaction"] in channels
+
+
+# --- admin-only member/thread triggers (threads-and-member-events.md §3) -------
+
+
+class _KeyAwareLimiter:
+    """Allows every key except the per-guild member-events window.
+
+    Simulates a raid: the ``hcap:memberevt:{guild}`` window is exhausted while
+    per-handler fire windows stay open, isolating the guild gate under test.
+    """
+
+    def __init__(self, redis=None):
+        self.hits: list[tuple[str, int]] = []
+
+    async def hit(self, key, limit):
+        self.hits.append((key, limit))
+        return "memberevt" not in key
+
+
+async def test_dispatch_member_event_matches_admin_by_guild_bypassing_scope(
+    client, db_session
+):
+    from smarter_dev.web.models import AdminHandler
+
+    # Scope names a specific channel, but a member event has no channel: the
+    # scope check is bypassed and the handler still matches by guild + trigger.
+    db_session.add(AdminHandler(
+        guild_id="G1", name="join-gate", trigger_type="member_join", settings={},
+        channel_ids=["SOMECHAN"], description="gate joins",
+        script="await send_message('welcome', 'LOGCHAN')\n", created_by_admin="A1",
+    ))
+    # A handler in a DIFFERENT guild must not fire.
+    db_session.add(AdminHandler(
+        guild_id="G2", name="other", trigger_type="member_join", settings={},
+        channel_ids=[], description="other guild", script="pass\n",
+        created_by_admin="A2",
+    ))
+    await db_session.commit()
+
+    resp = client.post(
+        "/api/handlers/dispatch",
+        json={
+            "guild_id": "G1",
+            "channel_id": "",
+            "trigger_type": "member_join",
+            "trigger_context": {"trigger_type": "member_join", "member_id": "U9"},
+        },
+    )
+    body = resp.json()
+    assert body["dispatched"] is True
+    assert len(body["handler_ids"]) == 1
+    # The fire carries no home channel — every send must name its target.
+    payload, _ = client.submitted[0]  # type: ignore[attr-defined]
+    assert payload.channel_id == ""
+
+
+@pytest.mark.parametrize(
+    "trigger",
+    ["member_join", "member_leave", "member_rules_accepted", "member_role_change"],
+)
+async def test_dispatch_member_events_decline_past_guild_window(
+    client, db_session, monkeypatch, trigger
+):
+    from smarter_dev.web.models import AdminHandler
+
+    monkeypatch.setattr(
+        handlers_module, "WindowedLimiter", lambda redis: _KeyAwareLimiter()
+    )
+    db_session.add(AdminHandler(
+        guild_id="G1", name="gate", trigger_type=trigger, settings={},
+        channel_ids=[], description="gate", script="pass\n", created_by_admin="A1",
+    ))
+    await db_session.commit()
+
+    resp = client.post(
+        "/api/handlers/dispatch",
+        json={
+            "guild_id": "G1",
+            "channel_id": "",
+            "trigger_type": trigger,
+            "trigger_context": {"trigger_type": trigger},
+        },
+    )
+    # Guild window exhausted → declined before any fire is enqueued.
+    assert resp.json()["dispatched"] is False
+    assert len(client.submitted) == 0  # type: ignore[attr-defined]
+
+
+async def test_dispatch_thread_create_scope_matches_parent(client, db_session):
+    from smarter_dev.web.models import AdminHandler
+
+    db_session.add(AdminHandler(
+        guild_id="G1", name="forum-triage", trigger_type="thread_create", settings={},
+        channel_ids=["PARENT"], description="triage", script="pass\n",
+        created_by_admin="A1",
+    ))
+    # Scoped to a different parent channel → must not fire.
+    db_session.add(AdminHandler(
+        guild_id="G1", name="other-forum", trigger_type="thread_create", settings={},
+        channel_ids=["OTHER"], description="other", script="pass\n",
+        created_by_admin="A1",
+    ))
+    await db_session.commit()
+
+    resp = client.post(
+        "/api/handlers/dispatch",
+        json={
+            "guild_id": "G1",
+            "channel_id": "PARENT",  # bot dispatches thread_create on the parent
+            "trigger_type": "thread_create",
+            "trigger_context": {
+                "trigger_type": "thread_create",
+                "parent_channel_id": "PARENT",
+            },
+        },
+    )
+    body = resp.json()
+    assert body["dispatched"] is True
+    assert len(body["handler_ids"]) == 1
+    payload, _ = client.submitted[0]  # type: ignore[attr-defined]
+    assert payload.channel_id == "PARENT"
+
+
+async def test_dispatch_thread_create_empty_scope_matches_any_parent(
+    client, db_session
+):
+    from smarter_dev.web.models import AdminHandler
+
+    db_session.add(AdminHandler(
+        guild_id="G1", name="all-forums", trigger_type="thread_create", settings={},
+        channel_ids=[], description="all", script="pass\n", created_by_admin="A1",
+    ))
+    await db_session.commit()
+
+    resp = client.post(
+        "/api/handlers/dispatch",
+        json={
+            "guild_id": "G1",
+            "channel_id": "ANYPARENT",
+            "trigger_type": "thread_create",
+            "trigger_context": {"trigger_type": "thread_create"},
+        },
+    )
+    assert resp.json()["dispatched"] is True
+
+
+async def test_dispatch_thread_create_not_gated_by_member_window(
+    client, db_session, monkeypatch
+):
+    from smarter_dev.web.models import AdminHandler
+
+    # Even with the member-events window exhausted, thread_create is unaffected —
+    # it is bounded by the per-handler fire cap and the thread-op caps, not this.
+    monkeypatch.setattr(
+        handlers_module, "WindowedLimiter", lambda redis: _KeyAwareLimiter()
+    )
+    db_session.add(AdminHandler(
+        guild_id="G1", name="all-forums", trigger_type="thread_create", settings={},
+        channel_ids=[], description="all", script="pass\n", created_by_admin="A1",
+    ))
+    await db_session.commit()
+
+    resp = client.post(
+        "/api/handlers/dispatch",
+        json={
+            "guild_id": "G1",
+            "channel_id": "ANYPARENT",
+            "trigger_type": "thread_create",
+            "trigger_context": {"trigger_type": "thread_create"},
+        },
+    )
+    assert resp.json()["dispatched"] is True
+
+
+async def test_active_channels_member_event_always_guild_scoped(client, db_session):
+    from smarter_dev.web.models import AdminHandler
+
+    # A member_join handler surfaces as a guild trigger even when channel_ids is
+    # set — its dispatch guard is per-guild (a member event has no channel).
+    db_session.add(AdminHandler(
+        guild_id="G1", name="join-gate", trigger_type="member_join", settings={},
+        channel_ids=["SOMECHAN"], description="gate", script="pass\n",
+        created_by_admin="A1",
+    ))
+    await db_session.commit()
+
+    resp = client.get("/api/handlers/active-channels")
+    body = resp.json()
+    assert ["G1", "member_join"] in body["guild_triggers"]
+    assert ["SOMECHAN", "member_join"] not in body["channels"]
+
+
+async def test_active_channels_thread_create_follows_channel_split(client, db_session):
+    from smarter_dev.web.models import AdminHandler
+
+    db_session.add(AdminHandler(
+        guild_id="G1", name="scoped-forum", trigger_type="thread_create", settings={},
+        channel_ids=["PARENT"], description="s", script="pass\n", created_by_admin="A1",
+    ))
+    db_session.add(AdminHandler(
+        guild_id="G1", name="wide-forum", trigger_type="thread_create", settings={},
+        channel_ids=[], description="w", script="pass\n", created_by_admin="A2",
+    ))
+    await db_session.commit()
+
+    resp = client.get("/api/handlers/active-channels")
+    body = resp.json()
+    assert ["PARENT", "thread_create"] in body["channels"]
+    assert ["G1", "thread_create"] in body["guild_triggers"]
+
+
+@pytest.mark.parametrize(
+    "trigger",
+    [
+        "member_join",
+        "member_leave",
+        "member_rules_accepted",
+        "member_role_change",
+        "thread_create",
+    ],
+)
+def test_create_standard_rejects_admin_only_triggers(client, trigger):
+    resp = client.post("/api/handlers", json=_event_body(trigger_type=trigger))
+    assert resp.status_code == 422
+    assert resp.json() == {"detail": "unknown trigger_type"}


### PR DESCRIPTION
## Summary
- Five new **admin-only** event triggers: `member_join`, `member_leave`, `member_rules_accepted`, `member_role_change`, `thread_create` (forum posts included; dispatches on the parent channel). Amends lifecycle E1's both-tier plan — member events are admin-tier only.
- New scripting functions — general tier: `list_threads()`, `create_thread`, `create_post`, `send_message` into home-channel threads; admin tier: `list_threads(channel_id)`, `close_thread`, `lock_thread`, `reopen_thread`, `delete_thread` with a tested 404→False gone-target contract and a host-side is-thread + in-guild verification rail in `AdminActor`.
- Metering: `discord_reads` + `thread_ops` budget counters (`HandlerRun` columns via one alembic migration), `GUILD_MEMBER_EVENTS_PER_MIN=60` and `GUILD_THREAD_OPS_PER_MIN=30` windows.
- Thread messages now also dispatch to parent-channel handlers with `is_thread`/`thread_id` context.
- Authoring pipeline: author/judge prompts learn the new surface; standard tier rejects admin-only triggers at every layer; ID-based targeting required end-to-end (chat agent passes snowflake IDs, authors compare by ID, judges reject name gates).
- Design of record: `docs/v2/feature-parity/threads-and-member-events.md`; staff-comms E5/E6 reconciled onto the shipped baseline.

## Test plan
- Full suite green locally: 1799 passed, 12 skipped.
- New coverage: bot listener contexts + cache-miss policies, dispatch matching/guild window decline, REST 404 contracts per method, budget/cap spends per function, verification-rail rejects, standard-tier rejection, migration.
- Migration runs via the deploy migrate job (extends the admin trigger CHECK constraint + two `HandlerRun` columns; standard table untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)