### PR TITLE
feat(bot): /chat-bot-settings — auto-respond, response filter, fallback model

### DIFF
--- a/alembic/main/versions/20260717_120000_f1a2b3c4d5e6_channel_override_response_settings.py
+++ b/alembic/main/versions/20260717_120000_f1a2b3c4d5e6_channel_override_response_settings.py
@@ -1,0 +1,52 @@
+"""add per-channel auto-respond and response filtering settings
+
+Adds three per-channel settings to ``channel_model_overrides``:
+
+- ``auto_respond`` — when true the chat bot activates on ANY channel message,
+  not just @mentions (NOT NULL, defaults false).
+- ``fallback_model_key`` — a catalog key used when the primary model is
+  unavailable, or NULL.
+- ``response_filter`` — free-text instructions describing which messages
+  deserve a response, or NULL.
+
+Revision ID: f1a2b3c4d5e6
+Revises: cfcaa2cbf2b0
+Create Date: 2026-07-17 12:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "f1a2b3c4d5e6"
+down_revision: Union[str, None] = "cfcaa2cbf2b0"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "channel_model_overrides",
+        sa.Column(
+            "auto_respond",
+            sa.Boolean(),
+            server_default=sa.text("false"),
+            nullable=False,
+        ),
+    )
+    op.add_column(
+        "channel_model_overrides",
+        sa.Column("fallback_model_key", sa.String(length=64), nullable=True),
+    )
+    op.add_column(
+        "channel_model_overrides",
+        sa.Column("response_filter", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("channel_model_overrides", "response_filter")
+    op.drop_column("channel_model_overrides", "fallback_model_key")
+    op.drop_column("channel_model_overrides", "auto_respond")

--- a/smarter_dev/bot/agents/message_gate.py
+++ b/smarter_dev/bot/agents/message_gate.py
@@ -1,0 +1,146 @@
+"""Pre-turn relevance gate (GPT-5.4 Nano) for admin-restricted channels.
+
+An admin can restrict a channel so the bot only replies to messages matching a
+written response filter. Before the chat engine spends a turn on an expensive
+model, it asks this cheap Nano classifier which of the pending messages the
+filter actually allows — so clearly off-topic chatter never reaches the pricey
+model.
+
+The gate is deliberately fail-open: a Nano outage returns every candidate
+rather than silencing the bot, since a wasted expensive reply is far cheaper
+than a channel that stops answering. It also short-circuits (no model call) when
+there is nothing to judge or no filter to apply.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from pydantic import BaseModel, Field
+from pydantic_ai import Agent
+
+from smarter_dev.bot.agents.model_router import build_model_for, model_settings_for
+from smarter_dev.shared.model_catalog import ReasoningLevel, get_model
+
+logger = logging.getLogger(__name__)
+
+GATE_MODEL_KEY = "gpt-5-4-nano"
+
+SYSTEM_PROMPT = """\
+You are a fast, cheap relevance gate for a Discord bot. An admin has restricted \
+this channel so the bot only replies to messages that match their written \
+INSTRUCTIONS. For each CANDIDATE message you decide whether the instructions \
+allow the bot to spend an (expensive) reply on it.
+
+You are given:
+- INSTRUCTIONS: the admin's filter describing which messages the bot should \
+respond to. They are about the TOPIC and CONTENT of a message, never about who \
+wrote it — ignore the author when deciding.
+- CONTEXT: recent channel messages, oldest first, provided only so you can \
+interpret the candidates. These are NOT candidates; never return a context id.
+- CANDIDATES: the messages to judge. Return the ids of the candidates the \
+instructions allow.
+
+Rules:
+- Judge each candidate on whether its topic/content matches the instructions.
+- The point of this gate is to protect an expensive model from clearly \
+off-topic messages, so lean DROP when a candidate is plainly off-topic.
+- When a candidate is genuinely ambiguous or borderline — it could reasonably \
+fall under the instructions — lean ALLOW.
+- Use the CONTEXT only to interpret a candidate (e.g. a short reply that only \
+makes sense given the prior messages); a candidate that is on-topic given the \
+conversation should be allowed even if it looks thin in isolation.
+
+Set allowed_message_ids to the ids of the candidates (and only the candidates) \
+that the instructions allow, in any order."""
+
+
+@dataclass(frozen=True)
+class GateMessage:
+    """One Discord message the gate reasons about."""
+
+    message_id: str
+    author_display: str
+    content: str
+
+
+class GateDecision(BaseModel):
+    """The gate's verdict: which candidate message ids the filter allows."""
+
+    allowed_message_ids: list[str] = Field(
+        description="Ids of the CANDIDATE messages the admin instructions allow.",
+    )
+
+
+_gate_agent: Agent[None, GateDecision] | None = None
+
+
+def get_message_gate_agent() -> Agent[None, GateDecision]:
+    """Return the singleton message-gate agent, building it on first use."""
+    global _gate_agent
+    if _gate_agent is None:
+        catalog_model = get_model(GATE_MODEL_KEY)
+        if catalog_model is None:
+            raise ValueError(f"Gate model {GATE_MODEL_KEY!r} is not in the catalog")
+        _gate_agent = Agent(
+            build_model_for(catalog_model),
+            output_type=GateDecision,
+            system_prompt=SYSTEM_PROMPT,
+            model_settings=model_settings_for(catalog_model, ReasoningLevel.NONE),
+        )
+    return _gate_agent
+
+
+def _render_message(message: GateMessage) -> str:
+    return f"[{message.message_id}] {message.author_display}: {message.content}"
+
+
+def _render_prompt(
+    response_filter: str,
+    candidates: list[GateMessage],
+    grounding: list[GateMessage],
+) -> str:
+    sections = [f"INSTRUCTIONS:\n{response_filter.strip()}"]
+    if grounding:
+        rendered = "\n".join(_render_message(message) for message in grounding)
+        sections.append(
+            "CONTEXT (oldest first, for reference only — never return these ids):\n"
+            + rendered
+        )
+    rendered_candidates = "\n".join(_render_message(message) for message in candidates)
+    sections.append("CANDIDATES (judge these):\n" + rendered_candidates)
+    return "\n\n".join(sections)
+
+
+async def filter_messages(
+    response_filter: str,
+    candidates: list[GateMessage],
+    grounding: list[GateMessage],
+) -> list[str]:
+    """Return the candidate message ids the ``response_filter`` allows.
+
+    Ids are returned in candidate order. An empty ``candidates`` list returns
+    ``[]`` without a model call, and an empty/whitespace ``response_filter``
+    allows every candidate without a model call. Any exception from the model is
+    logged and fails open — every candidate id is returned — so a Nano outage
+    never silences the bot. The model's answer is intersected with the real
+    candidate ids, since it may hallucinate ids that were never offered.
+    """
+    if not candidates:
+        return []
+    candidate_ids = [message.message_id for message in candidates]
+    if not response_filter.strip():
+        return candidate_ids
+    agent = get_message_gate_agent()
+    try:
+        result = await agent.run(_render_prompt(response_filter, candidates, grounding))
+    except Exception:
+        logger.warning(
+            "message gate model call failed; allowing all %d candidate(s) (fail-open)",
+            len(candidate_ids),
+            exc_info=True,
+        )
+        return candidate_ids
+    allowed = set(result.output.allowed_message_ids)
+    return [message_id for message_id in candidate_ids if message_id in allowed]

--- a/smarter_dev/bot/plugins/bot_usage.py
+++ b/smarter_dev/bot/plugins/bot_usage.py
@@ -9,7 +9,7 @@ publicly so the channel can discuss it. ``/bot-usage`` shows two things:
   the counted messages actually span ("32/60 messages in the last hour").
 - The channel's chat-token consumption for the current hour and day windows
   against its configured budgets ("76k/100k this hour · 512k/1m today").
-  Every channel is metered; without a ``/setmodel`` budget the allowance
+  Every channel is metered; without a ``/chat-bot-settings`` budget the allowance
   reads "unlimited", and a maxed-out budget window shows a live countdown
   to its wall-clock reset.
 

--- a/smarter_dev/bot/plugins/events.py
+++ b/smarter_dev/bot/plugins/events.py
@@ -12,6 +12,10 @@ from typing import Any
 
 import hikari
 
+from smarter_dev.bot.plugins.model_override import handle_model_budget_fallback
+from smarter_dev.bot.plugins.model_override import handle_model_override_auto_toggle
+from smarter_dev.bot.plugins.model_override import handle_model_override_continue
+from smarter_dev.bot.plugins.model_override import handle_model_override_fallback_select
 from smarter_dev.bot.plugins.model_override import handle_model_override_modal_submit
 from smarter_dev.bot.plugins.model_override import handle_model_override_reasoning_select
 from smarter_dev.bot.plugins.model_override import handle_model_override_select
@@ -65,7 +69,7 @@ async def handle_modal_interaction(event: hikari.InteractionCreateEvent) -> None
             await handle_solution_submission_modal(event)
         elif custom_id == "beacon_message_modal":
             await handle_beacon_message_modal(event)
-        elif custom_id.startswith("model_override_modal:"):
+        elif custom_id.startswith("cbs_modal:"):
             await handle_model_override_modal_submit(event)
         else:
             logger.warning(f"Unhandled modal interaction: {custom_id}")
@@ -251,8 +255,16 @@ async def handle_component_interaction(event: hikari.InteractionCreateEvent) -> 
             await handle_daily_quest_submit_interaction(event)
         elif custom_id == "model_override_select":
             await handle_model_override_select(event)
-        elif custom_id.startswith("model_override_reasoning:"):
+        elif custom_id.startswith("cbs_reasoning:"):
             await handle_model_override_reasoning_select(event)
+        elif custom_id.startswith("cbs_fallback:"):
+            await handle_model_override_fallback_select(event)
+        elif custom_id.startswith("cbs_auto:"):
+            await handle_model_override_auto_toggle(event)
+        elif custom_id.startswith("cbs_continue:"):
+            await handle_model_override_continue(event)
+        elif custom_id.startswith("model_budget_fallback:"):
+            await handle_model_budget_fallback(event)
         else:
             logger.warning(f"Unhandled component interaction: {custom_id}")
 

--- a/smarter_dev/bot/plugins/mention.py
+++ b/smarter_dev/bot/plugins/mention.py
@@ -167,6 +167,46 @@ async def _record_engaged_message(bot: Any, event: hikari.MessageCreateEvent) ->
         )
 
 
+def _model_override_service(bot: Any) -> Any | None:
+    """The bot's ModelOverrideService (set on ``bot.d``), or None if absent.
+
+    Mirrors ``plugins/model_override._get_override_service`` but stays fail-soft:
+    a bot without the service (or a non-dict ``bot.d`` in tests) yields None so
+    the channel behaves as if it has no override.
+    """
+    data = getattr(bot, "d", None)
+    if not isinstance(data, dict):
+        return None
+    service = data.get("model_override_service")
+    if service is None:
+        service = data.get("_services", {}).get("model_override_service")
+    return service
+
+
+async def _channel_auto_responds(bot: Any, event: hikari.MessageCreateEvent) -> bool:
+    """True when the channel's override opts into replying to plain messages.
+
+    Read fail-soft to match the chat runtime's override contract: a missing
+    service or any lookup error degrades to "no auto-respond" (logged at warning)
+    so a bad read never makes the bot answer — or stay silent — unexpectedly.
+    """
+    service = _model_override_service(bot)
+    if service is None:
+        return False
+    try:
+        override = await service.get_override(
+            str(event.guild_id), str(event.channel_id)
+        )
+    except Exception:
+        logger.warning(
+            "Failed to read model override for channel %s — no auto-respond",
+            event.channel_id,
+            exc_info=True,
+        )
+        return False
+    return bool(override and override.auto_respond)
+
+
 def _bot_was_engaged(event: hikari.MessageCreateEvent, bot_user_id: int) -> bool:
     """True if the message @mentions the bot or replies to one of its messages."""
     if event.message.user_mentions_ids and bot_user_id in event.message.user_mentions_ids:
@@ -175,6 +215,66 @@ def _bot_was_engaged(event: hikari.MessageCreateEvent, bot_user_id: int) -> bool
     if ref is not None and ref.author and ref.author.id == bot_user_id:
         return True
     return False
+
+
+async def _activate_engine(registry: Any, event: hikari.MessageCreateEvent) -> None:
+    """Run the shared activation pipeline for a triggering message.
+
+    Both an @mention/reply and an auto-respond channel funnel through here so the
+    two triggers cannot drift: apply the cooldown, rate-limit and per-user
+    message-limit gates, charge the message against its author, then hand it to
+    the channel engine — starting a fresh engagement or force-firing an
+    already-active one. Callers invoke this only after deciding the message
+    should activate (and after any stop phrase was already handled).
+    """
+    if is_channel_on_cooldown(event.channel_id):
+        logger.info(
+            "Channel %s on cooldown — ignoring activation", event.channel_id
+        )
+        return
+    if not rate_limiter.check_token_limit():
+        logger.warning("Rate limited — refusing activation in channel %s", event.channel_id)
+        try:
+            await plugin.bot.rest.create_message(
+                event.channel_id,
+                "I'm at capacity right now — try me again in a few minutes.",
+                reply=event.message,
+            )
+        except Exception:
+            logger.exception("Failed to send rate-limit message")
+        return
+
+    if await _reject_when_over_limit(plugin.bot, event):
+        logger.info(
+            "User %s over the rolling message limit — dropping activation "
+            "in channel %s",
+            event.message.author.id,
+            event.channel_id,
+        )
+        return
+    await _record_engaged_message(plugin.bot, event)
+
+    # Distinguish "engine doesn't exist yet" (first activation in this
+    # engagement) from "engine is already running and the user is
+    # @mentioning again" — the two need different plumbing.
+    existing_active = await registry.has_active(event.channel_id)
+    engine = await registry.ensure_engine(
+        bot=plugin.bot,
+        channel_id=event.channel_id,
+        guild_id=event.guild_id,
+        voice_send=_voice_send,
+    )
+    if not existing_active:
+        # Brand new engagement: kick off the initial activation. The
+        # engine reads the channel history and decides for itself
+        # whether to reply with voice.
+        engine.trigger_initial(event.message)
+    else:
+        # Engine already active — enqueue this @mention/reply and
+        # force-fire so the agent reacts to it right now rather than
+        # waiting on the 5s idle timer.
+        await engine.observe(event)
+        engine.fire_now()
 
 
 @plugin.listener(hikari.MessageCreateEvent)
@@ -195,8 +295,19 @@ async def on_message_create(event: hikari.MessageCreateEvent) -> None:
     engaged = _bot_was_engaged(event, bot_user.id)
     content = event.content or ""
 
-    # Stop heuristic — applies to engagements and any message in an active channel.
-    if engaged or await registry.has_active(event.channel_id):
+    has_active = await registry.has_active(event.channel_id)
+
+    # A channel override can opt into auto-respond, making the bot treat a plain
+    # message exactly like an @mention/reply. Only meaningful when the bot wasn't
+    # engaged and no engine is already running (an active engine's observe()
+    # already sees every message). The override read is TTL-cached and runs only
+    # after the cheap engaged/has_active checks above, keeping the hot path light.
+    should_activate = engaged
+    if not engaged and not has_active:
+        should_activate = await _channel_auto_responds(plugin.bot, event)
+
+    # Stop heuristic — applies to activations and any message in an active channel.
+    if should_activate or has_active:
         if is_stop_request(content):
             engine = await registry.get(event.channel_id)
             had_engine = engine is not None and engine.active
@@ -212,58 +323,11 @@ async def on_message_create(event: hikari.MessageCreateEvent) -> None:
                 logger.exception("Failed to send stop ack")
             return
 
-    if engaged:
-        if is_channel_on_cooldown(event.channel_id):
-            logger.info(
-                "Channel %s on cooldown — ignoring engagement", event.channel_id
-            )
-            return
-        if not rate_limiter.check_token_limit():
-            logger.warning("Rate limited — refusing engagement in channel %s", event.channel_id)
-            try:
-                await plugin.bot.rest.create_message(
-                    event.channel_id,
-                    "I'm at capacity right now — try me again in a few minutes.",
-                    reply=event.message,
-                )
-            except Exception:
-                logger.exception("Failed to send rate-limit message")
-            return
-
-        if await _reject_when_over_limit(plugin.bot, event):
-            logger.info(
-                "User %s over the rolling message limit — dropping engagement "
-                "in channel %s",
-                event.message.author.id,
-                event.channel_id,
-            )
-            return
-        await _record_engaged_message(plugin.bot, event)
-
-        # Distinguish "engine doesn't exist yet" (first activation in this
-        # engagement) from "engine is already running and the user is
-        # @mentioning again" — the two need different plumbing.
-        existing_active = await registry.has_active(event.channel_id)
-        engine = await registry.ensure_engine(
-            bot=plugin.bot,
-            channel_id=event.channel_id,
-            guild_id=event.guild_id,
-            voice_send=_voice_send,
-        )
-        if not existing_active:
-            # Brand new engagement: kick off the initial activation. The
-            # engine reads the channel history and decides for itself
-            # whether to reply with voice.
-            engine.trigger_initial(event.message)
-        else:
-            # Engine already active — enqueue this @mention/reply and
-            # force-fire so the agent reacts to it right now rather than
-            # waiting on the 5s idle timer.
-            await engine.observe(event)
-            engine.fire_now()
+    if should_activate:
+        await _activate_engine(registry, event)
         return
 
-    # Not an engagement — feed to engine if active, otherwise just bump the
+    # Not an activation — feed to engine if active, otherwise just bump the
     # idle-message counter so memory can detect staleness on the next activation.
     engine = await registry.get(event.channel_id)
     if engine is not None and engine.active:

--- a/smarter_dev/bot/plugins/model_override.py
+++ b/smarter_dev/bot/plugins/model_override.py
@@ -1,22 +1,30 @@
-"""Admin ``/setmodel`` slash command — per-channel LLM model override.
+"""Admin ``/chat-bot-settings`` slash command — per-channel LLM configuration.
 
 Admin-gated (ADMINISTRATOR). Opens a model string-select for the current
-channel; a reasoning-capable model then shows a reasoning-level select, after
-which a token-budget modal persists the override (model + reasoning + budgets)
-via :class:`~smarter_dev.bot.services.model_override_service.ModelOverrideService`.
-Models with no reasoning knob skip straight to the budgets modal. Picking the
-"server default" sentinel clears the override instead.
+channel; picking a model swaps the ephemeral message for one settings panel
+(reasoning level for reasoning-capable models, a fallback model, and an
+auto-respond toggle), and a "Budgets & filter…" button opens a modal for the
+daily/hourly token budgets and an optional response filter. Modal submit
+persists everything (model + reasoning + budgets + auto-respond + fallback +
+filter) in one call via
+:class:`~smarter_dev.bot.services.model_override_service.ModelOverrideService`.
+Picking the "server default" sentinel clears the override instead.
 
-The three interaction handlers here (``handle_model_override_select`` /
-``handle_model_override_reasoning_select`` / ``handle_model_override_modal_submit``)
-are dispatched from :mod:`smarter_dev.bot.plugins.events` by ``custom_id``. The
-chat runtime consumes the stored model + reasoning level via
+The interaction handlers here are dispatched from
+:mod:`smarter_dev.bot.plugins.events` by ``custom_id``: the model select
+(``handle_model_override_select``), the panel re-render handlers
+(``handle_model_override_reasoning_select`` / ``_fallback_select`` /
+``_auto_toggle``), the modal opener (``handle_model_override_continue``) and the
+modal submit (``handle_model_override_modal_submit``). The chat runtime consumes
+the stored settings via
 :func:`~smarter_dev.bot.agents.chat_agent.get_chat_agent`.
 """
 
 from __future__ import annotations
 
 import logging
+from datetime import UTC
+from datetime import datetime
 from typing import Any
 
 import hikari
@@ -29,23 +37,30 @@ from smarter_dev.shared.model_catalog import parse_reasoning_level
 from smarter_dev.shared.model_catalog import resolve_reasoning_level
 from smarter_dev.bot.plugins.admin_gate import deny_if_not_admin
 from smarter_dev.bot.plugins.admin_gate import is_admin
+from smarter_dev.bot.services.channel_token_budget import fallback_ended_key
+from smarter_dev.bot.services.channel_token_budget import fallback_flag_key
+from smarter_dev.bot.services.chat_engine_registry import get_chat_engine_registry
 from smarter_dev.bot.services.exceptions import APIError
 from smarter_dev.bot.services.model_override_service import ModelOverrideService
 from smarter_dev.bot.services.models import ChannelModelOverride
+from smarter_dev.bot.views.model_override_views import AUTO_TOGGLE_CUSTOM_ID_PREFIX
+from smarter_dev.bot.views.model_override_views import CONTINUE_CUSTOM_ID_PREFIX
+from smarter_dev.bot.views.model_override_views import (
+    FALLBACK_SELECT_CUSTOM_ID_PREFIX,
+)
 from smarter_dev.bot.views.model_override_views import MODAL_CUSTOM_ID_PREFIX
+from smarter_dev.bot.views.model_override_views import PanelState
 from smarter_dev.bot.views.model_override_views import (
     REASONING_SELECT_CUSTOM_ID_PREFIX,
 )
 from smarter_dev.bot.views.model_override_views import SENTINEL_DEFAULT
 from smarter_dev.bot.views.model_override_views import SENTINEL_MODEL_DEFAULT
-from smarter_dev.bot.views.model_override_views import create_budgets_modal
-from smarter_dev.bot.views.model_override_views import (
-    create_model_select_message,
-)
-from smarter_dev.bot.views.model_override_views import (
-    create_reasoning_select_message,
-)
+from smarter_dev.bot.views.model_override_views import SENTINEL_NO_FALLBACK
+from smarter_dev.bot.views.model_override_views import create_model_select_message
+from smarter_dev.bot.views.model_override_views import create_settings_modal
+from smarter_dev.bot.views.model_override_views import create_settings_panel
 from smarter_dev.bot.views.model_override_views import parse_budget
+from smarter_dev.bot.views.model_override_views import parse_panel_state
 
 logger = logging.getLogger(__name__)
 
@@ -53,15 +68,16 @@ plugin = lightbulb.Plugin("model_override")
 
 
 ADMIN_DENIAL_MESSAGE = (
-    "You need the Administrator permission to set a channel model."
+    "You need the Administrator permission to change chat-bot settings."
 )
 
 
 async def _deny_interaction_if_not_admin(
     event: hikari.InteractionCreateEvent,
 ) -> bool:
-    """Re-check admin on a select/modal interaction (defense in depth — a raw
-    custom_id could be replayed by a non-admin). Respond ephemerally on denial."""
+    """Re-check admin on a select/button/modal interaction (defense in depth — a
+    raw custom_id could be replayed by a non-admin). Respond ephemerally on
+    denial."""
     member = event.interaction.member
     if not isinstance(member, hikari.InteractionMember) or not is_admin(
         lightbulb.utils.permissions_for(member)
@@ -115,6 +131,14 @@ def _render_reasoning(model: CatalogModel, reasoning_level: str | None) -> str:
     return effective.label
 
 
+def _render_fallback(fallback_model_key: str | None) -> str:
+    """Human-render the fallback model for the confirmation message."""
+    if fallback_model_key is None:
+        return "none"
+    fallback = get_model(fallback_model_key)
+    return fallback.label if fallback is not None else fallback_model_key
+
+
 def _read_modal_text_values(
     interaction: hikari.ModalInteraction,
 ) -> dict[str, str]:
@@ -128,13 +152,53 @@ def _read_modal_text_values(
     return values
 
 
+async def _load_current_override(
+    app: Any, guild_id: str, channel_id: str
+) -> ChannelModelOverride | None:
+    """Load the channel's current override for prefilling, degrading to ``None``
+    on a read failure so a transient API error never blocks configuring."""
+    try:
+        service = _get_override_service(app)
+        return await service.get_override(guild_id, channel_id)
+    except APIError as exc:
+        logger.warning("Could not load current model override for prefill: %s", exc)
+        return None
+
+
+async def _render_panel(
+    interaction: hikari.ComponentInteraction, state: PanelState
+) -> None:
+    """Re-render the settings panel for ``state`` as a message update."""
+    model = get_model(state.model_key)
+    if model is None:
+        await interaction.create_initial_response(
+            hikari.ResponseType.MESSAGE_UPDATE,
+            content="❌ That model is no longer available. Please run `/chat-bot-settings` again.",
+            components=[],
+        )
+        return
+    await interaction.create_initial_response(
+        hikari.ResponseType.MESSAGE_UPDATE,
+        content=(
+            f"Configuring **{model.label}** for this channel. Adjust the settings "
+            "below, then open **Budgets & filter…** to finish."
+        ),
+        components=create_settings_panel(
+            model,
+            state.reasoning_level,
+            state.auto_respond,
+            state.fallback_model_key,
+        ),
+    )
+
+
 @plugin.command
 @lightbulb.command(
-    "setmodel",
-    "Set the LLM model and token budgets for this channel (admin only)",
+    "chat-bot-settings",
+    "Configure the LLM model, budgets and behaviour for this channel (admin only)",
 )
 @lightbulb.implements(lightbulb.SlashCommand)
-async def setmodel(ctx: lightbulb.Context) -> None:
+async def chat_bot_settings(ctx: lightbulb.Context) -> None:
     """Open the model-selection dropdown for the current channel."""
     if await deny_if_not_admin(ctx, ADMIN_DENIAL_MESSAGE):
         return
@@ -160,8 +224,8 @@ async def setmodel(ctx: lightbulb.Context) -> None:
 async def handle_model_override_select(
     event: hikari.InteractionCreateEvent,
 ) -> None:
-    """Handle the model string-select: clear on sentinel; for a reasoning-capable
-    model show the reasoning select next; otherwise open the budgets modal."""
+    """Handle the model string-select: clear on the sentinel, otherwise swap the
+    message for the settings panel prefilled from the stored override."""
     interaction = event.interaction
     if not isinstance(interaction, hikari.ComponentInteraction):
         return
@@ -196,85 +260,156 @@ async def handle_model_override_select(
     if not selected or not is_valid_model_key(selected):
         await interaction.create_initial_response(
             hikari.ResponseType.MESSAGE_UPDATE,
-            content="❌ That model is no longer available. Please run `/setmodel` again.",
+            content="❌ That model is no longer available. Please run `/chat-bot-settings` again.",
             components=[],
         )
         return
 
-    model = get_model(selected)
-    service = _get_override_service(event.app)
-    current: ChannelModelOverride | None = None
-    try:
-        current = await service.get_override(guild_id, channel_id)
-    except APIError as exc:
-        logger.warning("Could not load override for prefill: %s", exc)
-
-    if model.supports_reasoning:
-        # Reasoning-capable models get a second select before the budgets modal.
-        await interaction.create_initial_response(
-            hikari.ResponseType.MESSAGE_UPDATE,
-            content=(
-                f"Selected **{model.label}**. Now choose a reasoning level, "
-                "then set token budgets."
-            ),
-            components=create_reasoning_select_message(
-                guild_id, channel_id, model, current
-            ),
-        )
-        return
-
-    # No reasoning knob — go straight to the budgets modal (reasoning stays unset).
-    modal = create_budgets_modal(guild_id, channel_id, selected, None, current)
-    await interaction.create_modal_response(
-        modal.title,
-        modal.custom_id,
-        components=modal.components,
+    current = await _load_current_override(event.app, guild_id, channel_id)
+    # A stored fallback equal to the newly chosen primary is meaningless (a model
+    # never falls back to itself), so drop it — otherwise it would be excluded
+    # from the select yet still ride in the panel state.
+    fallback_key = current.fallback_model_key if current is not None else None
+    if fallback_key == selected:
+        fallback_key = None
+    state = PanelState(
+        model_key=selected,
+        reasoning_level=current.reasoning_level if current is not None else None,
+        auto_respond=current.auto_respond if current is not None else False,
+        fallback_model_key=fallback_key,
     )
+    await _render_panel(interaction, state)
 
 
 async def handle_model_override_reasoning_select(
     event: hikari.InteractionCreateEvent,
 ) -> None:
-    """Handle the reasoning string-select: open the budgets modal carrying the
-    chosen reasoning level (or unset for the model default)."""
+    """Handle the reasoning string-select: re-render the panel with the chosen
+    reasoning level (or unset for the model default)."""
     interaction = event.interaction
     if not isinstance(interaction, hikari.ComponentInteraction):
         return
     if await _deny_interaction_if_not_admin(event):
         return
 
-    parts = interaction.custom_id.split(":")
-    if len(parts) != 4 or parts[0] != REASONING_SELECT_CUSTOM_ID_PREFIX:
+    state = parse_panel_state(
+        interaction.custom_id, REASONING_SELECT_CUSTOM_ID_PREFIX
+    )
+    if state is None:
         logger.error("Invalid reasoning select custom_id: %s", interaction.custom_id)
         await interaction.create_initial_response(
             hikari.ResponseType.MESSAGE_UPDATE,
-            content="❌ Invalid request. Please run `/setmodel` again.",
-            components=[],
-        )
-        return
-
-    _, guild_id, channel_id, model_key = parts
-    if get_model(model_key) is None:
-        await interaction.create_initial_response(
-            hikari.ResponseType.MESSAGE_UPDATE,
-            content="❌ That model is no longer available. Please run `/setmodel` again.",
+            content="❌ Invalid request. Please run `/chat-bot-settings` again.",
             components=[],
         )
         return
 
     chosen = interaction.values[0] if interaction.values else SENTINEL_MODEL_DEFAULT
     reasoning_level = None if chosen == SENTINEL_MODEL_DEFAULT else chosen
-
-    service = _get_override_service(event.app)
-    current: ChannelModelOverride | None = None
-    try:
-        current = await service.get_override(guild_id, channel_id)
-    except APIError as exc:
-        logger.warning("Could not load override for budget prefill: %s", exc)
-
-    modal = create_budgets_modal(
-        guild_id, channel_id, model_key, reasoning_level, current
+    await _render_panel(
+        interaction,
+        PanelState(
+            model_key=state.model_key,
+            reasoning_level=reasoning_level,
+            auto_respond=state.auto_respond,
+            fallback_model_key=state.fallback_model_key,
+        ),
     )
+
+
+async def handle_model_override_fallback_select(
+    event: hikari.InteractionCreateEvent,
+) -> None:
+    """Handle the fallback string-select: re-render the panel with the chosen
+    fallback model (or unset for no fallback)."""
+    interaction = event.interaction
+    if not isinstance(interaction, hikari.ComponentInteraction):
+        return
+    if await _deny_interaction_if_not_admin(event):
+        return
+
+    state = parse_panel_state(
+        interaction.custom_id, FALLBACK_SELECT_CUSTOM_ID_PREFIX
+    )
+    if state is None:
+        logger.error("Invalid fallback select custom_id: %s", interaction.custom_id)
+        await interaction.create_initial_response(
+            hikari.ResponseType.MESSAGE_UPDATE,
+            content="❌ Invalid request. Please run `/chat-bot-settings` again.",
+            components=[],
+        )
+        return
+
+    chosen = interaction.values[0] if interaction.values else SENTINEL_NO_FALLBACK
+    fallback_model_key = None if chosen == SENTINEL_NO_FALLBACK else chosen
+    await _render_panel(
+        interaction,
+        PanelState(
+            model_key=state.model_key,
+            reasoning_level=state.reasoning_level,
+            auto_respond=state.auto_respond,
+            fallback_model_key=fallback_model_key,
+        ),
+    )
+
+
+async def handle_model_override_auto_toggle(
+    event: hikari.InteractionCreateEvent,
+) -> None:
+    """Handle the auto-respond toggle button: flip the flag and re-render."""
+    interaction = event.interaction
+    if not isinstance(interaction, hikari.ComponentInteraction):
+        return
+    if await _deny_interaction_if_not_admin(event):
+        return
+
+    state = parse_panel_state(interaction.custom_id, AUTO_TOGGLE_CUSTOM_ID_PREFIX)
+    if state is None:
+        logger.error("Invalid auto-toggle custom_id: %s", interaction.custom_id)
+        await interaction.create_initial_response(
+            hikari.ResponseType.MESSAGE_UPDATE,
+            content="❌ Invalid request. Please run `/chat-bot-settings` again.",
+            components=[],
+        )
+        return
+
+    await _render_panel(
+        interaction,
+        PanelState(
+            model_key=state.model_key,
+            reasoning_level=state.reasoning_level,
+            auto_respond=not state.auto_respond,
+            fallback_model_key=state.fallback_model_key,
+        ),
+    )
+
+
+async def handle_model_override_continue(
+    event: hikari.InteractionCreateEvent,
+) -> None:
+    """Handle the "Budgets & filter…" button: open the settings modal carrying
+    the full panel state, budget/filter inputs prefilled from the stored value."""
+    interaction = event.interaction
+    if not isinstance(interaction, hikari.ComponentInteraction):
+        return
+    if await _deny_interaction_if_not_admin(event):
+        return
+
+    state = parse_panel_state(interaction.custom_id, CONTINUE_CUSTOM_ID_PREFIX)
+    if state is None or get_model(state.model_key) is None:
+        logger.error("Invalid continue custom_id: %s", interaction.custom_id)
+        await interaction.create_initial_response(
+            hikari.ResponseType.MESSAGE_UPDATE,
+            content="❌ Invalid request. Please run `/chat-bot-settings` again.",
+            components=[],
+        )
+        return
+
+    guild_id = str(interaction.guild_id)
+    channel_id = str(interaction.channel_id)
+    current = await _load_current_override(event.app, guild_id, channel_id)
+
+    modal = create_settings_modal(state, current)
     await interaction.create_modal_response(
         modal.title,
         modal.custom_id,
@@ -285,30 +420,28 @@ async def handle_model_override_reasoning_select(
 async def handle_model_override_modal_submit(
     event: hikari.InteractionCreateEvent,
 ) -> None:
-    """Handle the budgets modal submit: validate, persist, confirm ephemerally."""
+    """Handle the settings modal submit: validate, persist everything, confirm."""
     interaction = event.interaction
     if not isinstance(interaction, hikari.ModalInteraction):
         return
     if await _deny_interaction_if_not_admin(event):
         return
 
-    parts = interaction.custom_id.split(":")
-    if len(parts) != 5 or parts[0] != MODAL_CUSTOM_ID_PREFIX:
+    state = parse_panel_state(interaction.custom_id, MODAL_CUSTOM_ID_PREFIX)
+    if state is None:
         logger.error("Invalid model override modal custom_id: %s", interaction.custom_id)
         await interaction.create_initial_response(
             hikari.ResponseType.MESSAGE_CREATE,
-            content="❌ Invalid request. Please run `/setmodel` again.",
+            content="❌ Invalid request. Please run `/chat-bot-settings` again.",
             flags=hikari.MessageFlag.EPHEMERAL,
         )
         return
 
-    _, guild_id, channel_id, model_key, reasoning_part = parts
-    reasoning_level = reasoning_part or None
-    model = get_model(model_key)
+    model = get_model(state.model_key)
     if model is None:
         await interaction.create_initial_response(
             hikari.ResponseType.MESSAGE_CREATE,
-            content="❌ That model is no longer available. Please run `/setmodel` again.",
+            content="❌ That model is no longer available. Please run `/chat-bot-settings` again.",
             flags=hikari.MessageFlag.EPHEMERAL,
         )
         return
@@ -325,21 +458,27 @@ async def handle_model_override_modal_submit(
         )
         return
 
+    filter_text = (values.get("response_filter") or "").strip()
+    response_filter = filter_text or None
+
     service = _get_override_service(event.app)
     try:
         await service.set_override(
-            guild_id,
-            channel_id,
-            model_key,
+            str(interaction.guild_id),
+            str(interaction.channel_id),
+            state.model_key,
             daily_budget,
             hourly_budget,
-            reasoning_level=reasoning_level,
+            reasoning_level=state.reasoning_level,
+            auto_respond=state.auto_respond,
+            fallback_model_key=state.fallback_model_key,
+            response_filter=response_filter,
         )
     except APIError as exc:
         # Without this, the failure surfaces as Discord's generic
         # "This interaction failed" (the events.py fallback responder is
         # broken) and the admin gets no explanation.
-        logger.error("Failed to save model override for channel %s: %s", channel_id, exc)
+        logger.error("Failed to save model override for channel %s: %s", interaction.channel_id, exc)
         await interaction.create_initial_response(
             hikari.ResponseType.MESSAGE_CREATE,
             content="❌ Couldn't save the override — please try again shortly.",
@@ -351,12 +490,133 @@ async def handle_model_override_modal_submit(
         hikari.ResponseType.MESSAGE_CREATE,
         content=(
             f"✅ This channel now uses **{model.label}**.\n"
-            f"• Reasoning: {_render_reasoning(model, reasoning_level)}\n"
+            f"• Reasoning: {_render_reasoning(model, state.reasoning_level)}\n"
+            f"• Auto-respond: {'on' if state.auto_respond else 'off'}\n"
+            f"• Fallback model: {_render_fallback(state.fallback_model_key)}\n"
+            f"• Response filter: {'set' if response_filter else 'none'}\n"
             f"• Daily budget: {_render_budget(daily_budget)}\n"
             f"• Hourly budget: {_render_budget(hourly_budget)}"
         ),
         flags=hikari.MessageFlag.EPHEMERAL,
     )
+
+
+def _budget_redis(app: Any) -> Any | None:
+    """The bot's shared chat-memory Redis (used for the per-channel budgets), or
+    ``None`` when unavailable/tests use a non-dict ``bot.d``."""
+    data = getattr(app, "d", None)
+    if not isinstance(data, dict):
+        return None
+    return data.get("chat_memory_redis")
+
+
+# Seconds the "primary is back" marker outlives the budget reset — one day, so a
+# channel still learns its primary returned even if it goes quiet after opting in.
+_FALLBACK_ENDED_MARKER_TTL_SECONDS = 86400
+
+
+async def handle_model_budget_fallback(
+    event: hikari.InteractionCreateEvent,
+) -> None:
+    """Handle the "Answer with <fallback> instead" button on a budget-exhausted
+    notice.
+
+    Member-facing with NO admin gate — any member may opt the channel into the
+    free fallback model while the primary's budget is spent. On press: re-read
+    the override; if no fallback is configured any more, say so; otherwise mark
+    the channel's fallback active in Redis (both keys expire around the budget
+    reset the button was minted with), update the notice to confirm and drop the
+    button, and fire the channel's engine so pending conversation resumes.
+    """
+    interaction = event.interaction
+    if not isinstance(interaction, hikari.ComponentInteraction):
+        return
+
+    parts = interaction.custom_id.split(":")
+    if len(parts) != 2:
+        logger.error("Invalid model-budget-fallback custom_id: %s", interaction.custom_id)
+        return
+    try:
+        reset_epoch = int(parts[1])
+    except ValueError:
+        logger.error(
+            "Non-numeric reset epoch in model-budget-fallback custom_id: %s",
+            interaction.custom_id,
+        )
+        return
+
+    guild_id = str(interaction.guild_id)
+    channel_id = str(interaction.channel_id)
+
+    override = await _load_current_override(event.app, guild_id, channel_id)
+    if override is None or override.fallback_model_key is None:
+        await interaction.create_initial_response(
+            hikari.ResponseType.MESSAGE_CREATE,
+            content="This channel no longer has a fallback model configured.",
+            flags=hikari.MessageFlag.EPHEMERAL,
+        )
+        return
+
+    now_epoch = int(datetime.now(UTC).timestamp())
+    if reset_epoch <= now_epoch:
+        await interaction.create_initial_response(
+            hikari.ResponseType.MESSAGE_CREATE,
+            content="The budget has already reset — the primary model is answering again.",
+            flags=hikari.MessageFlag.EPHEMERAL,
+        )
+        return
+
+    redis = _budget_redis(event.app)
+    if redis is None:
+        await interaction.create_initial_response(
+            hikari.ResponseType.MESSAGE_CREATE,
+            content="Sorry, couldn't switch to the fallback model right now — please try again shortly.",
+            flags=hikari.MessageFlag.EPHEMERAL,
+        )
+        return
+
+    try:
+        await redis.set(fallback_flag_key(channel_id), "1", exat=reset_epoch)
+        await redis.set(
+            fallback_ended_key(channel_id),
+            "1",
+            exat=reset_epoch + _FALLBACK_ENDED_MARKER_TTL_SECONDS,
+        )
+    except Exception as exc:
+        logger.warning(
+            "Failed to set fallback keys for channel %s: %s", channel_id, exc
+        )
+        await interaction.create_initial_response(
+            hikari.ResponseType.MESSAGE_CREATE,
+            content="Sorry, couldn't switch to the fallback model right now — please try again shortly.",
+            flags=hikari.MessageFlag.EPHEMERAL,
+        )
+        return
+
+    fallback_model = get_model(override.fallback_model_key)
+    label = (
+        fallback_model.label if fallback_model is not None else override.fallback_model_key
+    )
+    await interaction.create_initial_response(
+        hikari.ResponseType.MESSAGE_UPDATE,
+        content=(
+            f"Switched to **{label}** while the primary model's budget is spent — "
+            "it'll answer pending messages now."
+        ),
+        components=[],
+    )
+
+    # Resume any active engagement so queued messages get answered immediately
+    # rather than waiting on the next message to fire the engine.
+    try:
+        engine = await get_chat_engine_registry().get(int(channel_id))
+    except Exception:
+        logger.debug(
+            "could not resolve chat engine for channel %s", channel_id, exc_info=True
+        )
+        engine = None
+    if engine is not None and engine.active:
+        engine.fire_now()
 
 
 def load(bot: lightbulb.BotApp) -> None:

--- a/smarter_dev/bot/services/channel_token_budget.py
+++ b/smarter_dev/bot/services/channel_token_budget.py
@@ -2,7 +2,7 @@
 
 Every channel's chat-token spend is metered into hour and day windows (threads
 count as their own channels). An admin can additionally cap the spend per hour
-and per day via the ``/setmodel`` override — only channels with an override
+and per day via the ``/chat-bot-settings`` override — only channels with an override
 have budgets enforced. Enforcement runs bot-side inside :mod:`chat_engine`, so
 this module talks to the bot's Redis directly rather than round-tripping the
 web API every turn.
@@ -37,15 +37,47 @@ def budget_key(channel_id: str, scope: str, window_index: int) -> str:
     return f"modelbudget:{channel_id}:{scope}:{window_index}"
 
 
+def fallback_flag_key(channel_id: str) -> str:
+    """Redis key for a channel's active free-fallback flag.
+
+    Present (with EXAT = the budget reset epoch) while a member has opted the
+    channel into its fallback model because the primary's budget is spent. Its
+    presence tells the engine to skip budget enforcement and run the fallback.
+    """
+    return f"modelbudget-fallback:{channel_id}"
+
+
+def fallback_ended_key(channel_id: str) -> str:
+    """Redis key for a channel's "notify when the primary returns" marker.
+
+    Set alongside :func:`fallback_flag_key` (EXAT = reset epoch + a day) so the
+    engine can announce the primary model is back on the first turn after the
+    fallback window closes, then clear the marker.
+    """
+    return f"modelbudget-fallback-ended:{channel_id}"
+
+
 def next_window_reset_epoch(now_epoch: float, window_seconds: int) -> int:
     """Epoch second the current wall-aligned ``window_seconds`` window rolls over."""
     return (_window_index(now_epoch, window_seconds) + 1) * window_seconds
 
 
-# Ordered (scope, window length) pairs — the two windows every channel tracks.
+# Ordered (scope, window length) pairs — the two enforced windows every channel
+# tracks. These are the counters ``over_budget_reset_epoch`` checks.
 _WINDOWS: tuple[tuple[str, int], ...] = (
     ("hour", HOUR_WINDOW_SECONDS),
     ("day", DAY_WINDOW_SECONDS),
+)
+
+# Parallel display-only windows for free-fallback spend. A member opting a
+# channel into its fallback model runs turns whose tokens must NOT count toward
+# the primary's cap (otherwise the "free" opt-in would silently push the day
+# window over budget and re-block the primary the moment the fallback closes).
+# These windows are never read by ``over_budget_reset_epoch`` — they only feed
+# ``/bot-usage`` so the display still reflects every token the channel spent.
+_FALLBACK_WINDOWS: tuple[tuple[str, int], ...] = (
+    ("hour-fallback", HOUR_WINDOW_SECONDS),
+    ("day-fallback", DAY_WINDOW_SECONDS),
 )
 
 
@@ -90,19 +122,35 @@ async def current_window_usage(redis: Redis, channel_id: str) -> tuple[int, int]
     """Tokens ``channel_id`` has consumed in the current (hour, day) windows.
 
     Reads the live counters without mutating them — backs the ``/bot-usage``
-    display. Windows with no writes yet read as 0.
+    display. Each figure sums the enforced window and its parallel free-fallback
+    window so the display reflects every token spent, enforced or free. Windows
+    with no writes yet read as 0.
     """
     now_epoch = datetime.now(UTC).timestamp()
-    usage = []
-    for scope, window_seconds in _WINDOWS:
-        key = budget_key(channel_id, scope, _window_index(now_epoch, window_seconds))
-        usage.append(await _consumed(redis, key))
-    hour_used, day_used = usage
+    totals: list[int] = []
+    for enforced_scope, fallback_scope, window_seconds in (
+        ("hour", "hour-fallback", HOUR_WINDOW_SECONDS),
+        ("day", "day-fallback", DAY_WINDOW_SECONDS),
+    ):
+        window_index = _window_index(now_epoch, window_seconds)
+        enforced = await _consumed(
+            redis, budget_key(channel_id, enforced_scope, window_index)
+        )
+        fallback = await _consumed(
+            redis, budget_key(channel_id, fallback_scope, window_index)
+        )
+        totals.append(enforced + fallback)
+    hour_used, day_used = totals
     return hour_used, day_used
 
 
-async def add_usage(redis: Redis, channel_id: str, tokens: int) -> None:
-    """Add ``tokens`` to ``channel_id``'s current hour and day windows.
+async def _add_windowed_usage(
+    redis: Redis,
+    channel_id: str,
+    tokens: int,
+    windows: tuple[tuple[str, int], ...],
+) -> None:
+    """Add ``tokens`` to each of ``windows`` for ``channel_id``.
 
     Each window is incremented with ``INCRBY`` and given a fresh TTL only on the
     first write (``EXPIRE ... NX``) so the window expires exactly one length
@@ -111,9 +159,28 @@ async def add_usage(redis: Redis, channel_id: str, tokens: int) -> None:
     if tokens <= 0:
         return
     now_epoch = datetime.now(UTC).timestamp()
-    for scope, window_seconds in _WINDOWS:
+    for scope, window_seconds in windows:
         key = budget_key(channel_id, scope, _window_index(now_epoch, window_seconds))
         async with redis.pipeline(transaction=True) as pipe:
             pipe.incrby(key, tokens)
             pipe.expire(key, window_seconds, nx=True)
             await pipe.execute()
+
+
+async def add_usage(redis: Redis, channel_id: str, tokens: int) -> None:
+    """Add ``tokens`` to ``channel_id``'s current enforced hour and day windows.
+
+    These are the counters ``over_budget_reset_epoch`` enforces; a non-positive
+    ``tokens`` is a no-op.
+    """
+    await _add_windowed_usage(redis, channel_id, tokens, _WINDOWS)
+
+
+async def add_fallback_usage(redis: Redis, channel_id: str, tokens: int) -> None:
+    """Add a free-fallback turn's ``tokens`` to the display-only windows.
+
+    Metered separately from :func:`add_usage` so free-fallback spend shows in
+    ``/bot-usage`` but never counts toward the enforced budget — the whole point
+    of the opt-in is that its spend is free.
+    """
+    await _add_windowed_usage(redis, channel_id, tokens, _FALLBACK_WINDOWS)

--- a/smarter_dev/bot/services/chat_engine.py
+++ b/smarter_dev/bot/services/chat_engine.py
@@ -50,12 +50,17 @@ from smarter_dev.bot.agents.chat_compaction import start_collection
 from smarter_dev.bot.agents.chat_context import build_followup_input
 from smarter_dev.bot.agents.chat_context import build_initial_input
 from smarter_dev.bot.agents.chat_input_format import build_agent_call
+from smarter_dev.bot.agents.message_gate import GateMessage
+from smarter_dev.bot.agents.message_gate import filter_messages
 from smarter_dev.bot.agents.chat_models import ResponseBody
 from smarter_dev.bot.agents.chat_models import TurnDecision
 from smarter_dev.bot.agents.chat_tools import ChatDeps
 from smarter_dev.bot.agents.chat_tools import GeneratedImage
 from smarter_dev.shared.model_catalog import get_model
+from smarter_dev.bot.services.channel_token_budget import add_fallback_usage
 from smarter_dev.bot.services.channel_token_budget import add_usage
+from smarter_dev.bot.services.channel_token_budget import fallback_ended_key
+from smarter_dev.bot.services.channel_token_budget import fallback_flag_key
 from smarter_dev.bot.services.exceptions import APIError
 from smarter_dev.bot.services.channel_token_budget import over_budget_reset_epoch
 from smarter_dev.bot.services.chat_conversation_persistence import end_engagement
@@ -66,6 +71,9 @@ from smarter_dev.bot.services.user_message_limit import DIRECTED_SCORE_THRESHOLD
 from smarter_dev.bot.services.user_message_limit import record_directed_messages
 from smarter_dev.bot.utils.stop_detection import is_stop_request
 from smarter_dev.bot.utils.stop_detection import set_channel_cooldown
+from smarter_dev.bot.views.model_override_views import (
+    MODEL_BUDGET_FALLBACK_CUSTOM_ID_PREFIX,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -80,6 +88,9 @@ MAX_RUNTIME = timedelta(hours=2)
 # SET NX EX) caps that notice to once per hour per channel so a busy channel
 # can't be spammed while the budget stays spent.
 BUDGET_NOTICE_COOLDOWN_SECONDS = 60 * 60
+# How many channel messages immediately preceding the gated candidates are
+# fetched as read-only context for the response-filter gate.
+GATE_GROUNDING_LIMIT = 5
 # ``{reset_tag}`` is a Discord relative timestamp (``<t:epoch:R>``) that the
 # client renders as a live countdown ("in 25 minutes") to the window boundary.
 _BUDGET_EXHAUSTED_NOTICE_TEMPLATE = (
@@ -372,18 +383,76 @@ class ChannelEngine:
                 drained = [q.message for q in self.queue]
                 self.queue.clear()
 
+            memory = get_chat_memory()
+            if first_activation:
+                await memory.reset_idle_counter(self.channel_id)
+
+            # Resolve any admin per-channel override up front: its response
+            # filter (if set) decides which pending messages are worth a turn,
+            # and its budget / fallback model steer the model resolution below.
+            override = await self._get_channel_override()
+            budget_redis = self._budget_redis()
+
+            # Response-filter gate — runs BEFORE any model spend or budget check.
+            # A restricted channel asks the cheap relevance gate which of the
+            # candidate messages the admin's filter allows and drops the rest;
+            # if nothing survives the whole turn is skipped (no model call, no
+            # budget spend, no no-response strike, engagement untouched). Mentions
+            # get no bypass — an off-topic @mention is dropped too.
+            response_filter = (
+                getattr(override, "response_filter", None)
+                if override is not None
+                else None
+            )
+            if response_filter and response_filter.strip():
+                if first_activation:
+                    # Judge the activation trigger together with anything queued
+                    # since it: while the engine is already active every later
+                    # message routes through ``observe`` (never a fresh
+                    # ``trigger_initial``), so the queued messages are the only
+                    # way a later on-topic message can start the engagement when
+                    # the activating message itself was off-topic. The earliest
+                    # survivor becomes the engagement's trigger.
+                    candidates = [
+                        message
+                        for message in [self.activation_message, *drained]
+                        if message is not None
+                    ]
+                    allowed = await self._gate_allows(response_filter, candidates)
+                    survivors = [m for m in candidates if str(m.id) in allowed]
+                    if not survivors:
+                        logger.info(
+                            "Response filter dropped the activation and %d "
+                            "queued message(s) for channel %s — skipping turn "
+                            "(engagement retained)",
+                            len(drained),
+                            self.channel_id,
+                        )
+                        # Retain first_activation (return False) so a later
+                        # on-topic message still starts the engagement.
+                        return False
+                    self.activation_message = survivors[0]
+                else:
+                    allowed = await self._gate_allows(response_filter, drained)
+                    survivors = [m for m in drained if str(m.id) in allowed]
+                    if not survivors:
+                        logger.info(
+                            "Response filter dropped all %d queued message(s) "
+                            "for channel %s — skipping turn",
+                            len(drained),
+                            self.channel_id,
+                        )
+                        return True
+                    drained = survivors
+
             # Best reply-to anchor for any user-facing error message: the
             # activation trigger on first turn, otherwise the freshest
-            # queued message.
+            # surviving queued message.
             error_reply_to: int | None = None
             if first_activation and self.activation_message is not None:
                 error_reply_to = int(self.activation_message.id)
             elif drained:
                 error_reply_to = int(drained[-1].id)
-
-            memory = get_chat_memory()
-            if first_activation:
-                await memory.reset_idle_counter(self.channel_id)
 
             try:
                 if first_activation:
@@ -441,13 +510,28 @@ class ChannelEngine:
                 len(history),
             )
 
-            # Resolve any admin per-channel override and enforce its token
-            # budget before we spend a model call. A channel with no override
-            # falls through unchanged (default model, no budget checks) —
-            # though its token usage is still metered after the run.
-            override = await self._get_channel_override()
-            budget_redis = self._budget_redis()
-            if override is not None and budget_redis is not None:
+            # Enforce the override's token budget (and route around it via the
+            # fallback model) before we spend a model call. Three regimes:
+            #  * a free-fallback window is active — a member opted this channel
+            #    into its fallback model while the primary's budget is spent, so
+            #    budget enforcement is skipped and the fallback model runs;
+            #  * otherwise an over-budget channel skips the turn (offering the
+            #    fallback if one is configured);
+            #  * a channel under budget (or with no override) runs its model.
+            # A channel with no override always falls through unchanged (default
+            # model, no budget checks); its usage is still metered after the run.
+            fallback_active = (
+                await self._fallback_window_active(budget_redis)
+                if override is not None and budget_redis is not None
+                else False
+            )
+            if fallback_active:
+                # Free fallback model in effect — its spend does not count
+                # against the cap, so no budget check. Reasoning stays unset so
+                # the fallback model uses its own default.
+                override_model_id = self._resolve_fallback_model_id(override)
+                override_reasoning = None
+            elif override is not None and budget_redis is not None:
                 budget_reset_epoch = await over_budget_reset_epoch(
                     budget_redis,
                     str(self.channel_id),
@@ -464,20 +548,37 @@ class ChannelEngine:
                         budget_redis,
                         reset_epoch=budget_reset_epoch,
                         reply_to=error_reply_to,
+                        fallback_model_key=getattr(
+                            override, "fallback_model_key", None
+                        ),
                     )
                     # Skipped before start_engagement — report the first
                     # activation as NOT consumed so the engagement still starts
                     # (and turns persist) once the budget window resets.
                     return False
-            override_model_id = self._resolve_override_model_id(override)
-            # Only carry the override's reasoning level when its model actually
-            # applied — a stale model_key falls back to the default model, which
-            # keeps its own reasoning config.
-            override_reasoning = (
-                override.reasoning_level
-                if override is not None and override_model_id is not None
-                else None
-            )
+                # Under budget now. If a prior fallback window just ended,
+                # announce the primary is back once before running its turn —
+                # done only after the budget re-check so a channel that is still
+                # over budget never sees a "primary is back" notice immediately
+                # followed by a "budget exhausted" one (and the one-shot marker
+                # survives so the genuine restoration is announced later).
+                await self._maybe_notice_primary_restored(budget_redis, override)
+                override_model_id = self._resolve_override_model_id(override)
+                # Only carry the override's reasoning level when its model
+                # actually applied — a stale model_key falls back to the default
+                # model, which keeps its own reasoning config.
+                override_reasoning = (
+                    override.reasoning_level
+                    if override_model_id is not None
+                    else None
+                )
+            else:
+                override_model_id = self._resolve_override_model_id(override)
+                override_reasoning = (
+                    override.reasoning_level
+                    if override is not None and override_model_id is not None
+                    else None
+                )
             # The model this turn actually runs on: the override's wire id when
             # one applied, otherwise the configured default. Persisted with the
             # turn so the dashboard prices tokens against the right model.
@@ -561,9 +662,13 @@ class ChannelEngine:
             # Every channel is metered (so ``/bot-usage`` always has numbers);
             # the budgets that *enforce* only exist on override channels.
             # Compaction runs on its own summarizer model and its tokens are not
-            # in ``result.usage()``, so they are not counted here.
+            # in ``result.usage()``, so they are not counted here. A free-fallback
+            # turn meters into display-only windows so its spend still shows in
+            # ``/bot-usage`` but never counts toward the enforced budget.
             if budget_redis is not None:
-                await self._record_budget_usage(budget_redis, tokens)
+                await self._record_budget_usage(
+                    budget_redis, tokens, fallback_active=fallback_active
+                )
             await self._charge_directed_messages(
                 output, drained, first_activation=first_activation
             )
@@ -934,10 +1039,181 @@ class ChannelEngine:
             return None
         return catalog_model.model_id
 
-    async def _record_budget_usage(self, redis: Any, tokens: int) -> None:
-        """Add ``tokens`` to the channel's budget windows (best-effort)."""
+    def _fallback_flag_key(self) -> str:
+        """Redis key for this channel's active free-fallback flag."""
+        return fallback_flag_key(str(self.channel_id))
+
+    def _fallback_ended_key(self) -> str:
+        """Redis key for this channel's "notify when the primary returns" marker."""
+        return fallback_ended_key(str(self.channel_id))
+
+    async def _fallback_window_active(self, redis: Any) -> bool:
+        """Whether the free-fallback flag is set for this channel (best-effort).
+
+        A member sets the flag to opt the channel into its fallback model while
+        the primary's budget is spent; it self-expires at the budget reset. Any
+        Redis trouble reads as "no fallback" so a bad read never silently swaps
+        which model runs.
+        """
         try:
-            await add_usage(redis, str(self.channel_id), tokens)
+            return bool(await redis.exists(self._fallback_flag_key()))
+        except RedisError:
+            logger.debug(
+                "could not read fallback flag for channel %s",
+                self.channel_id,
+                exc_info=True,
+            )
+            return False
+
+    def _resolve_fallback_model_id(self, override: Any | None) -> str | None:
+        """Wire model id for the override's fallback model while the free-fallback
+        window is active.
+
+        A missing or stale ``fallback_model_key`` degrades to the primary
+        override model (with a warning), mirroring ``_resolve_override_model_id``.
+        """
+        fallback_key = (
+            getattr(override, "fallback_model_key", None)
+            if override is not None
+            else None
+        )
+        if fallback_key is None:
+            logger.warning(
+                "Channel %s fallback window active but no fallback model "
+                "configured — using the primary override model",
+                self.channel_id,
+            )
+            return self._resolve_override_model_id(override)
+        catalog_model = get_model(fallback_key)
+        if catalog_model is None:
+            logger.warning(
+                "Channel %s fallback names unknown model_key %r — using the "
+                "primary override model",
+                self.channel_id,
+                fallback_key,
+            )
+            return self._resolve_override_model_id(override)
+        return catalog_model.model_id
+
+    @staticmethod
+    def _to_gate_message(message: Any) -> GateMessage:
+        """Convert a hikari message into a ``GateMessage`` for the response gate."""
+        author = getattr(message, "author", None)
+        author_display = ""
+        if author is not None:
+            author_display = (
+                getattr(author, "username", None)
+                or getattr(author, "display_name", None)
+                or ""
+            )
+        return GateMessage(
+            message_id=str(message.id),
+            author_display=author_display,
+            content=getattr(message, "content", None) or "",
+        )
+
+    async def _fetch_gate_grounding(self, candidates: list[Any]) -> list[GateMessage]:
+        """Fetch up to ``GATE_GROUNDING_LIMIT`` channel messages preceding the
+        gate ``candidates`` as read-only context (oldest-first).
+
+        Any fetch failure degrades to empty grounding (debug log) — the gate
+        still judges the candidates, just without their surrounding context.
+        """
+        candidate_ids = [int(message.id) for message in candidates if message is not None]
+        if not candidate_ids:
+            return []
+        oldest_candidate_id = min(candidate_ids)
+        fetched: list[Any] = []
+        try:
+            iterator = self.bot.rest.fetch_messages(
+                self.channel_id, before=oldest_candidate_id
+            ).limit(GATE_GROUNDING_LIMIT)
+            async for message in iterator:
+                fetched.append(message)
+        except Exception:
+            logger.debug(
+                "could not fetch response-filter grounding for channel %s",
+                self.channel_id,
+                exc_info=True,
+            )
+            return []
+        fetched.reverse()
+        return [self._to_gate_message(message) for message in fetched]
+
+    async def _gate_allows(
+        self, response_filter: str, candidates: list[Any]
+    ) -> set[str]:
+        """Return the ids of ``candidates`` the response filter allows.
+
+        Wraps the (already fail-open) message gate so an unexpected error still
+        runs the turn unfiltered — a wasted reply is far cheaper than a channel
+        that goes mute. ``candidates`` are hikari messages; grounding is up to
+        five channel messages immediately preceding them.
+        """
+        candidate_messages = [
+            self._to_gate_message(message)
+            for message in candidates
+            if message is not None
+        ]
+        if not candidate_messages:
+            return set()
+        grounding = await self._fetch_gate_grounding(candidates)
+        try:
+            allowed = await filter_messages(
+                response_filter, candidate_messages, grounding
+            )
+        except Exception:
+            logger.warning(
+                "response filter gate errored for channel %s — running turn "
+                "unfiltered",
+                self.channel_id,
+                exc_info=True,
+            )
+            return {message.message_id for message in candidate_messages}
+        return set(allowed)
+
+    async def _maybe_notice_primary_restored(
+        self, redis: Any, override: Any
+    ) -> None:
+        """Announce the primary model is answering again once a fallback window
+        has ended, clearing the one-shot marker.
+
+        The marker outlives the fallback flag by a day so the channel still
+        learns its primary is back even when the first post-reset turn is much
+        later. Best-effort: any Redis trouble simply skips the notice.
+        """
+        try:
+            cleared = await redis.delete(self._fallback_ended_key())
+        except RedisError:
+            logger.debug(
+                "could not read fallback-ended marker for channel %s",
+                self.channel_id,
+                exc_info=True,
+            )
+            return
+        if not cleared:
+            return
+        model = get_model(override.model_key)
+        label = model.label if model is not None else override.model_key
+        await self._post_notice(
+            f"Budget reset — **{label}** is answering again.",
+            reply_to=None,
+        )
+
+    async def _record_budget_usage(
+        self, redis: Any, tokens: int, *, fallback_active: bool
+    ) -> None:
+        """Add ``tokens`` to the channel's usage windows (best-effort).
+
+        A free-fallback turn's spend is metered into display-only windows
+        (:func:`add_fallback_usage`) so it still shows in ``/bot-usage`` but
+        never counts toward the enforced budget — otherwise the "free" opt-in
+        would push the enforced day window over its cap and re-block the primary
+        the moment the fallback window closes.
+        """
+        record = add_fallback_usage if fallback_active else add_usage
+        try:
+            await record(redis, str(self.channel_id), tokens)
         except RedisError:
             logger.warning(
                 "Failed to record token budget usage for channel %s",
@@ -1002,7 +1278,12 @@ class ChannelEngine:
                 )
 
     async def _maybe_notice_budget_exhausted(
-        self, redis: Any, *, reset_epoch: int, reply_to: int | None
+        self,
+        redis: Any,
+        *,
+        reset_epoch: int,
+        reply_to: int | None,
+        fallback_model_key: str | None = None,
     ) -> None:
         """Post the budget-exhausted notice, throttled to once per hour.
 
@@ -1010,7 +1291,9 @@ class ChannelEngine:
         readers see a live countdown to the budget reset. A Redis ``SET NX EX``
         acts as the per-channel throttle: only the call that wins the key posts,
         so repeated over-budget turns stay silent until the cooldown lapses.
-        Any Redis hiccup skips the notice (never blocks).
+        Any Redis hiccup skips the notice (never blocks). When
+        ``fallback_model_key`` names a configured fallback, the notice carries a
+        one-press button that opts the channel into that model for free.
         """
         try:
             won = await redis.set(
@@ -1030,7 +1313,32 @@ class ChannelEngine:
             notice = _BUDGET_EXHAUSTED_NOTICE_TEMPLATE.format(
                 reset_tag=f"<t:{reset_epoch}:R>"
             )
-            await self._post_error(notice, reply_to=reply_to)
+            components = self._build_fallback_offer(fallback_model_key, reset_epoch)
+            await self._post_notice(
+                notice, reply_to=reply_to, components=components
+            )
+
+    def _build_fallback_offer(
+        self, fallback_model_key: str | None, reset_epoch: int
+    ) -> list[Any] | None:
+        """One-button action row offering the configured fallback model, or None.
+
+        ``None`` when no fallback is configured (or its key is stale) so the
+        notice posts plain. The button's ``custom_id`` carries only the reset
+        epoch; the handler reads channel/guild from the interaction.
+        """
+        if fallback_model_key is None:
+            return None
+        fallback_model = get_model(fallback_model_key)
+        if fallback_model is None:
+            return None
+        row = hikari.impl.MessageActionRowBuilder()
+        row.add_interactive_button(
+            hikari.ButtonStyle.PRIMARY,
+            f"{MODEL_BUDGET_FALLBACK_CUSTOM_ID_PREFIX}:{reset_epoch}",
+            label=f"Answer with {fallback_model.label} instead"[:80],
+        )
+        return [row]
 
     def _shared_api_client(self) -> Any | None:
         """The bot's shared APIClient (set on ``bot.d``), or None if absent.
@@ -1106,6 +1414,28 @@ class ChannelEngine:
             await self.bot.rest.create_message(self.channel_id, **kwargs)
         except Exception:
             logger.debug("Failed to post error message", exc_info=True)
+
+    async def _post_notice(
+        self,
+        text: str,
+        *,
+        reply_to: int | None = None,
+        components: list[Any] | None = None,
+    ) -> None:
+        """Send a channel notice, optionally carrying interactive components.
+
+        Like :meth:`_post_error` but with component support (the budget-exhausted
+        notice's fallback-offer button). Best-effort: send failures are swallowed.
+        """
+        try:
+            kwargs: dict[str, Any] = {"content": text[:2000]}
+            if reply_to is not None:
+                kwargs["reply"] = reply_to
+            if components is not None:
+                kwargs["components"] = components
+            await self.bot.rest.create_message(self.channel_id, **kwargs)
+        except Exception:
+            logger.debug("Failed to post notice message", exc_info=True)
 
     async def _maybe_refire(self) -> None:
         async with self.queue_lock:

--- a/smarter_dev/bot/services/model_override_service.py
+++ b/smarter_dev/bot/services/model_override_service.py
@@ -1,7 +1,7 @@
 """Bot-side service for per-channel LLM model overrides.
 
 Wraps the web API's ``/guilds/{guild_id}/channels/{channel_id}/model-override``
-endpoints so the admin ``/setmodel`` slash command (stage 03) and the chat runtime
+endpoints so the admin ``/chat-bot-settings`` slash command (stage 03) and the chat runtime
 (stage 04) can read/write a channel's model + token budgets without touching the
 DB directly.
 
@@ -86,10 +86,15 @@ class ModelOverrideService(BaseService):
         daily_token_budget: int,
         hourly_token_budget: int,
         reasoning_level: str | None = None,
+        auto_respond: bool = False,
+        fallback_model_key: str | None = None,
+        response_filter: str | None = None,
     ) -> ChannelModelOverride:
         """Upsert the channel's override and return the stored value.
 
         ``reasoning_level`` of ``None`` means "use the model's default level".
+        ``auto_respond`` makes the bot reply to any message, not just @mentions;
+        ``fallback_model_key`` and ``response_filter`` default to "unset".
         """
         response = await self._api_client.put(
             self._path(guild_id, channel_id),
@@ -98,6 +103,9 @@ class ModelOverrideService(BaseService):
                 "reasoning_level": reasoning_level,
                 "daily_token_budget": daily_token_budget,
                 "hourly_token_budget": hourly_token_budget,
+                "auto_respond": auto_respond,
+                "fallback_model_key": fallback_model_key,
+                "response_filter": response_filter,
             },
         )
         self._invalidate_override(guild_id, channel_id)

--- a/smarter_dev/bot/services/models.py
+++ b/smarter_dev/bot/services/models.py
@@ -611,6 +611,9 @@ class ChannelModelOverride:
     daily_token_budget: int
     hourly_token_budget: int
     reasoning_level: str | None = None
+    auto_respond: bool = False
+    fallback_model_key: str | None = None
+    response_filter: str | None = None
     created_at: datetime | None = None
     updated_at: datetime | None = None
 
@@ -624,6 +627,9 @@ class ChannelModelOverride:
             reasoning_level=data.get("reasoning_level"),
             daily_token_budget=data["daily_token_budget"],
             hourly_token_budget=data["hourly_token_budget"],
+            auto_respond=data.get("auto_respond", False),
+            fallback_model_key=data.get("fallback_model_key"),
+            response_filter=data.get("response_filter"),
             created_at=_parse_iso_datetime(data.get("created_at")),
             updated_at=_parse_iso_datetime(data.get("updated_at")),
         )

--- a/smarter_dev/bot/views/model_override_views.py
+++ b/smarter_dev/bot/views/model_override_views.py
@@ -1,24 +1,34 @@
-"""Discord components for the admin per-channel model-override command.
+"""Discord components for the admin per-channel chat-bot-settings command.
 
-Path B (multi-step) flow — chosen because the installed hikari (2.1.1) exposes no
-``Label`` component builder, so Discord modal string-selects are unsupported. The
-reasoning level therefore lives in its own *message* select (Discord modals
-cannot host selects), not in the budgets modal:
+Single-panel flow — chosen because the installed hikari (2.1.1) exposes no
+``Label`` component builder, so Discord modal string-selects are unsupported and
+a Discord message holds at most five action rows. The model is picked in an
+initial message select; everything else lives in one follow-up *settings panel*
+(selects + buttons cannot share a modal), and only the free-text budgets and
+response filter go in a modal:
 
-1. ``/setmodel`` responds (ephemeral) with a message string-select of models
-   (``create_model_select_message``), plus a "server default" sentinel option.
-2. Picking a reasoning-capable model swaps the message for a reasoning-level
-   select (``create_reasoning_select_message``); picking a model with no
-   reasoning knob skips straight to step 3.
-3. The budgets modal (``create_budgets_modal``) whose ``custom_id`` encodes the
-   guild, channel, chosen model key and reasoning level. Picking the server
-   default sentinel clears the override without a modal.
+1. ``/chat-bot-settings`` responds (ephemeral) with a message string-select of
+   models (``create_model_select_message``), plus a "server default" sentinel.
+2. Picking a model swaps the message for the settings panel
+   (``create_settings_panel``): an optional reasoning select (reasoning-capable
+   models only), a fallback-model select, and a button row with an auto-respond
+   toggle and a "Budgets & filter…" button. The panel's state (chosen model,
+   reasoning level, auto flag, fallback key) rides in every component's
+   ``custom_id`` — see :func:`encode_panel_state` / :func:`parse_panel_state` —
+   so each select/toggle re-renders the panel with the updated state and no
+   server-side session. Picking the server-default sentinel clears the override
+   without a panel.
+3. The "Budgets & filter…" button opens the settings modal
+   (``create_settings_modal``) whose ``custom_id`` carries the full panel state;
+   its text inputs collect the daily/hourly budgets and the response filter.
 
 Everything here is a pure builder or parser — the actual API writes and Discord
 responses live in :mod:`smarter_dev.bot.plugins.model_override`.
 """
 
 from __future__ import annotations
+
+from dataclasses import dataclass
 
 import hikari
 
@@ -27,7 +37,7 @@ from smarter_dev.shared.model_catalog import models_by_family
 from smarter_dev.shared.model_catalog import parse_reasoning_level
 from smarter_dev.bot.services.models import ChannelModelOverride
 
-# Select value that means "remove any override and fall back to the server
+# Model-select value that means "remove any override and fall back to the server
 # default model". Kept distinct from every catalog key.
 SENTINEL_DEFAULT = "__default__"
 
@@ -35,15 +45,90 @@ SENTINEL_DEFAULT = "__default__"
 # as NULL). Kept distinct from every ReasoningLevel value.
 SENTINEL_MODEL_DEFAULT = "__model_default__"
 
-# custom_id prefixes routed in smarter_dev.bot.plugins.events.
+# Fallback-select value that means "no fallback model" (stored as NULL). Kept
+# distinct from every catalog key.
+SENTINEL_NO_FALLBACK = "__no_fallback__"
+
+# custom_id constant/prefixes routed in smarter_dev.bot.plugins.events. The
+# panel prefixes are deliberately short (``cbs_`` = chat-bot-settings) so the
+# encoded state still fits inside Discord's 100-char custom_id limit.
 SELECT_CUSTOM_ID = "model_override_select"
-REASONING_SELECT_CUSTOM_ID_PREFIX = "model_override_reasoning"
-MODAL_CUSTOM_ID_PREFIX = "model_override_modal"
+REASONING_SELECT_CUSTOM_ID_PREFIX = "cbs_reasoning"
+FALLBACK_SELECT_CUSTOM_ID_PREFIX = "cbs_fallback"
+AUTO_TOGGLE_CUSTOM_ID_PREFIX = "cbs_auto"
+CONTINUE_CUSTOM_ID_PREFIX = "cbs_continue"
+MODAL_CUSTOM_ID_PREFIX = "cbs_modal"
+
+# Prefix for the button the chat engine attaches to a budget-exhausted notice,
+# offering the channel's configured fallback model. Its only state is the budget
+# reset epoch (``model_budget_fallback:<reset_epoch>``); channel/guild come from
+# the interaction. Routed in smarter_dev.bot.plugins.events like the others and
+# kept well under Discord's 100-char custom_id limit.
+MODEL_BUDGET_FALLBACK_CUSTOM_ID_PREFIX = "model_budget_fallback"
 
 # Server-side cap on a token budget (matches the API/DB 32-bit signed maximum).
 # Enforced here too so an over-limit entry gets a clear message instead of
 # Discord's generic "This interaction failed".
 MAX_TOKEN_BUDGET = 2_147_483_647
+
+
+@dataclass(frozen=True)
+class PanelState:
+    """The settings-panel state threaded through every component ``custom_id``.
+
+    Attributes:
+        model_key: The chosen primary model's catalog key.
+        reasoning_level: The chosen reasoning value, or ``None`` for the model
+            default.
+        auto_respond: Whether the bot replies to any message (not just mentions).
+        fallback_model_key: The chosen fallback model's key, or ``None`` for none.
+    """
+
+    model_key: str
+    reasoning_level: str | None
+    auto_respond: bool
+    fallback_model_key: str | None
+
+
+def encode_panel_state(
+    model_key: str,
+    reasoning_level: str | None,
+    auto_respond: bool,
+    fallback_model_key: str | None,
+) -> str:
+    """Encode the panel state as a colon-joined ``custom_id`` suffix.
+
+    Empty reasoning/fallback segments mean "model default" / "no fallback"; the
+    auto flag is ``1``/``0``. Guild and channel are deliberately *not* encoded —
+    the panel is ephemeral in the configured channel, so handlers read
+    ``interaction.guild_id`` / ``interaction.channel_id`` directly.
+    """
+    return ":".join(
+        (
+            model_key,
+            reasoning_level or "",
+            "1" if auto_respond else "0",
+            fallback_model_key or "",
+        )
+    )
+
+
+def parse_panel_state(custom_id: str, expected_prefix: str) -> PanelState | None:
+    """Parse a panel ``custom_id`` into a :class:`PanelState`.
+
+    Returns ``None`` when the prefix does not match or the field count is wrong
+    (a malformed/replayed id), so the caller can reject it cleanly.
+    """
+    parts = custom_id.split(":")
+    if len(parts) != 5 or parts[0] != expected_prefix:
+        return None
+    _, model_key, reasoning, auto, fallback = parts
+    return PanelState(
+        model_key=model_key,
+        reasoning_level=reasoning or None,
+        auto_respond=auto == "1",
+        fallback_model_key=fallback or None,
+    )
 
 
 def build_model_options(current_key: str | None) -> list[hikari.impl.SelectOptionBuilder]:
@@ -130,52 +215,123 @@ def build_reasoning_options(
     return options
 
 
-def create_reasoning_select_message(
-    guild_id: str,
-    channel_id: str,
+def build_fallback_options(
+    primary_key: str, current_fallback_key: str | None
+) -> list[hikari.impl.SelectOptionBuilder]:
+    """Build the fallback-select options: a "no fallback" sentinel first, then
+    every catalog model except the chosen ``primary_key`` (a model never falls
+    back to itself), grouped by family.
+
+    ``current_fallback_key`` (the channel's stored fallback, or ``None``) marks
+    the pre-selected default; ``None`` selects the sentinel. Kept within
+    Discord's 25-option limit by the catalog being <= 24 entries.
+    """
+    options: list[hikari.impl.SelectOptionBuilder] = [
+        hikari.impl.SelectOptionBuilder(
+            label="No fallback",
+            value=SENTINEL_NO_FALLBACK,
+            description="Don't retry with another model",
+            is_default=current_fallback_key is None,
+        )
+    ]
+    for family, models in models_by_family().items():
+        for model in models:
+            if model.key == primary_key:
+                continue
+            options.append(
+                hikari.impl.SelectOptionBuilder(
+                    label=f"{family} · {model.label}",
+                    value=model.key,
+                    is_default=model.key == current_fallback_key,
+                )
+            )
+    return options
+
+
+def create_settings_panel(
     model: CatalogModel,
-    current: ChannelModelOverride | None,
+    reasoning_level: str | None,
+    auto_respond: bool,
+    fallback_model_key: str | None,
 ) -> list[hikari.impl.MessageActionRowBuilder]:
-    """Build the ephemeral reasoning-select step for a chosen reasoning-capable
-    model. The ``custom_id`` carries ``guild_id``, ``channel_id`` and the model
-    key so the next handler can open the budgets modal without extra state."""
-    current_level = current.reasoning_level if current is not None else None
-    action_row = hikari.impl.MessageActionRowBuilder()
-    menu = action_row.add_text_menu(
-        f"{REASONING_SELECT_CUSTOM_ID_PREFIX}:{guild_id}:{channel_id}:{model.key}",
-        placeholder="Choose a reasoning level",
+    """Build the ephemeral settings panel for a chosen ``model``.
+
+    Holds (in order) an optional reasoning select (reasoning-capable models
+    only), a fallback-model select, and a button row with an auto-respond toggle
+    and a "Budgets & filter…" button. The current panel state is encoded into
+    every component's ``custom_id`` so each interaction can re-render the panel
+    without server-side session state.
+    """
+    state = encode_panel_state(
+        model.key, reasoning_level, auto_respond, fallback_model_key
+    )
+    rows: list[hikari.impl.MessageActionRowBuilder] = []
+
+    if model.supports_reasoning:
+        reasoning_row = hikari.impl.MessageActionRowBuilder()
+        reasoning_menu = reasoning_row.add_text_menu(
+            f"{REASONING_SELECT_CUSTOM_ID_PREFIX}:{state}",
+            placeholder="Choose a reasoning level",
+            min_values=1,
+            max_values=1,
+        )
+        for option in build_reasoning_options(model, reasoning_level):
+            reasoning_menu.add_option(
+                option.label,
+                option.value,
+                description=option.description,
+                is_default=option.is_default,
+            )
+        rows.append(reasoning_row)
+
+    fallback_row = hikari.impl.MessageActionRowBuilder()
+    fallback_menu = fallback_row.add_text_menu(
+        f"{FALLBACK_SELECT_CUSTOM_ID_PREFIX}:{state}",
+        placeholder="Choose a fallback model",
         min_values=1,
         max_values=1,
     )
-    for option in build_reasoning_options(model, current_level):
-        menu.add_option(
+    for option in build_fallback_options(model.key, fallback_model_key):
+        fallback_menu.add_option(
             option.label,
             option.value,
             description=option.description,
             is_default=option.is_default,
         )
-    return [action_row]
+    rows.append(fallback_row)
+
+    button_row = hikari.impl.MessageActionRowBuilder()
+    button_row.add_interactive_button(
+        hikari.ButtonStyle.SUCCESS if auto_respond else hikari.ButtonStyle.SECONDARY,
+        f"{AUTO_TOGGLE_CUSTOM_ID_PREFIX}:{state}",
+        label="Auto-respond: ON" if auto_respond else "Auto-respond: OFF",
+    )
+    button_row.add_interactive_button(
+        hikari.ButtonStyle.PRIMARY,
+        f"{CONTINUE_CUSTOM_ID_PREFIX}:{state}",
+        label="Budgets & filter…",
+    )
+    rows.append(button_row)
+
+    return rows
 
 
-def create_budgets_modal(
-    guild_id: str,
-    channel_id: str,
-    model_key: str,
-    reasoning_level: str | None,
+def create_settings_modal(
+    state: PanelState,
     current: ChannelModelOverride | None,
 ) -> hikari.api.InteractionModalBuilder:
-    """Build the daily/hourly token-budget modal for a chosen model.
+    """Build the budgets + response-filter modal carrying the full panel state.
 
-    The ``custom_id`` carries ``guild_id``, ``channel_id``, ``model_key`` and the
-    chosen ``reasoning_level`` (empty for "model default") so the submit handler
-    can persist without extra state. Budget inputs prefill from ``current`` when
-    present so reopening reflects the stored values.
+    The ``custom_id`` encodes ``state`` so the submit handler persists model,
+    reasoning, auto-respond and fallback alongside the free-text inputs. Budget
+    and filter inputs prefill from ``current`` when present so reopening reflects
+    the stored values.
     """
     modal = hikari.impl.InteractionModalBuilder(
-        title="Channel Token Budgets",
+        title="Channel Budgets & Filter",
         custom_id=(
-            f"{MODAL_CUSTOM_ID_PREFIX}:{guild_id}:{channel_id}:{model_key}"
-            f":{reasoning_level or ''}"
+            f"{MODAL_CUSTOM_ID_PREFIX}:"
+            f"{encode_panel_state(state.model_key, state.reasoning_level, state.auto_respond, state.fallback_model_key)}"
         ),
     )
     # Discord rejects a text-input value outside 1-4000 chars, so an empty
@@ -188,6 +344,11 @@ def create_budgets_modal(
     hourly_prefill = (
         str(current.hourly_token_budget)
         if current is not None
+        else hikari.UNDEFINED
+    )
+    filter_prefill = (
+        current.response_filter
+        if current is not None and current.response_filter
         else hikari.UNDEFINED
     )
     modal.add_component(
@@ -213,6 +374,23 @@ def create_budgets_modal(
                 value=hourly_prefill,
                 required=False,
                 max_length=10,
+            )
+        )
+    )
+    modal.add_component(
+        hikari.impl.ModalActionRowBuilder().add_component(
+            hikari.impl.TextInputBuilder(
+                custom_id="response_filter",
+                label="Response filter (optional)",
+                style=hikari.TextInputStyle.PARAGRAPH,
+                placeholder=(
+                    "When set, the bot only answers messages matching these "
+                    'instructions — e.g. "Only respond to questions about '
+                    'programming".'
+                ),
+                value=filter_prefill,
+                required=False,
+                max_length=4000,
             )
         )
     )

--- a/smarter_dev/web/api_native/model_overrides.py
+++ b/smarter_dev/web/api_native/model_overrides.py
@@ -92,6 +92,9 @@ class ChannelModelOverrideController(Controller):
             reasoning_level=data.reasoning_level,
             daily_token_budget=data.daily_token_budget,
             hourly_token_budget=data.hourly_token_budget,
+            auto_respond=data.auto_respond,
+            fallback_model_key=data.fallback_model_key,
+            response_filter=data.response_filter,
         )
         # Serialize before commit to avoid session-detachment issues with the
         # Skrift-injected session (mirrors the legacy router's ordering).

--- a/smarter_dev/web/api_native/schemas.py
+++ b/smarter_dev/web/api_native/schemas.py
@@ -761,10 +761,32 @@ class ChannelModelOverrideWrite(BaseAPIModel):
     hourly_token_budget: int = Field(
         0, ge=0, le=2_147_483_647, description="Hourly token cap (0 = unlimited)"
     )
+    auto_respond: bool = Field(
+        False,
+        description="When true the bot replies to any message, not just @mentions",
+    )
+    fallback_model_key: str | None = Field(
+        None,
+        description="Catalog key used when the primary model is unavailable; null for none",
+    )
+    response_filter: str | None = Field(
+        None,
+        max_length=4000,
+        description="Free-text instructions for which messages deserve a response",
+    )
 
     @field_validator("model_key")
     @classmethod
     def _model_key_in_catalog(cls, value: str) -> str:
+        if not is_valid_model_key(value):
+            raise ValueError(f"unknown model key: {value!r}")
+        return value
+
+    @field_validator("fallback_model_key")
+    @classmethod
+    def _fallback_model_key_in_catalog(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
         if not is_valid_model_key(value):
             raise ValueError(f"unknown model key: {value!r}")
         return value
@@ -792,6 +814,15 @@ class ChannelModelOverrideRead(BaseAPIModel):
     )
     daily_token_budget: int = Field(description="Daily token cap (0 = unlimited)")
     hourly_token_budget: int = Field(description="Hourly token cap (0 = unlimited)")
+    auto_respond: bool = Field(
+        description="When true the bot replies to any message, not just @mentions"
+    )
+    fallback_model_key: str | None = Field(
+        None, description="Fallback catalog key, or null for none"
+    )
+    response_filter: str | None = Field(
+        None, description="Instructions for which messages deserve a response, or null"
+    )
     created_at: datetime = Field(description="Override creation timestamp")
     updated_at: datetime = Field(description="Last update timestamp")
 

--- a/smarter_dev/web/crud.py
+++ b/smarter_dev/web/crud.py
@@ -5487,7 +5487,7 @@ class ModerationActionOperations:
 # Channel model override operations
 # ============================================================================
 #
-# One row per channel (unique ``channel_id``): the admin ``/setmodel`` command's
+# One row per channel (unique ``channel_id``): the admin ``/chat-bot-settings`` command's
 # PUT is an upsert so reopening the modal edits the existing row. These are
 # plain functions (not an Operations class) taking an ``AsyncSession``; the
 # caller owns the transaction and commits.
@@ -5514,6 +5514,9 @@ async def upsert_channel_model_override(
     daily_token_budget: int,
     hourly_token_budget: int,
     reasoning_level: str | None = None,
+    auto_respond: bool = False,
+    fallback_model_key: str | None = None,
+    response_filter: str | None = None,
 ) -> ChannelModelOverride:
     """Insert or update the single override row for ``channel_id``.
 
@@ -5529,6 +5532,9 @@ async def upsert_channel_model_override(
             reasoning_level=reasoning_level,
             daily_token_budget=daily_token_budget,
             hourly_token_budget=hourly_token_budget,
+            auto_respond=auto_respond,
+            fallback_model_key=fallback_model_key,
+            response_filter=response_filter,
         )
         session.add(record)
     else:
@@ -5537,6 +5543,9 @@ async def upsert_channel_model_override(
         record.reasoning_level = reasoning_level
         record.daily_token_budget = daily_token_budget
         record.hourly_token_budget = hourly_token_budget
+        record.auto_respond = auto_respond
+        record.fallback_model_key = fallback_model_key
+        record.response_filter = response_filter
     await session.flush()
     # Load server-generated timestamps (created_at/updated_at) now, so callers can
     # serialize the row without triggering a lazy load outside the async context.

--- a/smarter_dev/web/models.py
+++ b/smarter_dev/web/models.py
@@ -4518,3 +4518,13 @@ class ChannelModelOverride(Base):
     hourly_token_budget: Mapped[int] = mapped_column(
         Integer, nullable=False, default=0, server_default="0"
     )
+    # When true the chat bot activates on ANY channel message, not just @mentions.
+    auto_respond: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default="false"
+    )
+    # A stable catalog ``key`` to fall back to when the primary model is
+    # unavailable, or NULL to use no fallback.
+    fallback_model_key: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    # Free-text instructions describing which messages deserve a response, or NULL
+    # to respond without a content filter.
+    response_filter: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/tests/bot/agents/test_message_gate.py
+++ b/tests/bot/agents/test_message_gate.py
@@ -1,0 +1,115 @@
+"""Tests for the pre-turn message gate (GPT-5.4 Nano relevance filter).
+
+No live API calls: the mapping/order/hallucination cases drive the real agent
+through pydantic_ai's ``TestModel``/``FunctionModel`` via ``agent.override``,
+and the short-circuit cases patch the agent getter to prove the model is never
+built or called.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydantic_ai.messages import ModelResponse, ToolCallPart
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+from pydantic_ai.models.test import TestModel
+
+from smarter_dev.bot.agents import message_gate
+from smarter_dev.bot.agents.message_gate import GateMessage, filter_messages
+
+
+@pytest.fixture(autouse=True)
+def _offline_gate_agent(monkeypatch):
+    # The OpenAI SDK refuses to construct without a key; supply a dummy one so
+    # the agent builds. Every test that reaches the model swaps it out via
+    # ``agent.override``, so the key is never used for a real request. Reset the
+    # module-level cache so each test builds a fresh, un-overridden agent.
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    message_gate._gate_agent = None
+    yield
+    message_gate._gate_agent = None
+
+
+def _candidates() -> list[GateMessage]:
+    return [
+        GateMessage(message_id="1", author_display="alice", content="how do decorators work?"),
+        GateMessage(message_id="2", author_display="bob", content="what's for lunch?"),
+        GateMessage(message_id="3", author_display="cara", content="explain async/await"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_returns_only_allowed_candidate_ids():
+    agent = message_gate.get_message_gate_agent()
+    with agent.override(model=TestModel(custom_output_args={"allowed_message_ids": ["1", "3"]})):
+        result = await filter_messages("only python questions", _candidates(), [])
+    assert result == ["1", "3"]
+
+
+@pytest.mark.asyncio
+async def test_preserves_candidate_order_regardless_of_model_order():
+    agent = message_gate.get_message_gate_agent()
+    # Model answers out of candidate order; result must follow candidate order.
+    with agent.override(model=TestModel(custom_output_args={"allowed_message_ids": ["3", "1"]})):
+        result = await filter_messages("only python questions", _candidates(), [])
+    assert result == ["1", "3"]
+
+
+@pytest.mark.asyncio
+async def test_intersects_hallucinated_ids_out():
+    agent = message_gate.get_message_gate_agent()
+    with agent.override(
+        model=TestModel(custom_output_args={"allowed_message_ids": ["1", "9999", "2"]})
+    ):
+        result = await filter_messages("anything goes", _candidates(), [])
+    # "9999" is not a real candidate id and is dropped.
+    assert result == ["1", "2"]
+
+
+@pytest.mark.asyncio
+async def test_fail_open_returns_all_ids_on_model_error():
+    def _boom(messages, info: AgentInfo):
+        raise RuntimeError("nano outage")
+
+    agent = message_gate.get_message_gate_agent()
+    with agent.override(model=FunctionModel(_boom)):
+        result = await filter_messages("only python questions", _candidates(), [])
+    # A model failure must never silence the bot: every candidate is allowed.
+    assert result == ["1", "2", "3"]
+
+
+@pytest.mark.asyncio
+async def test_empty_candidates_short_circuits_without_model():
+    with patch.object(message_gate, "get_message_gate_agent") as getter:
+        result = await filter_messages("only python questions", [], _candidates())
+    assert result == []
+    getter.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_blank_filter_allows_all_without_model():
+    with patch.object(message_gate, "get_message_gate_agent") as getter:
+        result = await filter_messages("   ", _candidates(), [])
+    assert result == ["1", "2", "3"]
+    getter.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_grounding_is_rendered_but_never_returned():
+    grounding = [GateMessage(message_id="g1", author_display="dan", content="earlier chatter")]
+    captured: dict[str, object] = {}
+
+    def _echo(messages, info: AgentInfo):
+        captured["prompt"] = messages[-1].parts[-1].content
+        return ModelResponse(
+            parts=[ToolCallPart(tool_name="final_result", args={"allowed_message_ids": ["1", "g1"]})]
+        )
+
+    agent = message_gate.get_message_gate_agent()
+    with agent.override(model=FunctionModel(_echo)):
+        result = await filter_messages("only python questions", _candidates(), grounding)
+
+    # The grounding id the model tried to return is intersected out.
+    assert result == ["1"]
+    assert "earlier chatter" in captured["prompt"]

--- a/tests/bot/services/test_channel_token_budget.py
+++ b/tests/bot/services/test_channel_token_budget.py
@@ -9,6 +9,7 @@ import pytest
 from smarter_dev.bot.services.channel_token_budget import (
     DAY_WINDOW_SECONDS,
     HOUR_WINDOW_SECONDS,
+    add_fallback_usage,
     add_usage,
     budget_key,
     current_window_usage,
@@ -181,6 +182,37 @@ async def test_current_window_usage_is_per_channel():
     redis = _FakeRedis()
     await add_usage(redis, "chan-a", 100)
     assert await current_window_usage(redis, "chan-b") == (0, 0)
+
+
+@pytest.mark.asyncio
+async def test_fallback_usage_does_not_count_toward_enforced_budget():
+    """Free-fallback spend meters into its own windows, so it never trips the
+    enforced budget — even a huge fallback spend leaves the channel under cap."""
+    redis = _FakeRedis()
+    await add_fallback_usage(redis, "chan", 10_000_000)
+    # Enforced windows are untouched, so the daily/hourly caps are not met.
+    assert await over_budget_reset_epoch(redis, "chan", 500, 500) is None
+    # It lands in the parallel fallback windows, never the enforced ones.
+    assert not any(":hour:" in k or ":day:" in k for k in redis.store)
+    assert [k for k in redis.store if ":hour-fallback:" in k]
+    assert [k for k in redis.store if ":day-fallback:" in k]
+
+
+@pytest.mark.asyncio
+async def test_current_window_usage_sums_enforced_and_fallback_spend():
+    """/bot-usage still reflects every token: enforced plus free-fallback."""
+    redis = _FakeRedis()
+    await add_usage(redis, "chan", 100)
+    await add_fallback_usage(redis, "chan", 40)
+    assert await current_window_usage(redis, "chan") == (140, 140)
+
+
+@pytest.mark.asyncio
+async def test_fallback_usage_zero_or_negative_is_noop():
+    redis = _FakeRedis()
+    await add_fallback_usage(redis, "chan", 0)
+    await add_fallback_usage(redis, "chan", -5)
+    assert redis.store == {}
 
 
 def test_next_window_reset_epoch_is_the_next_wall_boundary():

--- a/tests/bot/services/test_chat_engine_override.py
+++ b/tests/bot/services/test_chat_engine_override.py
@@ -17,6 +17,7 @@ import pytest
 from smarter_dev.bot.agents.chat_models import (
     Author,
     ChannelInfo,
+    FollowupAgentInput,
     InitialAgentInput,
     Me,
     Message,
@@ -25,6 +26,7 @@ from smarter_dev.bot.agents.chat_models import (
     TurnDecision,
 )
 from smarter_dev.bot.services.chat_engine import ChannelEngine
+from smarter_dev.bot.services.chat_engine import _QueuedMessage
 
 
 def _initial_input() -> InitialAgentInput:
@@ -76,12 +78,24 @@ def _result(output, *, input_tokens=0, output_tokens=0):
     )
 
 
-def _override(model_key: str, *, daily=0, hourly=0, reasoning_level=None):
+def _override(
+    model_key: str,
+    *,
+    daily=0,
+    hourly=0,
+    reasoning_level=None,
+    auto_respond=False,
+    fallback_model_key=None,
+    response_filter=None,
+):
     return SimpleNamespace(
         model_key=model_key,
         daily_token_budget=daily,
         hourly_token_budget=hourly,
         reasoning_level=reasoning_level,
+        auto_respond=auto_respond,
+        fallback_model_key=fallback_model_key,
+        response_filter=response_filter,
     )
 
 
@@ -102,6 +116,9 @@ def fake_memory():
 def fake_redis():
     r = MagicMock()
     r.set = AsyncMock(return_value=True)
+    # Fallback flag/marker reads default to "absent" so normal budget flow runs.
+    r.exists = AsyncMock(return_value=0)
+    r.delete = AsyncMock(return_value=0)
     # The engine also records per-user message-limit charges through a
     # pipeline on this same Redis — make that path awaitable and inert.
     pipe = MagicMock()
@@ -397,3 +414,425 @@ async def test_unknown_model_key_falls_back_to_default(fake_memory, fake_redis):
 
     get_agent_mock.assert_called_once_with(None, None)
     agent_mock.run.assert_awaited_once()
+
+
+# --------------------------------------------------------------------------- #
+# Feature 1 — response-filter gate
+# --------------------------------------------------------------------------- #
+
+
+def _fake_message(message_id, *, author_id=200, username="alice", content="hello"):
+    """A minimal hikari-message stand-in for gate/queue plumbing."""
+    return SimpleNamespace(
+        id=message_id,
+        author=SimpleNamespace(id=author_id, username=username, is_bot=False),
+        content=content,
+        created_at=datetime.now(UTC),
+    )
+
+
+@pytest.mark.asyncio
+async def test_response_filter_drops_activation_skips_turn(fake_memory, fake_redis):
+    """The gate dropping the activation skips the turn entirely: no model call,
+    no budget spend, no no-response strike, engagement retained, engine active."""
+    agent_mock = MagicMock()
+    agent_mock.run = AsyncMock(return_value=_result(_send()))
+    engine, _ = _make_engine(
+        _override("gpt-5-4", response_filter="only python questions"), fake_redis
+    )
+    start_engagement = AsyncMock(return_value="engagement-1")
+
+    with _patches(agent_mock=agent_mock, fake_memory=fake_memory)[0], _patches(
+        agent_mock=agent_mock, fake_memory=fake_memory
+    )[1], _patches(agent_mock=agent_mock, fake_memory=fake_memory)[2], patch(
+        "smarter_dev.bot.services.chat_engine.over_budget_reset_epoch",
+        new=AsyncMock(return_value=None),
+    ) as over_budget, patch(
+        "smarter_dev.bot.services.chat_engine.add_usage", new=AsyncMock()
+    ) as add_usage_mock, patch(
+        "smarter_dev.bot.services.chat_engine.filter_messages",
+        new=AsyncMock(return_value=[]),
+    ), patch(
+        "smarter_dev.bot.services.chat_engine.start_engagement", new=start_engagement
+    ):
+        consumed = await engine._run_once(first_activation=True)
+
+    # first_activation retained (mirrors the over-budget skip contract).
+    assert consumed is False
+    agent_mock.run.assert_not_called()
+    add_usage_mock.assert_not_called()
+    over_budget.assert_not_called()  # gate short-circuits before the budget check
+    start_engagement.assert_not_awaited()
+    assert engine.active is True
+    assert engine.consecutive_no_response == 0
+
+
+@pytest.mark.asyncio
+async def test_response_filter_first_activation_starts_from_later_ontopic_message(
+    fake_memory, fake_redis
+):
+    """Regression: when the activating message is off-topic but a message queued
+    afterwards is on-topic, the first-activation gate must judge the queued
+    messages too and start the engagement from the earliest survivor — not
+    freeze forever on the dropped activation trigger."""
+    agent_mock = MagicMock()
+    agent_mock.run = AsyncMock(return_value=_result(_send()))
+    engine, _ = _make_engine(
+        _override("gpt-5-4", daily=1000, response_filter="only python questions"),
+        fake_redis,
+    )
+    off_topic_trigger = _fake_message(700, content="what's for lunch")
+    on_topic_followup = _fake_message(701, content="how do I use asyncio")
+    engine.activation_message = off_topic_trigger
+    engine.queue = [
+        _QueuedMessage(message=on_topic_followup, enqueued_at=datetime.now(UTC)),
+    ]
+
+    with _patches(agent_mock=agent_mock, fake_memory=fake_memory)[0], _patches(
+        agent_mock=agent_mock, fake_memory=fake_memory
+    )[1], _patches(agent_mock=agent_mock, fake_memory=fake_memory)[2], patch(
+        "smarter_dev.bot.services.chat_engine.over_budget_reset_epoch",
+        new=AsyncMock(return_value=None),
+    ), patch(
+        "smarter_dev.bot.services.chat_engine.add_usage", new=AsyncMock()
+    ), patch(
+        "smarter_dev.bot.services.chat_engine.filter_messages",
+        new=AsyncMock(return_value=["701"]),  # only the on-topic follow-up survives
+    ):
+        consumed = await engine._run_once(first_activation=True)
+
+    # The engagement starts: the model ran and the survivor became the trigger.
+    assert consumed is True
+    agent_mock.run.assert_awaited_once()
+    assert engine.activation_message is on_topic_followup
+
+
+@pytest.mark.asyncio
+async def test_response_filter_partial_drop_only_survivors_reach_agent(
+    fake_memory, fake_redis
+):
+    """On a follow-up, only the messages the gate allows are handed to the
+    agent input; the dropped ones never reach the model."""
+    agent_mock = MagicMock()
+    agent_mock.run = AsyncMock(return_value=_result(_send()))
+    engine, _ = _make_engine(
+        _override("gpt-5-4", daily=1000, response_filter="only python questions"),
+        fake_redis,
+    )
+    drop_msg = _fake_message(500, content="what's for lunch")
+    keep_msg = _fake_message(501, content="how do I use asyncio")
+    engine.queue = [
+        _QueuedMessage(message=drop_msg, enqueued_at=datetime.now(UTC)),
+        _QueuedMessage(message=keep_msg, enqueued_at=datetime.now(UTC)),
+    ]
+
+    build_followup = AsyncMock(
+        return_value=FollowupAgentInput(
+            me=Me(user_id="999", username="bot"),
+            new_messages=[
+                Message(message_id="501", author_id="200", body="how do I use asyncio")
+            ],
+            authors=[Author(user_id="200", username="alice")],
+            channel=ChannelInfo(channel_id="1", name="general"),
+            now_utc=datetime.now(UTC),
+        )
+    )
+
+    with _patches(agent_mock=agent_mock, fake_memory=fake_memory)[0], _patches(
+        agent_mock=agent_mock, fake_memory=fake_memory
+    )[1], patch(
+        "smarter_dev.bot.services.chat_engine.build_followup_input",
+        new=build_followup,
+    ), patch(
+        "smarter_dev.bot.services.chat_engine.over_budget_reset_epoch",
+        new=AsyncMock(return_value=None),
+    ), patch(
+        "smarter_dev.bot.services.chat_engine.add_usage", new=AsyncMock()
+    ), patch(
+        "smarter_dev.bot.services.chat_engine.filter_messages",
+        new=AsyncMock(return_value=["501"]),
+    ):
+        await engine._run_once(first_activation=False)
+
+    agent_mock.run.assert_awaited_once()
+    queued = build_followup.await_args.kwargs["queued"]
+    assert [m.id for m in queued] == [501]
+
+
+@pytest.mark.asyncio
+async def test_response_filter_gate_error_runs_turn_unfiltered(
+    fake_memory, fake_redis
+):
+    """An unexpected gate error must not silence the bot — the turn runs with
+    every candidate (fail-open at the engine's call site)."""
+    agent_mock = MagicMock()
+    agent_mock.run = AsyncMock(return_value=_result(_send()))
+    engine, _ = _make_engine(
+        _override("gpt-5-4", daily=1000, response_filter="only python questions"),
+        fake_redis,
+    )
+
+    with _patches(agent_mock=agent_mock, fake_memory=fake_memory)[0], _patches(
+        agent_mock=agent_mock, fake_memory=fake_memory
+    )[1], _patches(agent_mock=agent_mock, fake_memory=fake_memory)[2], patch(
+        "smarter_dev.bot.services.chat_engine.over_budget_reset_epoch",
+        new=AsyncMock(return_value=None),
+    ), patch(
+        "smarter_dev.bot.services.chat_engine.add_usage", new=AsyncMock()
+    ), patch(
+        "smarter_dev.bot.services.chat_engine.filter_messages",
+        new=AsyncMock(side_effect=RuntimeError("gate blew up")),
+    ):
+        consumed = await engine._run_once(first_activation=True)
+
+    assert consumed is True
+    agent_mock.run.assert_awaited_once()
+
+
+# --------------------------------------------------------------------------- #
+# Feature 2 — fallback model on budget exhaustion
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_fallback_flag_skips_budget_and_uses_fallback_model(
+    fake_memory, fake_redis
+):
+    """With the fallback flag set, the budget check is skipped, the fallback
+    model runs, and its tokens are metered into the display-only fallback
+    windows (visible in /bot-usage) — never the enforced windows, so the free
+    opt-in cannot re-trip the primary's cap when the fallback closes."""
+    agent_mock = MagicMock()
+    agent_mock.run = AsyncMock(
+        return_value=_result(_send(), input_tokens=10, output_tokens=5)
+    )
+    engine, _ = _make_engine(
+        _override("kimi-k2-6", hourly=100, fallback_model_key="gpt-5-4"), fake_redis
+    )
+    fake_redis.exists = AsyncMock(return_value=1)  # fallback flag present
+
+    get_agent = patch(
+        "smarter_dev.bot.services.chat_engine.get_chat_agent",
+        return_value=agent_mock,
+    )
+    over_budget = AsyncMock(return_value=1_800_000_000)  # would block if consulted
+    with get_agent as get_agent_mock, _patches(
+        agent_mock=agent_mock, fake_memory=fake_memory
+    )[1], _patches(agent_mock=agent_mock, fake_memory=fake_memory)[2], patch(
+        "smarter_dev.bot.services.chat_engine.over_budget_reset_epoch",
+        new=over_budget,
+    ), patch(
+        "smarter_dev.bot.services.chat_engine.add_usage", new=AsyncMock()
+    ) as add_usage_mock, patch(
+        "smarter_dev.bot.services.chat_engine.add_fallback_usage", new=AsyncMock()
+    ) as add_fallback_usage_mock:
+        await engine._run_once(first_activation=True)
+
+    # The fallback model's wire id, reasoning left to its own default.
+    get_agent_mock.assert_called_once_with("gpt-5.4", None)
+    over_budget.assert_not_called()  # budget enforcement skipped entirely
+    agent_mock.run.assert_awaited_once()
+    # Free-fallback spend goes to the display-only windows, not the enforced ones.
+    add_fallback_usage_mock.assert_awaited_once_with(fake_redis, "42", 15)
+    add_usage_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_fallback_persisted_turn_records_fallback_model(fake_memory, fake_redis):
+    """The persisted turn is priced against the fallback model actually used."""
+    agent_mock = MagicMock()
+    agent_mock.run = AsyncMock(
+        return_value=_result(_send(), input_tokens=10, output_tokens=5)
+    )
+    engine, _ = _make_engine(
+        _override("kimi-k2-6", hourly=100, fallback_model_key="gpt-5-4"), fake_redis
+    )
+    fake_redis.exists = AsyncMock(return_value=1)
+
+    start_engagement = AsyncMock(return_value="engagement-1")
+    persist_turn = AsyncMock()
+    with _patches(agent_mock=agent_mock, fake_memory=fake_memory)[0], _patches(
+        agent_mock=agent_mock, fake_memory=fake_memory
+    )[1], _patches(agent_mock=agent_mock, fake_memory=fake_memory)[2], patch(
+        "smarter_dev.bot.services.chat_engine.over_budget_reset_epoch",
+        new=AsyncMock(return_value=1_800_000_000),
+    ), patch(
+        "smarter_dev.bot.services.chat_engine.add_usage", new=AsyncMock()
+    ), patch(
+        "smarter_dev.bot.services.chat_engine.start_engagement", new=start_engagement
+    ), patch(
+        "smarter_dev.bot.services.chat_engine.persist_turn", new=persist_turn
+    ):
+        await engine._run_once(first_activation=True)
+
+    persist_turn.assert_awaited_once()
+    assert persist_turn.await_args.kwargs["chat_model_name"] == "gpt-5.4"
+
+
+@pytest.mark.asyncio
+async def test_fallback_stale_key_falls_back_to_primary_model(
+    fake_memory, fake_redis
+):
+    """A stale/unknown fallback key while the window is active degrades to the
+    primary override model rather than crashing the turn."""
+    agent_mock = MagicMock()
+    agent_mock.run = AsyncMock(return_value=_result(_send()))
+    engine, _ = _make_engine(
+        _override(
+            "kimi-k2-6", hourly=100, fallback_model_key="this-model-was-removed"
+        ),
+        fake_redis,
+    )
+    fake_redis.exists = AsyncMock(return_value=1)
+
+    get_agent = patch(
+        "smarter_dev.bot.services.chat_engine.get_chat_agent",
+        return_value=agent_mock,
+    )
+    with get_agent as get_agent_mock, _patches(
+        agent_mock=agent_mock, fake_memory=fake_memory
+    )[1], _patches(agent_mock=agent_mock, fake_memory=fake_memory)[2], patch(
+        "smarter_dev.bot.services.chat_engine.over_budget_reset_epoch",
+        new=AsyncMock(return_value=None),
+    ), patch(
+        "smarter_dev.bot.services.chat_engine.add_usage", new=AsyncMock()
+    ):
+        await engine._run_once(first_activation=True)
+
+    # Primary override model ("kimi-k2-6" -> wire id "kimi-k2.6"), not the stale
+    # fallback key.
+    get_agent_mock.assert_called_once_with("kimi-k2.6", None)
+    agent_mock.run.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_ended_marker_notifies_primary_restored_then_runs_primary(
+    fake_memory, fake_redis
+):
+    """The fallback window having ended (flag gone, marker present) posts a
+    "primary is back" notice, clears the marker, and runs the primary model."""
+    agent_mock = MagicMock()
+    agent_mock.run = AsyncMock(return_value=_result(_send()))
+    engine, _ = _make_engine(
+        _override("gpt-5-4", daily=1000, fallback_model_key="kimi-k2-6"), fake_redis
+    )
+    fake_redis.exists = AsyncMock(return_value=0)  # flag expired
+    fake_redis.delete = AsyncMock(return_value=1)  # marker still present
+
+    get_agent = patch(
+        "smarter_dev.bot.services.chat_engine.get_chat_agent",
+        return_value=agent_mock,
+    )
+    with get_agent as get_agent_mock, _patches(
+        agent_mock=agent_mock, fake_memory=fake_memory
+    )[1], _patches(agent_mock=agent_mock, fake_memory=fake_memory)[2], patch(
+        "smarter_dev.bot.services.chat_engine.over_budget_reset_epoch",
+        new=AsyncMock(return_value=None),
+    ), patch(
+        "smarter_dev.bot.services.chat_engine.add_usage", new=AsyncMock()
+    ):
+        await engine._run_once(first_activation=True)
+
+    fake_redis.delete.assert_awaited_once()  # marker cleared
+    # The primary model ran (its wire id), not the fallback.
+    get_agent_mock.assert_called_once_with("gpt-5.4", None)
+    # A "primary is back" notice was posted, naming the primary model.
+    notices = [
+        call.kwargs.get("content", "")
+        for call in engine.bot.rest.create_message.await_args_list
+    ]
+    assert any("answering again" in text and "GPT-5.4" in text for text in notices)
+
+
+@pytest.mark.asyncio
+async def test_ended_marker_while_over_budget_does_not_announce_restored(
+    fake_memory, fake_redis
+):
+    """Regression: with the fallback flag gone and the ended-marker present but
+    the channel still over budget, the turn must NOT announce "primary is back"
+    (it would immediately be contradicted by the budget-exhausted notice). The
+    marker survives so the genuine restoration is announced on a later turn."""
+    agent_mock = MagicMock()
+    agent_mock.run = AsyncMock(return_value=_result(_send()))
+    engine, _ = _make_engine(
+        _override("gpt-5-4", daily=1000, fallback_model_key="kimi-k2-6"), fake_redis
+    )
+    fake_redis.exists = AsyncMock(return_value=0)  # fallback flag expired
+    fake_redis.delete = AsyncMock(return_value=1)  # marker would clear if touched
+
+    with _patches(agent_mock=agent_mock, fake_memory=fake_memory)[0], _patches(
+        agent_mock=agent_mock, fake_memory=fake_memory
+    )[1], _patches(agent_mock=agent_mock, fake_memory=fake_memory)[2], patch(
+        "smarter_dev.bot.services.chat_engine.over_budget_reset_epoch",
+        new=AsyncMock(return_value=1_800_000_000),  # still over budget
+    ), patch(
+        "smarter_dev.bot.services.chat_engine.add_usage", new=AsyncMock()
+    ):
+        consumed = await engine._run_once(first_activation=True)
+
+    assert consumed is False
+    agent_mock.run.assert_not_called()  # turn skipped for budget
+    # The ended-marker was never touched (the restoration notice is deferred).
+    fake_redis.delete.assert_not_awaited()
+    notices = [
+        call.kwargs.get("content", "")
+        for call in engine.bot.rest.create_message.await_args_list
+    ]
+    # No "primary is back" notice; only the budget-exhausted one.
+    assert not any("answering again" in text for text in notices)
+    assert any("token budget is used up" in text for text in notices)
+
+
+@pytest.mark.asyncio
+async def test_budget_exhausted_notice_carries_fallback_button(
+    fake_memory, fake_redis
+):
+    """The over-budget notice carries the fallback-offer button when a fallback
+    model is configured; the button's custom_id carries the reset epoch."""
+    agent_mock = MagicMock()
+    agent_mock.run = AsyncMock(return_value=_result(_send()))
+    engine, _ = _make_engine(
+        _override("gpt-5-4", hourly=100, fallback_model_key="kimi-k2-6"), fake_redis
+    )
+
+    with _patches(agent_mock=agent_mock, fake_memory=fake_memory)[0], _patches(
+        agent_mock=agent_mock, fake_memory=fake_memory
+    )[1], _patches(agent_mock=agent_mock, fake_memory=fake_memory)[2], patch(
+        "smarter_dev.bot.services.chat_engine.over_budget_reset_epoch",
+        new=AsyncMock(return_value=1_800_000_000),
+    ), patch(
+        "smarter_dev.bot.services.chat_engine.add_usage", new=AsyncMock()
+    ):
+        consumed = await engine._run_once(first_activation=True)
+
+    assert consumed is False
+    engine.bot.rest.create_message.assert_awaited_once()
+    kwargs = engine.bot.rest.create_message.await_args.kwargs
+    row = kwargs["components"][0]
+    button = row.components[0]
+    assert button.custom_id == "model_budget_fallback:1800000000"
+
+
+@pytest.mark.asyncio
+async def test_budget_exhausted_notice_has_no_button_without_fallback(
+    fake_memory, fake_redis
+):
+    """Without a configured fallback, the over-budget notice posts plain (no
+    components), unchanged from the pre-feature behaviour."""
+    agent_mock = MagicMock()
+    agent_mock.run = AsyncMock(return_value=_result(_send()))
+    engine, _ = _make_engine(_override("gpt-5-4", hourly=100), fake_redis)
+
+    with _patches(agent_mock=agent_mock, fake_memory=fake_memory)[0], _patches(
+        agent_mock=agent_mock, fake_memory=fake_memory
+    )[1], _patches(agent_mock=agent_mock, fake_memory=fake_memory)[2], patch(
+        "smarter_dev.bot.services.chat_engine.over_budget_reset_epoch",
+        new=AsyncMock(return_value=1_800_000_000),
+    ), patch(
+        "smarter_dev.bot.services.chat_engine.add_usage", new=AsyncMock()
+    ):
+        await engine._run_once(first_activation=True)
+
+    engine.bot.rest.create_message.assert_awaited_once()
+    kwargs = engine.bot.rest.create_message.await_args.kwargs
+    assert "components" not in kwargs

--- a/tests/bot/services/test_model_override_service.py
+++ b/tests/bot/services/test_model_override_service.py
@@ -14,15 +14,19 @@ CHANNEL = "222"
 PATH = f"/guilds/{GUILD}/channels/{CHANNEL}/model-override"
 
 
-def _payload(model_key: str = "kimi-k2", daily: int = 0, hourly: int = 0) -> dict:
+def _payload(model_key: str = "kimi-k2", daily: int = 0, hourly: int = 0, **extra) -> dict:
     return {
         "guild_id": GUILD,
         "channel_id": CHANNEL,
         "model_key": model_key,
         "daily_token_budget": daily,
         "hourly_token_budget": hourly,
+        "auto_respond": False,
+        "fallback_model_key": None,
+        "response_filter": None,
         "created_at": "2026-07-14T00:00:00+00:00",
         "updated_at": "2026-07-14T00:00:00+00:00",
+        **extra,
     }
 
 
@@ -92,10 +96,83 @@ async def test_set_override_puts_and_returns_dto(service, mock_api_client):
             "reasoning_level": "high",
             "daily_token_budget": 100,
             "hourly_token_budget": 10,
+            "auto_respond": False,
+            "fallback_model_key": None,
+            "response_filter": None,
         },
     )
     assert result.model_key == "gpt-5-4"
     assert result.daily_token_budget == 100
+
+
+async def test_get_override_parses_new_settings(service, mock_api_client):
+    mock_api_client.get.return_value = create_mock_response(
+        200,
+        _payload(
+            auto_respond=True,
+            fallback_model_key="glm-4-6",
+            response_filter="Only coding questions.",
+        ),
+    )
+
+    result = await service.get_override(GUILD, CHANNEL)
+
+    assert result.auto_respond is True
+    assert result.fallback_model_key == "glm-4-6"
+    assert result.response_filter == "Only coding questions."
+
+
+async def test_get_override_defaults_new_settings_when_absent(service, mock_api_client):
+    # An older API response that omits the new keys must degrade to the defaults.
+    legacy_payload = _payload()
+    del legacy_payload["auto_respond"]
+    del legacy_payload["fallback_model_key"]
+    del legacy_payload["response_filter"]
+    mock_api_client.get.return_value = create_mock_response(200, legacy_payload)
+
+    result = await service.get_override(GUILD, CHANNEL)
+
+    assert result.auto_respond is False
+    assert result.fallback_model_key is None
+    assert result.response_filter is None
+
+
+async def test_set_override_sends_new_settings(service, mock_api_client):
+    mock_api_client.put.return_value = create_mock_response(
+        200,
+        _payload(
+            auto_respond=True,
+            fallback_model_key="glm-4-6",
+            response_filter="Only coding questions.",
+        ),
+    )
+
+    result = await service.set_override(
+        GUILD,
+        CHANNEL,
+        "gpt-5-4",
+        0,
+        0,
+        auto_respond=True,
+        fallback_model_key="glm-4-6",
+        response_filter="Only coding questions.",
+    )
+
+    mock_api_client.put.assert_awaited_once_with(
+        PATH,
+        json_data={
+            "model_key": "gpt-5-4",
+            "reasoning_level": None,
+            "daily_token_budget": 0,
+            "hourly_token_budget": 0,
+            "auto_respond": True,
+            "fallback_model_key": "glm-4-6",
+            "response_filter": "Only coding questions.",
+        },
+    )
+    assert result.auto_respond is True
+    assert result.fallback_model_key == "glm-4-6"
+    assert result.response_filter == "Only coding questions."
 
 
 async def test_set_override_invalidates_cache(service, mock_api_client):

--- a/tests/bot/test_mention_auto_respond.py
+++ b/tests/bot/test_mention_auto_respond.py
@@ -1,0 +1,250 @@
+"""Tests for auto-respond channel activation in the mention plugin.
+
+An admin can flag a channel's model override with ``auto_respond=True``, which
+makes the bot treat a *plain* message (no @mention/reply) exactly like an
+engagement — but only when no engine is already running and only through the
+same stop/cooldown/rate-limit/message-limit gates the mention branch uses.
+"""
+
+from __future__ import annotations
+
+from contextlib import ExitStack
+from datetime import UTC
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from smarter_dev.bot.plugins import mention
+from smarter_dev.bot.services.models import ChannelModelOverride
+
+BOT_USER_ID = 999
+CHANNEL_ID = 42
+GUILD_ID = 7
+
+
+def _override(auto_respond: bool) -> ChannelModelOverride:
+    return ChannelModelOverride(
+        guild_id=str(GUILD_ID),
+        channel_id=str(CHANNEL_ID),
+        model_key="test-model",
+        daily_token_budget=0,
+        hourly_token_budget=0,
+        auto_respond=auto_respond,
+    )
+
+
+def _fake_engine() -> SimpleNamespace:
+    return SimpleNamespace(
+        active=False,
+        trigger_initial=MagicMock(),
+        observe=AsyncMock(),
+        fire_now=MagicMock(),
+        shutdown=AsyncMock(),
+    )
+
+
+class _FakeRegistry:
+    """Minimal stand-in for the process-global chat engine registry."""
+
+    def __init__(self, *, active: bool, engine: SimpleNamespace) -> None:
+        self._active = active
+        self._engine = engine
+        self.ensure_engine = AsyncMock(return_value=engine)
+
+    async def has_active(self, channel_id: int) -> bool:
+        return self._active
+
+    async def get(self, channel_id: int) -> SimpleNamespace | None:
+        return self._engine if self._active else None
+
+
+def _override_service(auto_respond: bool | None) -> SimpleNamespace | None:
+    """A service whose ``get_override`` returns an override, ``None`` or raises.
+
+    ``auto_respond=None`` means "no override configured" (get returns ``None``).
+    """
+    override = None if auto_respond is None else _override(auto_respond)
+    return SimpleNamespace(get_override=AsyncMock(return_value=override))
+
+
+def _bot(override_service: SimpleNamespace | None) -> SimpleNamespace:
+    data: dict = {}
+    if override_service is not None:
+        data["model_override_service"] = override_service
+    rest = MagicMock()
+    rest.create_message = AsyncMock()
+    return SimpleNamespace(
+        get_me=MagicMock(return_value=SimpleNamespace(id=BOT_USER_ID)),
+        d=data,
+        rest=rest,
+    )
+
+
+def _plain_message_event(content: str = "hello there") -> SimpleNamespace:
+    message = SimpleNamespace(
+        id=555,
+        author=SimpleNamespace(id=200, is_bot=False),
+        created_at=datetime.now(UTC),
+        user_mentions_ids=[],
+        referenced_message=None,
+    )
+    return SimpleNamespace(
+        message=message,
+        channel_id=CHANNEL_ID,
+        guild_id=GUILD_ID,
+        content=content,
+    )
+
+
+async def _dispatch(
+    event: SimpleNamespace,
+    bot: SimpleNamespace,
+    registry: _FakeRegistry,
+    *,
+    memory: SimpleNamespace,
+    rate_ok: bool = True,
+    on_cooldown: bool = False,
+    reject_over_limit: bool = False,
+) -> None:
+    """Run ``on_message_create`` with the collaborators fully stubbed out."""
+    with ExitStack() as stack:
+        stack.enter_context(patch.object(mention.plugin, "_app", bot))
+        stack.enter_context(
+            patch.object(mention, "get_chat_engine_registry", return_value=registry)
+        )
+        stack.enter_context(
+            patch.object(mention, "get_chat_memory", return_value=memory)
+        )
+        stack.enter_context(
+            patch.object(
+                mention.rate_limiter,
+                "check_token_limit",
+                return_value=rate_ok,
+            )
+        )
+        stack.enter_context(
+            patch.object(mention, "is_channel_on_cooldown", return_value=on_cooldown)
+        )
+        stack.enter_context(patch.object(mention, "set_channel_cooldown"))
+        stack.enter_context(
+            patch.object(
+                mention,
+                "_reject_when_over_limit",
+                new=AsyncMock(return_value=reject_over_limit),
+            )
+        )
+        await mention.on_message_create(event)
+
+
+def _memory() -> SimpleNamespace:
+    return SimpleNamespace(increment_idle_counter=AsyncMock())
+
+
+@pytest.mark.asyncio
+async def test_auto_respond_channel_activates_on_plain_message():
+    engine = _fake_engine()
+    registry = _FakeRegistry(active=False, engine=engine)
+    memory = _memory()
+    event = _plain_message_event()
+    bot = _bot(_override_service(auto_respond=True))
+
+    await _dispatch(event, bot, registry, memory=memory)
+
+    registry.ensure_engine.assert_awaited_once()
+    engine.trigger_initial.assert_called_once_with(event.message)
+    memory.increment_idle_counter.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_non_auto_channel_does_not_activate():
+    engine = _fake_engine()
+    registry = _FakeRegistry(active=False, engine=engine)
+    memory = _memory()
+    event = _plain_message_event()
+    bot = _bot(_override_service(auto_respond=False))
+
+    await _dispatch(event, bot, registry, memory=memory)
+
+    registry.ensure_engine.assert_not_awaited()
+    engine.trigger_initial.assert_not_called()
+    memory.increment_idle_counter.assert_awaited_once_with(CHANNEL_ID)
+
+
+@pytest.mark.asyncio
+async def test_channel_without_override_does_not_activate():
+    engine = _fake_engine()
+    registry = _FakeRegistry(active=False, engine=engine)
+    memory = _memory()
+    event = _plain_message_event()
+    bot = _bot(_override_service(auto_respond=None))
+
+    await _dispatch(event, bot, registry, memory=memory)
+
+    registry.ensure_engine.assert_not_awaited()
+    memory.increment_idle_counter.assert_awaited_once_with(CHANNEL_ID)
+
+
+@pytest.mark.asyncio
+async def test_stop_phrase_in_auto_channel_does_not_activate():
+    engine = _fake_engine()
+    registry = _FakeRegistry(active=False, engine=engine)
+    memory = _memory()
+    event = _plain_message_event(content="stop")
+    bot = _bot(_override_service(auto_respond=True))
+
+    await _dispatch(event, bot, registry, memory=memory)
+
+    registry.ensure_engine.assert_not_awaited()
+    engine.trigger_initial.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_auto_respond_respects_cooldown():
+    engine = _fake_engine()
+    registry = _FakeRegistry(active=False, engine=engine)
+    memory = _memory()
+    event = _plain_message_event()
+    bot = _bot(_override_service(auto_respond=True))
+
+    await _dispatch(event, bot, registry, memory=memory, on_cooldown=True)
+
+    registry.ensure_engine.assert_not_awaited()
+    engine.trigger_initial.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_auto_respond_drops_over_limit_user():
+    engine = _fake_engine()
+    registry = _FakeRegistry(active=False, engine=engine)
+    memory = _memory()
+    event = _plain_message_event()
+    bot = _bot(_override_service(auto_respond=True))
+
+    await _dispatch(
+        event, bot, registry, memory=memory, reject_over_limit=True
+    )
+
+    registry.ensure_engine.assert_not_awaited()
+    engine.trigger_initial.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_override_lookup_failure_degrades_to_no_activation():
+    engine = _fake_engine()
+    registry = _FakeRegistry(active=False, engine=engine)
+    memory = _memory()
+    event = _plain_message_event()
+    service = SimpleNamespace(
+        get_override=AsyncMock(side_effect=RuntimeError("override backend down"))
+    )
+    bot = _bot(service)
+
+    await _dispatch(event, bot, registry, memory=memory)
+
+    registry.ensure_engine.assert_not_awaited()
+    engine.trigger_initial.assert_not_called()
+    memory.increment_idle_counter.assert_awaited_once_with(CHANNEL_ID)

--- a/tests/bot/test_model_override.py
+++ b/tests/bot/test_model_override.py
@@ -1,11 +1,13 @@
-"""Tests for the admin ``/setmodel`` per-channel model-override command.
+"""Tests for the admin ``/chat-bot-settings`` per-channel model-override command.
 
 Covers the pure view/parse helpers, the admin gate on the slash command, and the
-select + modal-submit interaction handlers (Path B, two-step flow).
+select + button + modal-submit interaction handlers (single settings-panel flow).
 """
 
 from __future__ import annotations
 
+from datetime import UTC
+from datetime import datetime
 from unittest.mock import AsyncMock
 from unittest.mock import Mock
 from unittest.mock import patch
@@ -18,23 +20,36 @@ from smarter_dev.shared.model_catalog import get_model
 from smarter_dev.bot.plugins import model_override
 from smarter_dev.bot.services.exceptions import APIError
 from smarter_dev.bot.services.models import ChannelModelOverride
+from smarter_dev.bot.views.model_override_views import AUTO_TOGGLE_CUSTOM_ID_PREFIX
+from smarter_dev.bot.views.model_override_views import CONTINUE_CUSTOM_ID_PREFIX
+from smarter_dev.bot.views.model_override_views import FALLBACK_SELECT_CUSTOM_ID_PREFIX
+from smarter_dev.bot.views.model_override_views import MAX_TOKEN_BUDGET
+from smarter_dev.bot.views.model_override_views import MODAL_CUSTOM_ID_PREFIX
+from smarter_dev.bot.views.model_override_views import PanelState
+from smarter_dev.bot.views.model_override_views import REASONING_SELECT_CUSTOM_ID_PREFIX
 from smarter_dev.bot.views.model_override_views import SENTINEL_DEFAULT
 from smarter_dev.bot.views.model_override_views import SENTINEL_MODEL_DEFAULT
-from smarter_dev.bot.views.model_override_views import MAX_TOKEN_BUDGET
+from smarter_dev.bot.views.model_override_views import SENTINEL_NO_FALLBACK
+from smarter_dev.bot.views.model_override_views import build_fallback_options
 from smarter_dev.bot.views.model_override_views import build_model_options
 from smarter_dev.bot.views.model_override_views import build_reasoning_options
-from smarter_dev.bot.views.model_override_views import create_budgets_modal
+from smarter_dev.bot.views.model_override_views import create_settings_modal
+from smarter_dev.bot.views.model_override_views import create_settings_panel
+from smarter_dev.bot.views.model_override_views import encode_panel_state
 from smarter_dev.bot.views.model_override_views import parse_budget
+from smarter_dev.bot.views.model_override_views import parse_panel_state
 
 ADMIN = hikari.Permissions.ADMINISTRATOR
 NONE = hikari.Permissions.NONE
 
 PERMS_TARGET = "lightbulb.utils.permissions_for"
 
-# A model with no reasoning knob (goes straight to the budgets modal) and one
-# with a reasoning ladder (gets the intermediate reasoning select).
+# A model with no reasoning knob (its panel omits the reasoning select) and one
+# with a reasoning ladder (its panel shows the reasoning select).
 NO_REASONING_KEY = "kimi-k2-6"
 REASONING_KEY = "glm-5-2"
+# A second reasoning-capable model used as a fallback target in tests.
+FALLBACK_KEY = "deepseek-v4"
 
 
 def _override(
@@ -42,6 +57,9 @@ def _override(
     daily: int = 0,
     hourly: int = 0,
     reasoning_level: str | None = None,
+    auto_respond: bool = False,
+    fallback_model_key: str | None = None,
+    response_filter: str | None = None,
 ):
     return ChannelModelOverride(
         guild_id="G",
@@ -50,11 +68,19 @@ def _override(
         daily_token_budget=daily,
         hourly_token_budget=hourly,
         reasoning_level=reasoning_level,
+        auto_respond=auto_respond,
+        fallback_model_key=fallback_model_key,
+        response_filter=response_filter,
     )
 
 
+def _row_components(rows):
+    """Flatten action-row builders into their child component builders."""
+    return [component for row in rows for component in row.components]
+
+
 # --------------------------------------------------------------------------- #
-# Pure helpers
+# Pure helpers — model options
 # --------------------------------------------------------------------------- #
 
 
@@ -82,6 +108,11 @@ def test_build_model_options_defaults_to_sentinel_without_override():
     assert defaults == [SENTINEL_DEFAULT]
 
 
+# --------------------------------------------------------------------------- #
+# Pure helpers — budget parsing
+# --------------------------------------------------------------------------- #
+
+
 @pytest.mark.parametrize(
     "raw,expected",
     [("", 0), (None, 0), ("   ", 0), ("0", 0), ("1500", 1500), ("42", 42)],
@@ -105,46 +136,9 @@ def test_parse_budget_rejects_over_limit():
         parse_budget(str(MAX_TOKEN_BUDGET + 1))
 
 
-def test_create_budgets_modal_omits_value_without_override():
-    # A first-time-setup modal (no existing override) must leave the budget
-    # inputs' value UNDEFINED — an empty string is rejected by Discord.
-    modal = create_budgets_modal("G", "C", NO_REASONING_KEY, None, None)
-    values = [
-        component.value
-        for row in modal.components
-        for component in row.components
-    ]
-    assert values == [hikari.UNDEFINED, hikari.UNDEFINED]
-
-
-def test_create_budgets_modal_inputs_cap_length_at_ten():
-    modal = create_budgets_modal("G", "C", NO_REASONING_KEY, None, None)
-    lengths = [
-        component.max_length
-        for row in modal.components
-        for component in row.components
-    ]
-    assert lengths == [10, 10]
-
-
-def test_create_budgets_modal_encodes_ids_and_prefills():
-    modal = create_budgets_modal(
-        "G", "C", NO_REASONING_KEY, None, _override(daily=1500, hourly=200)
-    )
-    # Trailing empty segment encodes "no explicit reasoning level".
-    assert modal.custom_id == f"model_override_modal:G:C:{NO_REASONING_KEY}:"
-    values = [
-        component.value
-        for row in modal.components
-        for component in row.components
-    ]
-    assert "1500" in values
-    assert "200" in values
-
-
-def test_create_budgets_modal_encodes_reasoning_level():
-    modal = create_budgets_modal("G", "C", REASONING_KEY, "high", _override())
-    assert modal.custom_id == f"model_override_modal:G:C:{REASONING_KEY}:high"
+# --------------------------------------------------------------------------- #
+# Pure helpers — reasoning options
+# --------------------------------------------------------------------------- #
 
 
 def test_build_reasoning_options_covers_model_levels_and_sentinel():
@@ -167,6 +161,221 @@ def test_build_reasoning_options_marks_stored_level_default():
 
 
 # --------------------------------------------------------------------------- #
+# Pure helpers — fallback options
+# --------------------------------------------------------------------------- #
+
+
+def test_build_fallback_options_excludes_primary_and_offers_sentinel():
+    options = build_fallback_options(primary_key=REASONING_KEY, current_fallback_key=None)
+    values = [opt.value for opt in options]
+
+    assert values[0] == SENTINEL_NO_FALLBACK
+    # The chosen primary is never offered as its own fallback.
+    assert REASONING_KEY not in values
+    # Every other catalog model is offered.
+    for model in MODEL_CATALOG:
+        if model.key != REASONING_KEY:
+            assert model.key in values
+    # sentinel + (catalog - primary), within Discord's 25-option limit
+    assert len(options) == len(MODEL_CATALOG)
+    assert len(options) <= 25
+    # No stored fallback -> the "no fallback" sentinel is preselected.
+    defaults = [opt.value for opt in options if opt.is_default]
+    assert defaults == [SENTINEL_NO_FALLBACK]
+
+
+def test_build_fallback_options_marks_current_fallback_default():
+    options = build_fallback_options(
+        primary_key=REASONING_KEY, current_fallback_key=FALLBACK_KEY
+    )
+    defaults = [opt.value for opt in options if opt.is_default]
+    assert defaults == [FALLBACK_KEY]
+
+
+# --------------------------------------------------------------------------- #
+# Pure helpers — panel state encode/parse
+# --------------------------------------------------------------------------- #
+
+
+def test_encode_panel_state_full():
+    assert (
+        encode_panel_state(REASONING_KEY, "high", True, FALLBACK_KEY)
+        == f"{REASONING_KEY}:high:1:{FALLBACK_KEY}"
+    )
+
+
+def test_encode_panel_state_empties():
+    assert encode_panel_state(NO_REASONING_KEY, None, False, None) == f"{NO_REASONING_KEY}::0:"
+
+
+def test_parse_panel_state_roundtrip():
+    custom_id = f"{AUTO_TOGGLE_CUSTOM_ID_PREFIX}:{REASONING_KEY}:high:1:{FALLBACK_KEY}"
+    state = parse_panel_state(custom_id, AUTO_TOGGLE_CUSTOM_ID_PREFIX)
+    assert state == PanelState(
+        model_key=REASONING_KEY,
+        reasoning_level="high",
+        auto_respond=True,
+        fallback_model_key=FALLBACK_KEY,
+    )
+
+
+def test_parse_panel_state_empties():
+    custom_id = f"{CONTINUE_CUSTOM_ID_PREFIX}:{NO_REASONING_KEY}::0:"
+    state = parse_panel_state(custom_id, CONTINUE_CUSTOM_ID_PREFIX)
+    assert state == PanelState(
+        model_key=NO_REASONING_KEY,
+        reasoning_level=None,
+        auto_respond=False,
+        fallback_model_key=None,
+    )
+
+
+def test_parse_panel_state_wrong_prefix_returns_none():
+    custom_id = f"{AUTO_TOGGLE_CUSTOM_ID_PREFIX}:{REASONING_KEY}:high:1:{FALLBACK_KEY}"
+    assert parse_panel_state(custom_id, CONTINUE_CUSTOM_ID_PREFIX) is None
+
+
+def test_parse_panel_state_wrong_field_count_returns_none():
+    assert parse_panel_state(f"{AUTO_TOGGLE_CUSTOM_ID_PREFIX}:only:two", AUTO_TOGGLE_CUSTOM_ID_PREFIX) is None
+
+
+# --------------------------------------------------------------------------- #
+# Pure helpers — settings panel
+# --------------------------------------------------------------------------- #
+
+
+def test_create_settings_panel_reasoning_model_has_reasoning_row():
+    model = get_model(REASONING_KEY)
+    rows = create_settings_panel(model, None, False, None)
+    # reasoning select + fallback select + button row
+    assert len(rows) == 3
+    prefixes = [row.components[0].custom_id.split(":")[0] for row in rows[:2]]
+    assert prefixes == [REASONING_SELECT_CUSTOM_ID_PREFIX, FALLBACK_SELECT_CUSTOM_ID_PREFIX]
+
+
+def test_create_settings_panel_no_reasoning_model_omits_reasoning_row():
+    model = get_model(NO_REASONING_KEY)
+    rows = create_settings_panel(model, None, False, None)
+    # No reasoning knob -> fallback select + button row only.
+    assert len(rows) == 2
+    assert rows[0].components[0].custom_id.split(":")[0] == FALLBACK_SELECT_CUSTOM_ID_PREFIX
+
+
+def test_create_settings_panel_buttons_carry_auto_and_continue():
+    model = get_model(NO_REASONING_KEY)
+    rows = create_settings_panel(model, None, False, None)
+    buttons = rows[-1].components
+    button_prefixes = [button.custom_id.split(":")[0] for button in buttons]
+    assert AUTO_TOGGLE_CUSTOM_ID_PREFIX in button_prefixes
+    assert CONTINUE_CUSTOM_ID_PREFIX in button_prefixes
+
+
+def test_create_settings_panel_auto_button_reflects_off_state():
+    model = get_model(NO_REASONING_KEY)
+    rows = create_settings_panel(model, None, False, None)
+    auto_button = next(
+        button
+        for button in rows[-1].components
+        if button.custom_id.split(":")[0] == AUTO_TOGGLE_CUSTOM_ID_PREFIX
+    )
+    assert "OFF" in auto_button.label
+    assert auto_button.style == hikari.ButtonStyle.SECONDARY
+
+
+def test_create_settings_panel_auto_button_reflects_on_state():
+    model = get_model(NO_REASONING_KEY)
+    rows = create_settings_panel(model, None, True, None)
+    auto_button = next(
+        button
+        for button in rows[-1].components
+        if button.custom_id.split(":")[0] == AUTO_TOGGLE_CUSTOM_ID_PREFIX
+    )
+    assert "ON" in auto_button.label
+    assert auto_button.style == hikari.ButtonStyle.SUCCESS
+
+
+def test_create_settings_panel_custom_ids_carry_state_and_stay_short():
+    model = get_model(REASONING_KEY)
+    rows = create_settings_panel(model, "high", True, FALLBACK_KEY)
+    state = encode_panel_state(REASONING_KEY, "high", True, FALLBACK_KEY)
+    for component in _row_components(rows):
+        assert component.custom_id.endswith(state)
+        assert len(component.custom_id) < 100
+
+
+def test_create_settings_panel_prefills_reasoning_and_fallback():
+    model = get_model(REASONING_KEY)
+    rows = create_settings_panel(model, "high", False, FALLBACK_KEY)
+    reasoning_select = rows[0].components[0]
+    fallback_select = rows[1].components[0]
+    reasoning_defaults = [o.value for o in reasoning_select.options if o.is_default]
+    fallback_defaults = [o.value for o in fallback_select.options if o.is_default]
+    assert reasoning_defaults == ["high"]
+    assert fallback_defaults == [FALLBACK_KEY]
+
+
+# --------------------------------------------------------------------------- #
+# Pure helpers — settings modal
+# --------------------------------------------------------------------------- #
+
+
+def _panel_state(
+    model_key: str = NO_REASONING_KEY,
+    reasoning_level: str | None = None,
+    auto_respond: bool = False,
+    fallback_model_key: str | None = None,
+) -> PanelState:
+    return PanelState(
+        model_key=model_key,
+        reasoning_level=reasoning_level,
+        auto_respond=auto_respond,
+        fallback_model_key=fallback_model_key,
+    )
+
+
+def test_create_settings_modal_encodes_full_state():
+    state = _panel_state(REASONING_KEY, "high", True, FALLBACK_KEY)
+    modal = create_settings_modal(state, None)
+    assert modal.custom_id == (
+        f"{MODAL_CUSTOM_ID_PREFIX}:{REASONING_KEY}:high:1:{FALLBACK_KEY}"
+    )
+
+
+def test_create_settings_modal_has_budget_and_filter_inputs():
+    modal = create_settings_modal(_panel_state(), None)
+    inputs = _row_components(modal.components)
+    ids = [component.custom_id for component in inputs]
+    assert ids == ["daily_budget", "hourly_budget", "response_filter"]
+    response_filter_input = inputs[-1]
+    assert response_filter_input.style == hikari.TextInputStyle.PARAGRAPH
+    assert response_filter_input.is_required is False
+    assert response_filter_input.max_length == 4000
+
+
+def test_create_settings_modal_omits_prefill_without_override():
+    modal = create_settings_modal(_panel_state(), None)
+    values = [component.value for component in _row_components(modal.components)]
+    assert values == [hikari.UNDEFINED, hikari.UNDEFINED, hikari.UNDEFINED]
+
+
+def test_create_settings_modal_prefills_from_override():
+    modal = create_settings_modal(
+        _panel_state(),
+        _override(daily=1500, hourly=200, response_filter="only questions"),
+    )
+    values = [component.value for component in _row_components(modal.components)]
+    assert values == ["1500", "200", "only questions"]
+
+
+def test_create_settings_modal_omits_empty_filter_prefill():
+    modal = create_settings_modal(
+        _panel_state(), _override(daily=10, hourly=10, response_filter=None)
+    )
+    values = [component.value for component in _row_components(modal.components)]
+    assert values[-1] is hikari.UNDEFINED
+
+
+# --------------------------------------------------------------------------- #
 # Slash command admin gate
 # --------------------------------------------------------------------------- #
 
@@ -182,11 +391,11 @@ def _slash_ctx(member_perms: hikari.Permissions, service: AsyncMock):
     return ctx
 
 
-async def test_setmodel_denies_non_admin():
+async def test_chat_bot_settings_denies_non_admin():
     service = AsyncMock()
     ctx = _slash_ctx(NONE, service)
     with patch(PERMS_TARGET, return_value=NONE):
-        await model_override.setmodel(ctx)
+        await model_override.chat_bot_settings(ctx)
 
     ctx.respond.assert_called_once()
     _, kwargs = ctx.respond.call_args
@@ -195,12 +404,12 @@ async def test_setmodel_denies_non_admin():
     service.get_override.assert_not_called()
 
 
-async def test_setmodel_shows_select_for_admin():
+async def test_chat_bot_settings_shows_select_for_admin():
     service = AsyncMock()
     service.get_override.return_value = None
     ctx = _slash_ctx(ADMIN, service)
     with patch(PERMS_TARGET, return_value=ADMIN):
-        await model_override.setmodel(ctx)
+        await model_override.chat_bot_settings(ctx)
 
     service.get_override.assert_awaited_once_with("G", "C")
     ctx.respond.assert_called_once()
@@ -210,16 +419,21 @@ async def test_setmodel_shows_select_for_admin():
 
 
 # --------------------------------------------------------------------------- #
-# Select handler
+# Model select handler
 # --------------------------------------------------------------------------- #
 
 
-def _component_event(values: list[str], service: AsyncMock, admin: bool = True):
+def _component_event(
+    values: list[str],
+    service: AsyncMock,
+    custom_id: str = "model_override_select",
+):
     interaction = Mock(spec=hikari.ComponentInteraction)
     interaction.member = Mock(spec=hikari.InteractionMember)
     interaction.guild_id = "G"
     interaction.channel_id = "C"
     interaction.values = values
+    interaction.custom_id = custom_id
     interaction.create_initial_response = AsyncMock()
     interaction.create_modal_response = AsyncMock()
     event = Mock()
@@ -254,32 +468,54 @@ async def test_select_sentinel_clear_failure_reports_to_admin():
     assert "Couldn't remove the override" in kwargs["content"]
 
 
-async def test_select_no_reasoning_model_opens_budget_modal():
+async def test_select_no_reasoning_model_renders_panel():
     service = AsyncMock()
     service.get_override.return_value = None
     event = _component_event([NO_REASONING_KEY], service)
     with patch(PERMS_TARGET, return_value=ADMIN):
         await model_override.handle_model_override_select(event)
 
-    event.interaction.create_modal_response.assert_awaited_once()
-    args, kwargs = event.interaction.create_modal_response.call_args
-    assert args[1] == f"model_override_modal:G:C:{NO_REASONING_KEY}:"
+    # The panel is a message update, not a modal — budgets are deferred to the
+    # "Budgets & filter…" button.
+    event.interaction.create_modal_response.assert_not_called()
+    event.interaction.create_initial_response.assert_awaited_once()
+    args, kwargs = event.interaction.create_initial_response.call_args
+    assert args[0] == hikari.ResponseType.MESSAGE_UPDATE
+    assert kwargs["components"]
     service.clear_override.assert_not_called()
 
 
-async def test_select_reasoning_model_shows_reasoning_select():
+async def test_select_reasoning_model_renders_panel_with_reasoning_row():
     service = AsyncMock()
     service.get_override.return_value = None
     event = _component_event([REASONING_KEY], service)
     with patch(PERMS_TARGET, return_value=ADMIN):
         await model_override.handle_model_override_select(event)
 
-    # A reasoning-capable model updates the message with the reasoning select
-    # rather than jumping straight to the budgets modal.
     event.interaction.create_modal_response.assert_not_called()
     event.interaction.create_initial_response.assert_awaited_once()
     _, kwargs = event.interaction.create_initial_response.call_args
-    assert kwargs["components"]
+    rows = kwargs["components"]
+    # reasoning select + fallback select + buttons
+    assert len(rows) == 3
+
+
+async def test_select_panel_prefills_from_current_override():
+    service = AsyncMock()
+    service.get_override.return_value = _override(
+        model_key=REASONING_KEY,
+        reasoning_level="high",
+        auto_respond=True,
+        fallback_model_key=FALLBACK_KEY,
+    )
+    event = _component_event([REASONING_KEY], service)
+    with patch(PERMS_TARGET, return_value=ADMIN):
+        await model_override.handle_model_override_select(event)
+
+    _, kwargs = event.interaction.create_initial_response.call_args
+    rows = kwargs["components"]
+    state = encode_panel_state(REASONING_KEY, "high", True, FALLBACK_KEY)
+    assert rows[0].components[0].custom_id.endswith(state)
 
 
 async def test_select_denies_non_admin():
@@ -293,35 +529,136 @@ async def test_select_denies_non_admin():
     service.clear_override.assert_not_called()
 
 
-async def test_reasoning_select_opens_budget_modal_with_level():
+# --------------------------------------------------------------------------- #
+# Panel component handlers (re-render)
+# --------------------------------------------------------------------------- #
+
+
+async def test_reasoning_select_rerenders_panel_with_new_level():
     service = AsyncMock()
-    service.get_override.return_value = None
-    event = _component_event(["high"], service)
-    event.interaction.custom_id = (
-        f"model_override_reasoning:G:C:{REASONING_KEY}"
+    event = _component_event(
+        ["high"],
+        service,
+        custom_id=f"{REASONING_SELECT_CUSTOM_ID_PREFIX}:{REASONING_KEY}::0:",
     )
     with patch(PERMS_TARGET, return_value=ADMIN):
         await model_override.handle_model_override_reasoning_select(event)
 
-    event.interaction.create_modal_response.assert_awaited_once()
-    args, _ = event.interaction.create_modal_response.call_args
-    assert args[1] == f"model_override_modal:G:C:{REASONING_KEY}:high"
+    event.interaction.create_modal_response.assert_not_called()
+    event.interaction.create_initial_response.assert_awaited_once()
+    args, kwargs = event.interaction.create_initial_response.call_args
+    assert args[0] == hikari.ResponseType.MESSAGE_UPDATE
+    state = encode_panel_state(REASONING_KEY, "high", False, None)
+    assert kwargs["components"][0].components[0].custom_id.endswith(state)
 
 
 async def test_reasoning_select_sentinel_maps_to_model_default():
     service = AsyncMock()
-    service.get_override.return_value = None
-    event = _component_event([SENTINEL_MODEL_DEFAULT], service)
-    event.interaction.custom_id = (
-        f"model_override_reasoning:G:C:{REASONING_KEY}"
+    event = _component_event(
+        [SENTINEL_MODEL_DEFAULT],
+        service,
+        custom_id=f"{REASONING_SELECT_CUSTOM_ID_PREFIX}:{REASONING_KEY}:high:0:",
     )
     with patch(PERMS_TARGET, return_value=ADMIN):
         await model_override.handle_model_override_reasoning_select(event)
 
+    _, kwargs = event.interaction.create_initial_response.call_args
+    # Sentinel -> empty reasoning segment (the model default).
+    state = encode_panel_state(REASONING_KEY, None, False, None)
+    assert kwargs["components"][0].components[0].custom_id.endswith(state)
+
+
+async def test_fallback_select_rerenders_with_new_fallback():
+    service = AsyncMock()
+    event = _component_event(
+        [FALLBACK_KEY],
+        service,
+        custom_id=f"{FALLBACK_SELECT_CUSTOM_ID_PREFIX}:{REASONING_KEY}:high:0:",
+    )
+    with patch(PERMS_TARGET, return_value=ADMIN):
+        await model_override.handle_model_override_fallback_select(event)
+
+    _, kwargs = event.interaction.create_initial_response.call_args
+    state = encode_panel_state(REASONING_KEY, "high", False, FALLBACK_KEY)
+    assert kwargs["components"][0].components[0].custom_id.endswith(state)
+
+
+async def test_fallback_select_sentinel_clears_fallback():
+    service = AsyncMock()
+    event = _component_event(
+        [SENTINEL_NO_FALLBACK],
+        service,
+        custom_id=f"{FALLBACK_SELECT_CUSTOM_ID_PREFIX}:{REASONING_KEY}:high:0:{FALLBACK_KEY}",
+    )
+    with patch(PERMS_TARGET, return_value=ADMIN):
+        await model_override.handle_model_override_fallback_select(event)
+
+    _, kwargs = event.interaction.create_initial_response.call_args
+    state = encode_panel_state(REASONING_KEY, "high", False, None)
+    assert kwargs["components"][0].components[0].custom_id.endswith(state)
+
+
+async def test_auto_toggle_flips_state_off_to_on():
+    service = AsyncMock()
+    event = _component_event(
+        [],
+        service,
+        custom_id=f"{AUTO_TOGGLE_CUSTOM_ID_PREFIX}:{REASONING_KEY}:high:0:{FALLBACK_KEY}",
+    )
+    with patch(PERMS_TARGET, return_value=ADMIN):
+        await model_override.handle_model_override_auto_toggle(event)
+
+    args, kwargs = event.interaction.create_initial_response.call_args
+    assert args[0] == hikari.ResponseType.MESSAGE_UPDATE
+    state = encode_panel_state(REASONING_KEY, "high", True, FALLBACK_KEY)
+    for component in _row_components(kwargs["components"]):
+        assert component.custom_id.endswith(state)
+
+
+async def test_auto_toggle_flips_state_on_to_off():
+    service = AsyncMock()
+    event = _component_event(
+        [],
+        service,
+        custom_id=f"{AUTO_TOGGLE_CUSTOM_ID_PREFIX}:{REASONING_KEY}:high:1:{FALLBACK_KEY}",
+    )
+    with patch(PERMS_TARGET, return_value=ADMIN):
+        await model_override.handle_model_override_auto_toggle(event)
+
+    _, kwargs = event.interaction.create_initial_response.call_args
+    state = encode_panel_state(REASONING_KEY, "high", False, FALLBACK_KEY)
+    assert kwargs["components"][0].components[0].custom_id.endswith(state)
+
+
+async def test_auto_toggle_denies_non_admin():
+    service = AsyncMock()
+    event = _component_event(
+        [],
+        service,
+        custom_id=f"{AUTO_TOGGLE_CUSTOM_ID_PREFIX}:{REASONING_KEY}:high:0:",
+    )
+    with patch(PERMS_TARGET, return_value=NONE):
+        await model_override.handle_model_override_auto_toggle(event)
+
+    event.interaction.create_initial_response.assert_awaited_once()
+    _, kwargs = event.interaction.create_initial_response.call_args
+    assert "Administrator" in kwargs["content"]
+
+
+async def test_continue_opens_modal_carrying_state():
+    service = AsyncMock()
+    service.get_override.return_value = _override(daily=1500, hourly=200)
+    event = _component_event(
+        [],
+        service,
+        custom_id=f"{CONTINUE_CUSTOM_ID_PREFIX}:{REASONING_KEY}:high:1:{FALLBACK_KEY}",
+    )
+    with patch(PERMS_TARGET, return_value=ADMIN):
+        await model_override.handle_model_override_continue(event)
+
     event.interaction.create_modal_response.assert_awaited_once()
     args, _ = event.interaction.create_modal_response.call_args
-    # Empty reasoning segment -> stored as the model default (NULL).
-    assert args[1] == f"model_override_modal:G:C:{REASONING_KEY}:"
+    assert args[1] == f"{MODAL_CUSTOM_ID_PREFIX}:{REASONING_KEY}:high:1:{FALLBACK_KEY}"
 
 
 # --------------------------------------------------------------------------- #
@@ -336,13 +673,16 @@ def _text_input(custom_id: str, value: str):
     return component
 
 
-def _modal_event(custom_id: str, budgets: dict[str, str], service: AsyncMock):
+def _modal_event(custom_id: str, fields: dict[str, str], service: AsyncMock):
     interaction = Mock(spec=hikari.ModalInteraction)
     interaction.member = Mock(spec=hikari.InteractionMember)
+    interaction.guild_id = "G"
+    interaction.channel_id = "C"
     interaction.custom_id = custom_id
     interaction.components = [
-        [_text_input("daily_budget", budgets.get("daily_budget", ""))],
-        [_text_input("hourly_budget", budgets.get("hourly_budget", ""))],
+        [_text_input("daily_budget", fields.get("daily_budget", ""))],
+        [_text_input("hourly_budget", fields.get("hourly_budget", ""))],
+        [_text_input("response_filter", fields.get("response_filter", ""))],
     ]
     interaction.create_initial_response = AsyncMock()
     event = Mock()
@@ -352,27 +692,38 @@ def _modal_event(custom_id: str, budgets: dict[str, str], service: AsyncMock):
     return event
 
 
-async def test_modal_submit_persists_override_with_model_default_reasoning():
+async def test_modal_submit_persists_all_fields():
     service = AsyncMock()
     event = _modal_event(
-        f"model_override_modal:G:C:{NO_REASONING_KEY}:",
-        {"daily_budget": "1500", "hourly_budget": "0"},
+        f"{MODAL_CUSTOM_ID_PREFIX}:{REASONING_KEY}:high:1:{FALLBACK_KEY}",
+        {
+            "daily_budget": "1500",
+            "hourly_budget": "200",
+            "response_filter": "Only respond to programming questions",
+        },
         service,
     )
     with patch(PERMS_TARGET, return_value=ADMIN):
         await model_override.handle_model_override_modal_submit(event)
 
-    # Empty reasoning segment persists as None (use the model default).
     service.set_override.assert_awaited_once_with(
-        "G", "C", NO_REASONING_KEY, 1500, 0, reasoning_level=None
+        "G",
+        "C",
+        REASONING_KEY,
+        1500,
+        200,
+        reasoning_level="high",
+        auto_respond=True,
+        fallback_model_key=FALLBACK_KEY,
+        response_filter="Only respond to programming questions",
     )
     event.interaction.create_initial_response.assert_awaited_once()
 
 
-async def test_modal_submit_persists_selected_reasoning_level():
+async def test_modal_submit_persists_minimal_state():
     service = AsyncMock()
     event = _modal_event(
-        f"model_override_modal:G:C:{REASONING_KEY}:high",
+        f"{MODAL_CUSTOM_ID_PREFIX}:{NO_REASONING_KEY}::0:",
         {"daily_budget": "0", "hourly_budget": "0"},
         service,
     )
@@ -380,9 +731,68 @@ async def test_modal_submit_persists_selected_reasoning_level():
         await model_override.handle_model_override_modal_submit(event)
 
     service.set_override.assert_awaited_once_with(
-        "G", "C", REASONING_KEY, 0, 0, reasoning_level="high"
+        "G",
+        "C",
+        NO_REASONING_KEY,
+        0,
+        0,
+        reasoning_level=None,
+        auto_respond=False,
+        fallback_model_key=None,
+        response_filter=None,
     )
-    event.interaction.create_initial_response.assert_awaited_once()
+
+
+async def test_modal_submit_empty_filter_persists_none():
+    service = AsyncMock()
+    event = _modal_event(
+        f"{MODAL_CUSTOM_ID_PREFIX}:{REASONING_KEY}:high:1:{FALLBACK_KEY}",
+        {"daily_budget": "0", "hourly_budget": "0", "response_filter": "   "},
+        service,
+    )
+    with patch(PERMS_TARGET, return_value=ADMIN):
+        await model_override.handle_model_override_modal_submit(event)
+
+    _, kwargs = service.set_override.call_args
+    assert kwargs["response_filter"] is None
+
+
+async def test_modal_submit_confirmation_lists_all_settings():
+    service = AsyncMock()
+    event = _modal_event(
+        f"{MODAL_CUSTOM_ID_PREFIX}:{REASONING_KEY}:high:1:{FALLBACK_KEY}",
+        {
+            "daily_budget": "1500",
+            "hourly_budget": "200",
+            "response_filter": "Only respond to programming questions",
+        },
+        service,
+    )
+    with patch(PERMS_TARGET, return_value=ADMIN):
+        await model_override.handle_model_override_modal_submit(event)
+
+    _, kwargs = event.interaction.create_initial_response.call_args
+    content = kwargs["content"]
+    assert "Auto-respond" in content
+    assert "on" in content.lower()
+    assert get_model(FALLBACK_KEY).label in content
+    # A configured filter is reported as present.
+    assert "filter" in content.lower()
+
+
+async def test_modal_submit_confirmation_reports_no_fallback_and_no_filter():
+    service = AsyncMock()
+    event = _modal_event(
+        f"{MODAL_CUSTOM_ID_PREFIX}:{NO_REASONING_KEY}::0:",
+        {"daily_budget": "0", "hourly_budget": "0"},
+        service,
+    )
+    with patch(PERMS_TARGET, return_value=ADMIN):
+        await model_override.handle_model_override_modal_submit(event)
+
+    _, kwargs = event.interaction.create_initial_response.call_args
+    content = kwargs["content"]
+    assert "none" in content.lower()
 
 
 async def test_modal_submit_save_failure_reports_to_admin():
@@ -391,7 +801,7 @@ async def test_modal_submit_save_failure_reports_to_admin():
     service = AsyncMock()
     service.set_override.side_effect = APIError("boom", status_code=500)
     event = _modal_event(
-        f"model_override_modal:G:C:{NO_REASONING_KEY}:",
+        f"{MODAL_CUSTOM_ID_PREFIX}:{NO_REASONING_KEY}::0:",
         {"daily_budget": "1500", "hourly_budget": "0"},
         service,
     )
@@ -406,7 +816,7 @@ async def test_modal_submit_save_failure_reports_to_admin():
 async def test_modal_submit_rejects_invalid_budget():
     service = AsyncMock()
     event = _modal_event(
-        f"model_override_modal:G:C:{NO_REASONING_KEY}:",
+        f"{MODAL_CUSTOM_ID_PREFIX}:{NO_REASONING_KEY}::0:",
         {"daily_budget": "-5", "hourly_budget": "0"},
         service,
     )
@@ -420,7 +830,7 @@ async def test_modal_submit_rejects_invalid_budget():
 async def test_modal_submit_denies_non_admin():
     service = AsyncMock()
     event = _modal_event(
-        f"model_override_modal:G:C:{NO_REASONING_KEY}:",
+        f"{MODAL_CUSTOM_ID_PREFIX}:{NO_REASONING_KEY}::0:",
         {"daily_budget": "10", "hourly_budget": "10"},
         service,
     )
@@ -434,7 +844,7 @@ async def test_modal_submit_denies_non_admin():
 async def test_modal_submit_rejects_unknown_model():
     service = AsyncMock()
     event = _modal_event(
-        "model_override_modal:G:C:not-a-real-model:",
+        f"{MODAL_CUSTOM_ID_PREFIX}:not-a-real-model::0:",
         {"daily_budget": "10", "hourly_budget": "10"},
         service,
     )
@@ -443,3 +853,144 @@ async def test_modal_submit_rejects_unknown_model():
 
     service.set_override.assert_not_called()
     event.interaction.create_initial_response.assert_awaited_once()
+
+
+async def test_modal_submit_rejects_malformed_custom_id():
+    service = AsyncMock()
+    event = _modal_event(
+        f"{MODAL_CUSTOM_ID_PREFIX}:too:few",
+        {"daily_budget": "10", "hourly_budget": "10"},
+        service,
+    )
+    with patch(PERMS_TARGET, return_value=ADMIN):
+        await model_override.handle_model_override_modal_submit(event)
+
+    service.set_override.assert_not_called()
+    event.interaction.create_initial_response.assert_awaited_once()
+
+
+# --------------------------------------------------------------------------- #
+# Budget-exhausted fallback button handler (member-facing, no admin gate)
+# --------------------------------------------------------------------------- #
+
+REGISTRY_TARGET = "smarter_dev.bot.plugins.model_override.get_chat_engine_registry"
+
+
+def _fallback_button_event(
+    service: AsyncMock,
+    redis,
+    *,
+    channel_id: str = "123",
+    guild_id: str = "456",
+    reset_epoch: int | None = None,
+):
+    if reset_epoch is None:
+        reset_epoch = int(datetime.now(UTC).timestamp()) + 3600
+    interaction = Mock(spec=hikari.ComponentInteraction)
+    interaction.guild_id = guild_id
+    interaction.channel_id = channel_id
+    interaction.custom_id = f"model_budget_fallback:{reset_epoch}"
+    interaction.create_initial_response = AsyncMock()
+    event = Mock()
+    event.interaction = interaction
+    event.app = Mock()
+    data = {"model_override_service": service}
+    if redis is not None:
+        data["chat_memory_redis"] = redis
+    event.app.d = data
+    return event
+
+
+def _stub_registry(engine=None):
+    registry = AsyncMock()
+    registry.get.return_value = engine
+    return registry
+
+
+async def test_fallback_button_sets_keys_updates_message_and_fires_engine():
+    service = AsyncMock()
+    service.get_override.return_value = _override(fallback_model_key=FALLBACK_KEY)
+    redis = AsyncMock()
+    engine = Mock()
+    engine.active = True
+    engine.fire_now = Mock()
+    reset_epoch = int(datetime.now(UTC).timestamp()) + 3600
+    event = _fallback_button_event(service, redis, reset_epoch=reset_epoch)
+
+    with patch(REGISTRY_TARGET, return_value=_stub_registry(engine)):
+        await model_override.handle_model_budget_fallback(event)
+
+    assert redis.set.await_count == 2
+    keys = [call.args[0] for call in redis.set.await_args_list]
+    assert keys == [
+        "modelbudget-fallback:123",
+        "modelbudget-fallback-ended:123",
+    ]
+    exats = [call.kwargs["exat"] for call in redis.set.await_args_list]
+    assert exats == [reset_epoch, reset_epoch + 86400]
+
+    args, kwargs = event.interaction.create_initial_response.call_args
+    assert args[0] == hikari.ResponseType.MESSAGE_UPDATE
+    assert kwargs["components"] == []
+    assert get_model(FALLBACK_KEY).label in kwargs["content"]
+    engine.fire_now.assert_called_once()
+
+
+async def test_fallback_button_no_fallback_configured_reports_ephemeral():
+    service = AsyncMock()
+    service.get_override.return_value = _override(fallback_model_key=None)
+    redis = AsyncMock()
+    event = _fallback_button_event(service, redis)
+
+    with patch(REGISTRY_TARGET, return_value=_stub_registry()):
+        await model_override.handle_model_budget_fallback(event)
+
+    redis.set.assert_not_called()
+    args, kwargs = event.interaction.create_initial_response.call_args
+    assert args[0] == hikari.ResponseType.MESSAGE_CREATE
+    assert kwargs["flags"] == hikari.MessageFlag.EPHEMERAL
+    assert "no longer has a fallback" in kwargs["content"].lower()
+
+
+async def test_fallback_button_past_epoch_says_already_reset():
+    service = AsyncMock()
+    service.get_override.return_value = _override(fallback_model_key=FALLBACK_KEY)
+    redis = AsyncMock()
+    past = int(datetime.now(UTC).timestamp()) - 10
+    event = _fallback_button_event(service, redis, reset_epoch=past)
+
+    with patch(REGISTRY_TARGET, return_value=_stub_registry()):
+        await model_override.handle_model_budget_fallback(event)
+
+    redis.set.assert_not_called()
+    _, kwargs = event.interaction.create_initial_response.call_args
+    assert kwargs["flags"] == hikari.MessageFlag.EPHEMERAL
+    assert "already reset" in kwargs["content"].lower()
+
+
+async def test_fallback_button_redis_unavailable_reports_ephemeral():
+    service = AsyncMock()
+    service.get_override.return_value = _override(fallback_model_key=FALLBACK_KEY)
+    event = _fallback_button_event(service, None)  # no chat_memory_redis on bot.d
+
+    with patch(REGISTRY_TARGET, return_value=_stub_registry()):
+        await model_override.handle_model_budget_fallback(event)
+
+    _, kwargs = event.interaction.create_initial_response.call_args
+    assert kwargs["flags"] == hikari.MessageFlag.EPHEMERAL
+    assert "couldn't switch" in kwargs["content"].lower()
+
+
+async def test_fallback_button_redis_error_reports_ephemeral():
+    service = AsyncMock()
+    service.get_override.return_value = _override(fallback_model_key=FALLBACK_KEY)
+    redis = AsyncMock()
+    redis.set.side_effect = Exception("redis down")
+    event = _fallback_button_event(service, redis)
+
+    with patch(REGISTRY_TARGET, return_value=_stub_registry()):
+        await model_override.handle_model_budget_fallback(event)
+
+    _, kwargs = event.interaction.create_initial_response.call_args
+    assert kwargs["flags"] == hikari.MessageFlag.EPHEMERAL
+    assert "couldn't switch" in kwargs["content"].lower()

--- a/tests/web/test_api_native/test_model_overrides.py
+++ b/tests/web/test_api_native/test_model_overrides.py
@@ -33,6 +33,9 @@ def _record(**overrides) -> SimpleNamespace:
         "reasoning_level": None,
         "daily_token_budget": 5000,
         "hourly_token_budget": 500,
+        "auto_respond": False,
+        "fallback_model_key": None,
+        "response_filter": None,
         "created_at": datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc),
         "updated_at": datetime(2026, 1, 2, 12, 0, tzinfo=timezone.utc),
     }
@@ -54,6 +57,9 @@ class TestGetModelOverride:
         assert body["reasoning_level"] is None
         assert body["daily_token_budget"] == 5000
         assert body["hourly_token_budget"] == 500
+        assert body["auto_respond"] is False
+        assert body["fallback_model_key"] is None
+        assert body["response_filter"] is None
         assert body["created_at"] == "2026-01-01T12:00:00+00:00"
         assert body["updated_at"] == "2026-01-02T12:00:00+00:00"
 
@@ -99,6 +105,53 @@ class TestPutModelOverride:
         _, kwargs = model_override_crud_mock.upsert.call_args
         assert kwargs["hourly_token_budget"] == 0
         assert kwargs["reasoning_level"] is None
+        # New per-channel settings default off when omitted (old-style write).
+        assert kwargs["auto_respond"] is False
+        assert kwargs["fallback_model_key"] is None
+        assert kwargs["response_filter"] is None
+
+    def test_new_settings_passed_through(
+        self, model_override_client: TestClient, model_override_crud_mock
+    ):
+        model_override_crud_mock.upsert.return_value = _record(
+            auto_respond=True,
+            fallback_model_key="kimi-k2-6",
+            response_filter="Only coding questions.",
+        )
+
+        response = model_override_client.put(
+            _url(),
+            json={
+                "model_key": "glm-5-2",
+                "auto_respond": True,
+                "fallback_model_key": "kimi-k2-6",
+                "response_filter": "Only coding questions.",
+            },
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["auto_respond"] is True
+        assert body["fallback_model_key"] == "kimi-k2-6"
+        assert body["response_filter"] == "Only coding questions."
+        _, kwargs = model_override_crud_mock.upsert.call_args
+        assert kwargs["auto_respond"] is True
+        assert kwargs["fallback_model_key"] == "kimi-k2-6"
+        assert kwargs["response_filter"] == "Only coding questions."
+
+    def test_unknown_fallback_model_key_is_422(self, model_override_client: TestClient):
+        response = model_override_client.put(
+            _url(),
+            json={"model_key": "glm-5-2", "fallback_model_key": "not-a-real-model"},
+        )
+        assert response.status_code == 422
+
+    def test_over_length_response_filter_is_422(self, model_override_client: TestClient):
+        response = model_override_client.put(
+            _url(),
+            json={"model_key": "glm-5-2", "response_filter": "x" * 4001},
+        )
+        assert response.status_code == 422
 
     def test_reasoning_level_passed_through(
         self, model_override_client: TestClient, model_override_crud_mock

--- a/tests/web/test_models/test_channel_model_override.py
+++ b/tests/web/test_models/test_channel_model_override.py
@@ -54,6 +54,36 @@ async def test_budgets_default_to_zero(db_session):
     assert stored.hourly_token_budget == 0
 
 
+async def test_new_settings_default_off(db_session):
+    db_session.add(_override())
+    await db_session.commit()
+
+    stored = (
+        await db_session.execute(select(ChannelModelOverride))
+    ).scalar_one()
+    assert stored.auto_respond is False
+    assert stored.fallback_model_key is None
+    assert stored.response_filter is None
+
+
+async def test_new_settings_round_trip(db_session):
+    db_session.add(
+        _override(
+            auto_respond=True,
+            fallback_model_key="glm-4-6",
+            response_filter="Only answer coding questions.",
+        )
+    )
+    await db_session.commit()
+
+    stored = (
+        await db_session.execute(select(ChannelModelOverride))
+    ).scalar_one()
+    assert stored.auto_respond is True
+    assert stored.fallback_model_key == "glm-4-6"
+    assert stored.response_filter == "Only answer coding questions."
+
+
 async def test_channel_id_is_unique(db_session):
     db_session.add(_override(channel_id="C1", model_key="kimi-k2"))
     await db_session.commit()


### PR DESCRIPTION
## Summary
- Renames the admin `/setmodel` command to `/chat-bot-settings` and extends the flow: model select → settings panel (reasoning level, fallback-model select, auto-respond toggle) → modal (daily/hourly token budgets + response-filter textbox).
- **Auto-respond**: flagged channels activate the chat agent on any message — same stop-phrase, cooldown, rate-limit, and per-user message-limit gates as @mentions.
- **Response filter**: a GPT-5.4 Nano classifier (`bot/agents/message_gate.py`) screens messages (queued + 5 grounding messages) against the admin's instructions before any chat-model spend. Off-topic messages are dropped — mentions included; a turn with no survivors is skipped without a no-response strike. Fail-open so a classifier outage never silences the bot. Intended use: expensive models (e.g. Claude) in topic-focused channels.
- **Fallback model**: when the token budget is exhausted and a fallback is configured, the notice carries a member-facing button opting the channel into the fallback until the budget window resets. Fallback turns skip budget enforcement and meter into a separate usage namespace; the first turn after a genuine reset announces the primary model's return.
- New `channel_model_overrides` columns (`auto_respond`, `fallback_model_key`, `response_filter`) with alembic migration, API schema/CRUD, and bot-side service propagation.

## Test plan
- Full suite: 1,662 passed, 8 skipped (`uv run pytest tests/bot tests/web tests/test_migration_ownership.py`). Only exclusions: the pre-existing `tests/bot/services/test_integration.py` collection error (missing `fastapi`, fails on baseline) and the wall-clock-flaky `test_cache_performance_optimization` (passes in isolation).
- New/updated coverage: settings-panel flow and state threading, modal persistence, auto-respond activation paths, message-gate classification (fail-open, hallucinated-id intersection), engine gate/fallback regimes, fallback-usage metering, API round-trips and validation.
- Adversarial review pass found and fixed three bugs pre-merge (first-activation filter deadlock, fallback spend polluting the enforced day window, premature "primary is back" notice).
- semgrep + gitleaks clean (remaining semgrep warnings are pre-existing or false-positive log-string matches).
- Post-deploy: migration runs via the CI migrate-job; verify with a live `/chat-bot-settings` pass in a test channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KXwW8dZS8yQUEyTFpVV25r