### PR TITLE
fix(migrations): linearize channel-override settings migration

### DIFF
--- a/alembic/main/versions/20260717_120000_f1a2b3c4d5e6_channel_override_response_settings.py
+++ b/alembic/main/versions/20260717_120000_f1a2b3c4d5e6_channel_override_response_settings.py
@@ -21,7 +21,7 @@ import sqlalchemy as sa
 
 
 revision: str = "f1a2b3c4d5e6"
-down_revision: Union[str, None] = "cfcaa2cbf2b0"
+down_revision: Union[str, None] = "b2e4f7a1c3d9"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 


### PR DESCRIPTION
## Summary
The deploy for #56 failed in the migrate-job with "Multiple head revisions": #55 and #56 both chained their migrations off `cfcaa2cbf2b0`. This re-parents `f1a2b3c4d5e6` (channel-override settings) onto `b2e4f7a1c3d9` (thread triggers), restoring a single head. Safe because `f1a2b3c4d5e6` was never applied anywhere — the CI job halts before running DDL — and the two migrations touch disjoint tables.

## Test plan
- `uv run alembic heads` → single head `f1a2b3c4d5e6`
- `uv run pytest tests/test_migration_ownership.py` → 3 passed
- Deploy workflow on merge is the real test: migrate-job should apply both pending revisions in order, then roll deployments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KXwW8dZS8yQUEyTFpVV25r