### PR TITLE
feat: monthly LLM invoice + per-channel usage breakdown in admin dashboard

### DIFF
--- a/alembic/main/versions/20260721_120000_a3f9c1e7b4d2_chat_reasoning_level.py
+++ b/alembic/main/versions/20260721_120000_a3f9c1e7b4d2_chat_reasoning_level.py
@@ -1,0 +1,48 @@
+"""add reasoning-level tracking to chat usage records
+
+Adds a nullable ReasoningLevel wire value to each chat usage row so the
+operator dashboard can attribute reasoning spend:
+
+- ``chat_agent_turns.chat_reasoning_level`` — the level in effect for the chat
+  model call, or NULL when the model has no reasoning knob / an ad-hoc model.
+- ``chat_agent_compaction_events.summarizer_reasoning_level`` — the level in
+  effect for the summarizer call (the summarizer runs at a fixed level), or
+  NULL when it has no reasoning knob configured.
+
+Both nullable, no backfill.
+
+Revision ID: a3f9c1e7b4d2
+Revises: f1a2b3c4d5e6
+Create Date: 2026-07-21 12:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "a3f9c1e7b4d2"
+down_revision: Union[str, None] = "f1a2b3c4d5e6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "chat_agent_turns",
+        sa.Column("chat_reasoning_level", sa.String(length=16), nullable=True),
+    )
+    op.add_column(
+        "chat_agent_compaction_events",
+        sa.Column(
+            "summarizer_reasoning_level", sa.String(length=16), nullable=True
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column(
+        "chat_agent_compaction_events", "summarizer_reasoning_level"
+    )
+    op.drop_column("chat_agent_turns", "chat_reasoning_level")

--- a/smarter_dev/bot/agents/chat_agent.py
+++ b/smarter_dev/bot/agents/chat_agent.py
@@ -38,6 +38,7 @@ from smarter_dev.shared.model_catalog import MODEL_CATALOG
 from smarter_dev.shared.model_catalog import CatalogModel
 from smarter_dev.shared.model_catalog import ModelProvider
 from smarter_dev.shared.model_catalog import parse_reasoning_level
+from smarter_dev.shared.model_catalog import resolve_reasoning_level
 from smarter_dev.bot.agents.model_router import build_model_for
 from smarter_dev.bot.agents.model_router import model_settings_for
 
@@ -124,6 +125,28 @@ def _model_settings_for(
     return GoogleModelSettings(
         google_thinking_config={"thinking_level": "MEDIUM"},
     )
+
+
+def resolved_reasoning_level(
+    model_id: str | None = None, reasoning_level: str | None = None
+) -> str | None:
+    """Return the ReasoningLevel wire value actually applied for a chat run.
+
+    Mirrors the reasoning resolution in :func:`_model_settings_for`: a catalog
+    model clamps the requested ``reasoning_level`` onto what it supports (or its
+    ``default_reasoning`` when unset), and a model with no reasoning knob yields
+    ``None``. A non-catalog ad-hoc ``CHAT_AGENT_MODEL`` id also yields ``None``
+    (no channel level maps onto it — its provider default is applied implicitly).
+    Used to persist the level in effect alongside the turn.
+    """
+    resolved_id = model_id or _model_id()
+    catalog_model = _catalog_model_for_id(resolved_id)
+    if catalog_model is None:
+        return None
+    effective = resolve_reasoning_level(
+        catalog_model, parse_reasoning_level(reasoning_level)
+    )
+    return effective.value if effective is not None else None
 
 
 # One agent per resolved (model id, reasoning level). A per-channel override

--- a/smarter_dev/bot/agents/chat_compaction.py
+++ b/smarter_dev/bot/agents/chat_compaction.py
@@ -65,6 +65,8 @@ from pydantic_ai.messages import (
 from pydantic_ai.models.google import GoogleModel, GoogleModelSettings
 from pydantic_ai.providers.google import GoogleProvider
 
+from smarter_dev.shared.model_catalog import ReasoningLevel
+
 logger = logging.getLogger(__name__)
 
 # Quality floor: this many characters of the most recent turns are never
@@ -94,6 +96,9 @@ COMPACTED_PREFIX = "[compacted history]"
 
 DEFAULT_COMPACT_MODEL = "gemini-3.1-flash-lite"
 COMPACT_MODEL_ENV_VAR = "CHAT_AGENT_COMPACT_MODEL"
+# The summarizer runs at a fixed reasoning level (Gemini thinking_level LOW);
+# persisted with each compaction event so the dashboard can attribute its spend.
+SUMMARIZER_REASONING_LEVEL = ReasoningLevel.LOW
 # Mirrors chat_agent.MODEL_ENV_VAR — chat_agent imports this module, so
 # importing back would be circular.
 CHAT_MODEL_ENV_VAR = "CHAT_AGENT_MODEL"
@@ -173,6 +178,7 @@ class CompactionEvent:
     summarizer_tokens_input: int
     summarizer_tokens_output: int
     summarizer_model_name: str
+    summarizer_reasoning_level: str | None
 
 
 _collected: ContextVar[list[CompactionEvent] | None] = ContextVar(
@@ -252,7 +258,9 @@ def get_summarizer_agent() -> Agent[None, str]:
             output_type=str,
             system_prompt=_SUMMARIZER_PROMPT.format(max_chars=MAX_SUMMARY_CHARS),
             model_settings=GoogleModelSettings(
-                google_thinking_config={"thinking_level": "LOW"},
+                google_thinking_config={
+                    "thinking_level": SUMMARIZER_REASONING_LEVEL.value.upper(),
+                },
             ),
         )
     return _summarizer_agent
@@ -455,6 +463,7 @@ async def compact_history(messages: list[ModelMessage]) -> list[ModelMessage]:
             summarizer_tokens_input=summary.tokens_input,
             summarizer_tokens_output=summary.tokens_output,
             summarizer_model_name=summary.model_name,
+            summarizer_reasoning_level=SUMMARIZER_REASONING_LEVEL.value,
         )
     )
 

--- a/smarter_dev/bot/services/chat_conversation_persistence.py
+++ b/smarter_dev/bot/services/chat_conversation_persistence.py
@@ -119,6 +119,7 @@ async def persist_turn(
     chat_tokens_input: int,
     chat_tokens_output: int,
     chat_model_name: str | None,
+    chat_reasoning_level: str | None = None,
     voice_tokens_input: int = 0,
     voice_tokens_output: int = 0,
     voice_model_name: str | None = None,
@@ -150,6 +151,7 @@ async def persist_turn(
             "summarizer_tokens_input": ev.summarizer_tokens_input,
             "summarizer_tokens_output": ev.summarizer_tokens_output,
             "summarizer_model_name": ev.summarizer_model_name,
+            "summarizer_reasoning_level": ev.summarizer_reasoning_level,
         }
         for ev in (compaction_events or [])
     ]
@@ -166,6 +168,7 @@ async def persist_turn(
         "chat_tokens_input": chat_tokens_input,
         "chat_tokens_output": chat_tokens_output,
         "chat_model_name": chat_model_name,
+        "chat_reasoning_level": chat_reasoning_level,
         "voice_tokens_input": voice_tokens_input,
         "voice_tokens_output": voice_tokens_output,
         "voice_model_name": voice_model_name,

--- a/smarter_dev/bot/services/chat_engine.py
+++ b/smarter_dev/bot/services/chat_engine.py
@@ -44,6 +44,7 @@ from redis.exceptions import RedisError
 from smarter_dev.bot.agents.chat_agent import DEFAULT_MODEL as CHAT_DEFAULT_MODEL
 from smarter_dev.bot.agents.chat_agent import MODEL_ENV_VAR as CHAT_MODEL_ENV_VAR
 from smarter_dev.bot.agents.chat_agent import get_chat_agent
+from smarter_dev.bot.agents.chat_agent import resolved_reasoning_level
 from smarter_dev.bot.agents.chat_compaction import drain_collection
 from smarter_dev.bot.agents.chat_compaction import set_last_model_call
 from smarter_dev.bot.agents.chat_compaction import start_collection
@@ -585,6 +586,14 @@ class ChannelEngine:
             resolved_model_name = override_model_id or os.environ.get(
                 CHAT_MODEL_ENV_VAR, CHAT_DEFAULT_MODEL
             )
+            # The reasoning level actually applied this turn: the override's
+            # choice clamped onto what the resolved model supports (or the
+            # model default when unset). Persisted with the turn so the
+            # dashboard can attribute reasoning spend. Matches the model +
+            # reasoning pair handed to ``get_chat_agent`` below.
+            resolved_reasoning_wire = resolved_reasoning_level(
+                override_model_id, override_reasoning
+            )
 
             # Start engagement persistence on the very first turn — gives us
             # an engagement_id we attach to every persisted turn that follows.
@@ -729,6 +738,7 @@ class ChannelEngine:
                         chat_tokens_input=chat_in,
                         chat_tokens_output=chat_out,
                         chat_model_name=resolved_model_name,
+                        chat_reasoning_level=resolved_reasoning_wire,
                         voice_tokens_input=(
                             voice.tokens_input if voice else 0
                         ),

--- a/smarter_dev/web/api_native/chat_conversations.py
+++ b/smarter_dev/web/api_native/chat_conversations.py
@@ -251,6 +251,7 @@ class ChatConversationController(Controller):
             chat_tokens_input=data.chat_tokens_input,
             chat_tokens_output=data.chat_tokens_output,
             chat_model_name=data.chat_model_name,
+            chat_reasoning_level=data.chat_reasoning_level,
             chat_cost_usd=chat_cost,
             voice_tokens_input=data.voice_tokens_input,
             voice_tokens_output=data.voice_tokens_output,
@@ -288,6 +289,7 @@ class ChatConversationController(Controller):
                     summarizer_tokens_input=ev.summarizer_tokens_input,
                     summarizer_tokens_output=ev.summarizer_tokens_output,
                     summarizer_model_name=ev.summarizer_model_name,
+                    summarizer_reasoning_level=ev.summarizer_reasoning_level,
                     summarizer_cost_usd=ev_cost,
                 )
             )

--- a/smarter_dev/web/api_native/schemas.py
+++ b/smarter_dev/web/api_native/schemas.py
@@ -685,6 +685,7 @@ class ChatAgentCompactionEventCreate(BaseAPIModel):
     summarizer_tokens_input: int = 0
     summarizer_tokens_output: int = 0
     summarizer_model_name: Optional[str] = None
+    summarizer_reasoning_level: Optional[str] = None
 
 
 class ChatAgentTurnCreate(BaseAPIModel):
@@ -699,6 +700,7 @@ class ChatAgentTurnCreate(BaseAPIModel):
     chat_tokens_input: int = 0
     chat_tokens_output: int = 0
     chat_model_name: Optional[str] = None
+    chat_reasoning_level: Optional[str] = None
     voice_tokens_input: int = 0
     voice_tokens_output: int = 0
     voice_model_name: Optional[str] = None

--- a/smarter_dev/web/models.py
+++ b/smarter_dev/web/models.py
@@ -4003,6 +4003,11 @@ class ChatAgentTurn(Base):
     chat_tokens_input: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     chat_tokens_output: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     chat_model_name: Mapped[Optional[str]] = mapped_column(String(80), nullable=True)
+    # ReasoningLevel wire value (e.g. "high") in effect for the chat model call,
+    # or NULL when the model has no reasoning knob / an ad-hoc model was used.
+    chat_reasoning_level: Mapped[str | None] = mapped_column(
+        String(16), nullable=True, default=None
+    )
     chat_cost_usd: Mapped[Decimal] = mapped_column(
         Numeric(10, 6), nullable=False, default=Decimal("0")
     )
@@ -4064,6 +4069,11 @@ class ChatAgentCompactionEvent(Base):
     summarizer_tokens_input: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     summarizer_tokens_output: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     summarizer_model_name: Mapped[Optional[str]] = mapped_column(String(80), nullable=True)
+    # ReasoningLevel wire value in effect for the summarizer call (the summarizer
+    # runs at a fixed level), or NULL when it has no reasoning knob configured.
+    summarizer_reasoning_level: Mapped[str | None] = mapped_column(
+        String(16), nullable=True, default=None
+    )
     summarizer_cost_usd: Mapped[Decimal] = mapped_column(
         Numeric(10, 6), nullable=False, default=Decimal("0")
     )

--- a/smarter_dev/web/usage_admin.py
+++ b/smarter_dev/web/usage_admin.py
@@ -16,7 +16,15 @@ from skrift.admin.helpers import get_admin_context
 from skrift.admin.navigation import ADMIN_NAV_TAG
 from skrift.auth.guards import Permission, auth_guard
 
+from smarter_dev.shared.model_catalog import ReasoningLevel
 from smarter_dev.web.models import ResearchSession, ScanServiceUsage
+from smarter_dev.web.usage_invoice import (
+    ChannelUsageLine,
+    InvoiceLine,
+    available_months,
+    channel_breakdown,
+    monthly_invoice,
+)
 
 # Bucket expressions keyed by granularity name.
 # Each returns a string label suitable for Chart.js x-axis.
@@ -48,6 +56,122 @@ def _build_filters(
     return filters
 
 
+_SOURCE_LABELS = {
+    "chat": "Chat",
+    "voice": "Voice",
+    "compaction": "Compaction",
+    "scan": "Scan research",
+    "scan_service": "Scan services",
+}
+
+_VALID_TABS = {"runs", "users", "service", "invoice", "channels"}
+
+
+def _reasoning_display(reasoning_level: str | None) -> str:
+    if reasoning_level is None:
+        return "—"
+    try:
+        return ReasoningLevel(reasoning_level).label
+    except ValueError:
+        return reasoning_level
+
+
+def _zero_token_totals() -> dict:
+    return {
+        "cost": Decimal("0"),
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_read_tokens": 0,
+        "cache_write_tokens": 0,
+    }
+
+
+def build_invoice_tree(lines: list[InvoiceLine]) -> tuple[list[dict], dict]:
+    """Group flat invoice lines into provider → model → reasoning rows.
+
+    Returns (providers, grand_totals) where each provider carries its own
+    subtotals and a cost-descending list of models, each model carrying its
+    subtotals and cost-descending reasoning/source rows.
+    """
+    providers_by_key: dict[str, dict] = {}
+    grand_totals = _zero_token_totals()
+
+    for line in lines:
+        provider = providers_by_key.setdefault(line.provider_key, {
+            "key": line.provider_key,
+            "label": line.provider_label,
+            **_zero_token_totals(),
+            "models": {},
+        })
+        model = provider["models"].setdefault(line.model_name, {
+            "name": line.model_name,
+            **_zero_token_totals(),
+            "rows": [],
+        })
+        model["rows"].append({
+            "reasoning": _reasoning_display(line.reasoning_level),
+            "source": _SOURCE_LABELS.get(line.source, line.source),
+            "input_tokens": line.input_tokens,
+            "output_tokens": line.output_tokens,
+            "cache_read_tokens": line.cache_read_tokens,
+            "cache_write_tokens": line.cache_write_tokens,
+            "cost": line.cost_usd,
+        })
+        for bucket in (model, provider, grand_totals):
+            bucket["cost"] += line.cost_usd
+            bucket["input_tokens"] += line.input_tokens
+            bucket["output_tokens"] += line.output_tokens
+            bucket["cache_read_tokens"] += line.cache_read_tokens
+            bucket["cache_write_tokens"] += line.cache_write_tokens
+
+    providers = sorted(
+        providers_by_key.values(), key=lambda p: p["cost"], reverse=True
+    )
+    for provider in providers:
+        provider["models"] = sorted(
+            provider["models"].values(), key=lambda m: m["cost"], reverse=True
+        )
+        for model in provider["models"]:
+            model["rows"].sort(key=lambda r: r["cost"], reverse=True)
+    return providers, grand_totals
+
+
+def build_channel_tree(lines: list[ChannelUsageLine]) -> list[dict]:
+    """Group flat channel usage lines into per-channel groups with subtotals."""
+    channels_by_key: dict[tuple, dict] = {}
+
+    for line in lines:
+        channel = channels_by_key.setdefault((line.guild_id, line.channel_id), {
+            "guild_id": line.guild_id,
+            "channel_id": line.channel_id,
+            "display_name": None,
+            "cost": Decimal("0"),
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "rows": [],
+        })
+        if line.channel_name and not channel["display_name"]:
+            channel["display_name"] = f"#{line.channel_name}"
+        channel["rows"].append({
+            "provider_label": line.provider_label,
+            "model_name": line.model_name,
+            "reasoning": _reasoning_display(line.reasoning_level),
+            "source": _SOURCE_LABELS.get(line.source, line.source),
+            "input_tokens": line.input_tokens,
+            "output_tokens": line.output_tokens,
+            "cost": line.cost_usd,
+        })
+        channel["cost"] += line.cost_usd
+        channel["input_tokens"] += line.input_tokens
+        channel["output_tokens"] += line.output_tokens
+
+    for channel in channels_by_key.values():
+        if not channel["display_name"]:
+            channel["display_name"] = channel["channel_id"] or "unknown channel"
+        channel["rows"].sort(key=lambda r: r["cost"], reverse=True)
+    return sorted(channels_by_key.values(), key=lambda c: c["cost"], reverse=True)
+
+
 class _DecimalEncoder(json.JSONEncoder):
     def default(self, o: object) -> object:
         if isinstance(o, Decimal):
@@ -74,6 +198,8 @@ class UsageAdminController(Controller):
         days: Optional[int] = 30,
         pipeline_mode: Optional[str] = None,
         granularity: Optional[str] = "day",
+        month: str | None = None,
+        tab: str | None = None,
     ) -> TemplateResponse:
         """Usage dashboard with individual runs, per-user aggregation, and cost chart."""
         ctx = await get_admin_context(request, db_session)
@@ -81,6 +207,21 @@ class UsageAdminController(Controller):
 
         if granularity not in _BUCKET_EXPR:
             granularity = "day"
+        active_tab = tab if tab in _VALID_TABS else "runs"
+
+        # ------------------------------------------------------------------
+        # Monthly invoice + per-channel breakdown
+        # ------------------------------------------------------------------
+        months = await available_months(db_session)
+        selected_month = month if month in months else (months[0] if months else None)
+        if selected_month:
+            invoice_lines = await monthly_invoice(db_session, selected_month)
+            channel_lines = await channel_breakdown(db_session, selected_month)
+        else:
+            invoice_lines = []
+            channel_lines = []
+        invoice_providers, invoice_totals = build_invoice_tree(invoice_lines)
+        channels = build_channel_tree(channel_lines)
 
         # ------------------------------------------------------------------
         # Tab 1: Individual runs (most recent 200)
@@ -221,6 +362,12 @@ class UsageAdminController(Controller):
                 "svc_agg_rows": svc_agg_rows,
                 "svc_total_cost": svc_total_cost,
                 "svc_total_invocations": svc_total_invocations,
+                "active_tab": active_tab,
+                "months": months,
+                "selected_month": selected_month,
+                "invoice_providers": invoice_providers,
+                "invoice_totals": invoice_totals,
+                "channels": channels,
                 **ctx,
             },
         )

--- a/smarter_dev/web/usage_invoice.py
+++ b/smarter_dev/web/usage_invoice.py
@@ -1,0 +1,589 @@
+"""Aggregation queries backing the admin LLM-usage "invoice" dashboard.
+
+Pure data layer: turns the four cost-bearing tables (chat turns, chat
+compaction events, research sessions, and internal scan-service runs) into
+flat, provider-labelled invoice lines for a given calendar month, plus a
+per-Discord-channel breakdown.
+
+Every query uses plain ``>= start`` / ``< end`` range predicates and
+``func.sum`` / ``func.coalesce`` grouping so it runs unchanged on SQLite
+(no ``date_trunc`` / ``to_char``). Provider identity is derived in Python
+from the stored model-name string.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from decimal import Decimal
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from smarter_dev.shared.model_catalog import MODEL_CATALOG
+from smarter_dev.web.models import (
+    ChatAgentCompactionEvent,
+    ChatAgentEngagement,
+    ChatAgentTurn,
+    ResearchSession,
+    ScanServiceUsage,
+)
+
+# ---------------------------------------------------------------------------
+# Provider identity
+# ---------------------------------------------------------------------------
+
+# Wire/pydantic-ai model-name prefix -> internal provider key.
+_PROVIDER_KEYS: dict[str, str] = {
+    "google-gla": "google",
+    "google": "google",
+    "openai": "openai",
+    "openai-responses": "openai",
+    "anthropic": "anthropic",
+    "digitalocean": "digitalocean",
+}
+
+# The chat/voice/summarizer buckets store flat provider-less wire ids
+# (e.g. "gpt-5.4"); the catalog knows which provider serves each of those.
+_PROVIDER_BY_FLAT_MODEL_ID: dict[str, str] = {
+    catalog_model.model_id: catalog_model.provider.value
+    for catalog_model in MODEL_CATALOG
+}
+
+# Provider key -> human display label.
+PROVIDER_LABELS: dict[str, str] = {
+    "google": "Google",
+    "openai": "OpenAI",
+    "anthropic": "Anthropic",
+    "digitalocean": "DigitalOcean",
+    "unknown": "Unknown",
+}
+
+
+def provider_key_from_model_name(model_name: str | None) -> str:
+    """Derive the provider key from a stored model-name string.
+
+    A ``"provider:model"`` name (research sessions) maps via its prefix.
+    A flat provider-less wire id (chat/voice/compaction/scan-service
+    buckets) maps via the model catalog. Anything unrecognised is
+    ``"unknown"``.
+    """
+    if not model_name:
+        return "unknown"
+    if ":" in model_name:
+        prefix = model_name.split(":", 1)[0]
+        return _PROVIDER_KEYS.get(prefix, "unknown")
+    return _PROVIDER_BY_FLAT_MODEL_ID.get(model_name, "unknown")
+
+
+def bare_model_name(model_name: str | None) -> str:
+    """Strip the ``"provider:"`` prefix from a model name, if present."""
+    if not model_name:
+        return "unknown"
+    if ":" in model_name:
+        return model_name.split(":", 1)[1]
+    return model_name
+
+
+# ---------------------------------------------------------------------------
+# Month handling
+# ---------------------------------------------------------------------------
+
+
+def month_bounds(month: str) -> tuple[datetime, datetime]:
+    """Parse ``"YYYY-MM"`` into a tz-aware UTC half-open ``[start, end)`` range.
+
+    ``end`` is the first instant of the following month. Raises ``ValueError``
+    on any malformed input (fail fast).
+    """
+    parts = month.split("-")
+    if len(parts) != 2 or len(parts[0]) != 4 or len(parts[1]) != 2:
+        raise ValueError(f"month must be 'YYYY-MM', got {month!r}")
+    year = int(parts[0])  # int() raises ValueError on non-numeric parts
+    month_number = int(parts[1])
+    if not 1 <= month_number <= 12:
+        raise ValueError(f"month out of range: {month!r}")
+    start = datetime(year, month_number, 1, tzinfo=timezone.utc)
+    if month_number == 12:
+        end = datetime(year + 1, 1, 1, tzinfo=timezone.utc)
+    else:
+        end = datetime(year, month_number + 1, 1, tzinfo=timezone.utc)
+    return start, end
+
+
+def _month_label(moment: datetime) -> str:
+    return f"{moment.year:04d}-{moment.month:02d}"
+
+
+async def available_months(db_session: AsyncSession) -> list[str]:
+    """Distinct ``"YYYY-MM"`` labels, newest first.
+
+    Spans from the earliest record across the four cost tables up to the
+    current UTC month (inclusive). Computed portably: min timestamps come
+    from the database, the month list is generated in Python so it works on
+    SQLite. When no records exist, returns just the current month.
+    """
+    earliest_columns = (
+        ChatAgentTurn.started_at,
+        ChatAgentCompactionEvent.created_at,
+        ResearchSession.created_at,
+        ScanServiceUsage.created_at,
+    )
+    earliest: datetime | None = None
+    for column in earliest_columns:
+        # Each table queried separately: a single cross-table SELECT would
+        # null every min() as soon as one table is empty.
+        table_min = await db_session.scalar(select(func.min(column)))
+        if table_min is None:
+            continue
+        if table_min.tzinfo is None:
+            table_min = table_min.replace(tzinfo=timezone.utc)
+        if earliest is None or table_min < earliest:
+            earliest = table_min
+
+    now = datetime.now(timezone.utc)
+    if earliest is None:
+        return [_month_label(now)]
+
+    months: list[str] = []
+    year, month = now.year, now.month
+    while (year, month) >= (earliest.year, earliest.month):
+        months.append(f"{year:04d}-{month:02d}")
+        if month == 1:
+            year, month = year - 1, 12
+        else:
+            month -= 1
+    return months
+
+
+# ---------------------------------------------------------------------------
+# Invoice lines
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class InvoiceLine:
+    """One aggregated (model, reasoning, source) row for a month."""
+
+    provider_key: str
+    provider_label: str
+    model_name: str
+    reasoning_level: str | None
+    source: str
+    input_tokens: int
+    output_tokens: int
+    cache_read_tokens: int
+    cache_write_tokens: int
+    cost_usd: Decimal
+
+
+@dataclass(frozen=True)
+class ChannelUsageLine:
+    """One aggregated per-channel (model, reasoning, source) row for a month."""
+
+    guild_id: str | None
+    channel_id: str | None
+    channel_name: str | None
+    provider_key: str
+    provider_label: str
+    model_name: str
+    reasoning_level: str | None
+    source: str
+    input_tokens: int
+    output_tokens: int
+    cost_usd: Decimal
+
+
+def _invoice_line(
+    *,
+    raw_model_name: str | None,
+    reasoning_level: str | None,
+    source: str,
+    input_tokens: int,
+    output_tokens: int,
+    cache_read_tokens: int,
+    cache_write_tokens: int,
+    cost_usd: Decimal,
+) -> InvoiceLine:
+    provider_key = provider_key_from_model_name(raw_model_name)
+    return InvoiceLine(
+        provider_key=provider_key,
+        provider_label=PROVIDER_LABELS[provider_key],
+        model_name=bare_model_name(raw_model_name),
+        reasoning_level=reasoning_level,
+        source=source,
+        input_tokens=int(input_tokens),
+        output_tokens=int(output_tokens),
+        cache_read_tokens=int(cache_read_tokens),
+        cache_write_tokens=int(cache_write_tokens),
+        cost_usd=cost_usd,
+    )
+
+
+def _channel_line(
+    *,
+    guild_id: str | None,
+    channel_id: str | None,
+    channel_name: str | None,
+    raw_model_name: str | None,
+    reasoning_level: str | None,
+    source: str,
+    input_tokens: int,
+    output_tokens: int,
+    cost_usd: Decimal,
+) -> ChannelUsageLine:
+    provider_key = provider_key_from_model_name(raw_model_name)
+    return ChannelUsageLine(
+        guild_id=guild_id,
+        channel_id=channel_id,
+        channel_name=channel_name,
+        provider_key=provider_key,
+        provider_label=PROVIDER_LABELS[provider_key],
+        model_name=bare_model_name(raw_model_name),
+        reasoning_level=reasoning_level,
+        source=source,
+        input_tokens=int(input_tokens),
+        output_tokens=int(output_tokens),
+        cost_usd=cost_usd,
+    )
+
+
+def _tokens(column):
+    return func.coalesce(func.sum(column), 0)
+
+
+def _cost(column):
+    return func.coalesce(func.sum(column), Decimal("0"))
+
+
+async def monthly_invoice(db_session: AsyncSession, month: str) -> list[InvoiceLine]:
+    """Aggregate every cost source for *month* into flat invoice lines.
+
+    Each source is grouped by ``(model_name, reasoning_level)`` (voice and
+    the scan sources have no reasoning knob, so their reasoning level is
+    always ``None``). Lines are returned sorted by ``cost_usd`` descending.
+    """
+    start, end = month_bounds(month)
+    lines: list[InvoiceLine] = []
+
+    # -- chat bucket -------------------------------------------------------
+    chat_stmt = (
+        select(
+            ChatAgentTurn.chat_model_name,
+            ChatAgentTurn.chat_reasoning_level,
+            _tokens(ChatAgentTurn.chat_tokens_input).label("input_tokens"),
+            _tokens(ChatAgentTurn.chat_tokens_output).label("output_tokens"),
+            _cost(ChatAgentTurn.chat_cost_usd).label("cost_usd"),
+        )
+        .where(ChatAgentTurn.started_at >= start)
+        .where(ChatAgentTurn.started_at < end)
+        .group_by(ChatAgentTurn.chat_model_name, ChatAgentTurn.chat_reasoning_level)
+    )
+    for row in (await db_session.execute(chat_stmt)).all():
+        lines.append(
+            _invoice_line(
+                raw_model_name=row.chat_model_name,
+                reasoning_level=row.chat_reasoning_level,
+                source="chat",
+                input_tokens=row.input_tokens,
+                output_tokens=row.output_tokens,
+                cache_read_tokens=0,
+                cache_write_tokens=0,
+                cost_usd=row.cost_usd,
+            )
+        )
+
+    # -- voice bucket ------------------------------------------------------
+    # A turn only belongs to the voice source when a voice call actually
+    # happened, which is exactly when voice_model_name was recorded.
+    voice_stmt = (
+        select(
+            ChatAgentTurn.voice_model_name,
+            _tokens(ChatAgentTurn.voice_tokens_input).label("input_tokens"),
+            _tokens(ChatAgentTurn.voice_tokens_output).label("output_tokens"),
+            _cost(ChatAgentTurn.voice_cost_usd).label("cost_usd"),
+        )
+        .where(ChatAgentTurn.started_at >= start)
+        .where(ChatAgentTurn.started_at < end)
+        .where(ChatAgentTurn.voice_model_name.is_not(None))
+        .group_by(ChatAgentTurn.voice_model_name)
+    )
+    for row in (await db_session.execute(voice_stmt)).all():
+        lines.append(
+            _invoice_line(
+                raw_model_name=row.voice_model_name,
+                reasoning_level=None,
+                source="voice",
+                input_tokens=row.input_tokens,
+                output_tokens=row.output_tokens,
+                cache_read_tokens=0,
+                cache_write_tokens=0,
+                cost_usd=row.cost_usd,
+            )
+        )
+
+    # -- compaction bucket -------------------------------------------------
+    compaction_stmt = (
+        select(
+            ChatAgentCompactionEvent.summarizer_model_name,
+            ChatAgentCompactionEvent.summarizer_reasoning_level,
+            _tokens(ChatAgentCompactionEvent.summarizer_tokens_input).label("input_tokens"),
+            _tokens(ChatAgentCompactionEvent.summarizer_tokens_output).label("output_tokens"),
+            _cost(ChatAgentCompactionEvent.summarizer_cost_usd).label("cost_usd"),
+        )
+        .where(ChatAgentCompactionEvent.created_at >= start)
+        .where(ChatAgentCompactionEvent.created_at < end)
+        .group_by(
+            ChatAgentCompactionEvent.summarizer_model_name,
+            ChatAgentCompactionEvent.summarizer_reasoning_level,
+        )
+    )
+    for row in (await db_session.execute(compaction_stmt)).all():
+        lines.append(
+            _invoice_line(
+                raw_model_name=row.summarizer_model_name,
+                reasoning_level=row.summarizer_reasoning_level,
+                source="compaction",
+                input_tokens=row.input_tokens,
+                output_tokens=row.output_tokens,
+                cache_read_tokens=0,
+                cache_write_tokens=0,
+                cost_usd=row.cost_usd,
+            )
+        )
+
+    # -- scan research bucket ---------------------------------------------
+    research_stmt = (
+        select(
+            ResearchSession.model_name,
+            _tokens(ResearchSession.input_tokens).label("input_tokens"),
+            _tokens(ResearchSession.output_tokens).label("output_tokens"),
+            _tokens(ResearchSession.cache_read_tokens).label("cache_read_tokens"),
+            _tokens(ResearchSession.cache_write_tokens).label("cache_write_tokens"),
+            _cost(ResearchSession.cost_usd).label("cost_usd"),
+        )
+        .where(ResearchSession.created_at >= start)
+        .where(ResearchSession.created_at < end)
+        .group_by(ResearchSession.model_name)
+    )
+    for row in (await db_session.execute(research_stmt)).all():
+        lines.append(
+            _invoice_line(
+                raw_model_name=row.model_name,
+                reasoning_level=None,
+                source="scan",
+                input_tokens=row.input_tokens,
+                output_tokens=row.output_tokens,
+                cache_read_tokens=row.cache_read_tokens,
+                cache_write_tokens=row.cache_write_tokens,
+                cost_usd=row.cost_usd,
+            )
+        )
+
+    # -- scan internal-service bucket -------------------------------------
+    service_stmt = (
+        select(
+            ScanServiceUsage.model_name,
+            _tokens(ScanServiceUsage.input_tokens).label("input_tokens"),
+            _tokens(ScanServiceUsage.output_tokens).label("output_tokens"),
+            _tokens(ScanServiceUsage.cache_read_tokens).label("cache_read_tokens"),
+            _tokens(ScanServiceUsage.cache_write_tokens).label("cache_write_tokens"),
+            _cost(ScanServiceUsage.cost_usd).label("cost_usd"),
+        )
+        .where(ScanServiceUsage.created_at >= start)
+        .where(ScanServiceUsage.created_at < end)
+        .group_by(ScanServiceUsage.model_name)
+    )
+    for row in (await db_session.execute(service_stmt)).all():
+        lines.append(
+            _invoice_line(
+                raw_model_name=row.model_name,
+                reasoning_level=None,
+                source="scan_service",
+                input_tokens=row.input_tokens,
+                output_tokens=row.output_tokens,
+                cache_read_tokens=row.cache_read_tokens,
+                cache_write_tokens=row.cache_write_tokens,
+                cost_usd=row.cost_usd,
+            )
+        )
+
+    return sorted(lines, key=lambda line: line.cost_usd, reverse=True)
+
+
+async def channel_breakdown(
+    db_session: AsyncSession, month: str
+) -> list[ChannelUsageLine]:
+    """Per-Discord-channel usage lines for *month*, sorted by cost descending.
+
+    Chat, voice, and compaction rows are joined through the engagement for
+    channel identity (the channel name is the most-recent non-null snapshot).
+    Research sessions carry their own ``guild_id`` / ``channel_id`` but have
+    no denormalised channel name. Scan-service rows have no channel and are
+    intentionally excluded.
+    """
+    start, end = month_bounds(month)
+    lines: list[ChannelUsageLine] = []
+
+    channel_name = func.max(ChatAgentEngagement.channel_name).label("channel_name")
+
+    # -- chat bucket -------------------------------------------------------
+    chat_stmt = (
+        select(
+            ChatAgentEngagement.guild_id,
+            ChatAgentEngagement.channel_id,
+            channel_name,
+            ChatAgentTurn.chat_model_name,
+            ChatAgentTurn.chat_reasoning_level,
+            _tokens(ChatAgentTurn.chat_tokens_input).label("input_tokens"),
+            _tokens(ChatAgentTurn.chat_tokens_output).label("output_tokens"),
+            _cost(ChatAgentTurn.chat_cost_usd).label("cost_usd"),
+        )
+        .select_from(ChatAgentTurn)
+        .join(
+            ChatAgentEngagement,
+            ChatAgentTurn.engagement_id == ChatAgentEngagement.id,
+        )
+        .where(ChatAgentTurn.started_at >= start)
+        .where(ChatAgentTurn.started_at < end)
+        .group_by(
+            ChatAgentEngagement.guild_id,
+            ChatAgentEngagement.channel_id,
+            ChatAgentTurn.chat_model_name,
+            ChatAgentTurn.chat_reasoning_level,
+        )
+    )
+    for row in (await db_session.execute(chat_stmt)).all():
+        lines.append(
+            _channel_line(
+                guild_id=row.guild_id,
+                channel_id=row.channel_id,
+                channel_name=row.channel_name,
+                raw_model_name=row.chat_model_name,
+                reasoning_level=row.chat_reasoning_level,
+                source="chat",
+                input_tokens=row.input_tokens,
+                output_tokens=row.output_tokens,
+                cost_usd=row.cost_usd,
+            )
+        )
+
+    # -- voice bucket ------------------------------------------------------
+    voice_stmt = (
+        select(
+            ChatAgentEngagement.guild_id,
+            ChatAgentEngagement.channel_id,
+            channel_name,
+            ChatAgentTurn.voice_model_name,
+            _tokens(ChatAgentTurn.voice_tokens_input).label("input_tokens"),
+            _tokens(ChatAgentTurn.voice_tokens_output).label("output_tokens"),
+            _cost(ChatAgentTurn.voice_cost_usd).label("cost_usd"),
+        )
+        .select_from(ChatAgentTurn)
+        .join(
+            ChatAgentEngagement,
+            ChatAgentTurn.engagement_id == ChatAgentEngagement.id,
+        )
+        .where(ChatAgentTurn.started_at >= start)
+        .where(ChatAgentTurn.started_at < end)
+        .where(ChatAgentTurn.voice_model_name.is_not(None))
+        .group_by(
+            ChatAgentEngagement.guild_id,
+            ChatAgentEngagement.channel_id,
+            ChatAgentTurn.voice_model_name,
+        )
+    )
+    for row in (await db_session.execute(voice_stmt)).all():
+        lines.append(
+            _channel_line(
+                guild_id=row.guild_id,
+                channel_id=row.channel_id,
+                channel_name=row.channel_name,
+                raw_model_name=row.voice_model_name,
+                reasoning_level=None,
+                source="voice",
+                input_tokens=row.input_tokens,
+                output_tokens=row.output_tokens,
+                cost_usd=row.cost_usd,
+            )
+        )
+
+    # -- compaction bucket -------------------------------------------------
+    compaction_stmt = (
+        select(
+            ChatAgentEngagement.guild_id,
+            ChatAgentEngagement.channel_id,
+            channel_name,
+            ChatAgentCompactionEvent.summarizer_model_name,
+            ChatAgentCompactionEvent.summarizer_reasoning_level,
+            _tokens(ChatAgentCompactionEvent.summarizer_tokens_input).label("input_tokens"),
+            _tokens(ChatAgentCompactionEvent.summarizer_tokens_output).label("output_tokens"),
+            _cost(ChatAgentCompactionEvent.summarizer_cost_usd).label("cost_usd"),
+        )
+        .select_from(ChatAgentCompactionEvent)
+        .join(
+            ChatAgentTurn,
+            ChatAgentCompactionEvent.turn_id == ChatAgentTurn.id,
+        )
+        .join(
+            ChatAgentEngagement,
+            ChatAgentTurn.engagement_id == ChatAgentEngagement.id,
+        )
+        .where(ChatAgentCompactionEvent.created_at >= start)
+        .where(ChatAgentCompactionEvent.created_at < end)
+        .group_by(
+            ChatAgentEngagement.guild_id,
+            ChatAgentEngagement.channel_id,
+            ChatAgentCompactionEvent.summarizer_model_name,
+            ChatAgentCompactionEvent.summarizer_reasoning_level,
+        )
+    )
+    for row in (await db_session.execute(compaction_stmt)).all():
+        lines.append(
+            _channel_line(
+                guild_id=row.guild_id,
+                channel_id=row.channel_id,
+                channel_name=row.channel_name,
+                raw_model_name=row.summarizer_model_name,
+                reasoning_level=row.summarizer_reasoning_level,
+                source="compaction",
+                input_tokens=row.input_tokens,
+                output_tokens=row.output_tokens,
+                cost_usd=row.cost_usd,
+            )
+        )
+
+    # -- scan research bucket ---------------------------------------------
+    research_stmt = (
+        select(
+            ResearchSession.guild_id,
+            ResearchSession.channel_id,
+            ResearchSession.model_name,
+            _tokens(ResearchSession.input_tokens).label("input_tokens"),
+            _tokens(ResearchSession.output_tokens).label("output_tokens"),
+            _cost(ResearchSession.cost_usd).label("cost_usd"),
+        )
+        .where(ResearchSession.created_at >= start)
+        .where(ResearchSession.created_at < end)
+        .group_by(
+            ResearchSession.guild_id,
+            ResearchSession.channel_id,
+            ResearchSession.model_name,
+        )
+    )
+    for row in (await db_session.execute(research_stmt)).all():
+        lines.append(
+            _channel_line(
+                guild_id=row.guild_id,
+                channel_id=row.channel_id,
+                channel_name=None,
+                raw_model_name=row.model_name,
+                reasoning_level=None,
+                source="scan",
+                input_tokens=row.input_tokens,
+                output_tokens=row.output_tokens,
+                cost_usd=row.cost_usd,
+            )
+        )
+
+    return sorted(lines, key=lambda line: line.cost_usd, reverse=True)

--- a/templates/admin/usage.html
+++ b/templates/admin/usage.html
@@ -33,6 +33,13 @@
 .usage-td-query { max-width: 280px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .usage-td-model { font-size: .85em; }
 .usage-status-error { color: #da3633; }
+.usage-month-form { display: flex; gap: .75rem; align-items: center; margin: 1rem 0; }
+.usage-td-num { text-align: right; white-space: nowrap; font-variant-numeric: tabular-nums; }
+.usage-invoice-summary { margin: 1rem 0; opacity: .8; }
+.usage-invoice-panel { margin-bottom: 1.5rem; }
+.usage-invoice-panel-head { display: flex; justify-content: space-between; align-items: baseline; gap: 1rem; }
+.usage-invoice-subtotal { white-space: nowrap; font-variant-numeric: tabular-nums; }
+.usage-invoice-model-row td { font-weight: 600; background: rgba(255,255,255,.04); }
 </style>
 
 <hgroup>
@@ -93,13 +100,15 @@
 {# ── Tabs ────────────────────────────────────────────────────────── #}
 <div class="usage-tabs-wrap">
     <div class="usage-tab-bar">
-        <button class="usage-tab active" data-tab="runs">Individual Runs</button>
-        <button class="usage-tab" data-tab="users">By User</button>
-        <button class="usage-tab" data-tab="service">Service Costs</button>
+        <button class="usage-tab {% if active_tab == 'runs' %}active{% endif %}" data-tab="runs">Individual Runs</button>
+        <button class="usage-tab {% if active_tab == 'users' %}active{% endif %}" data-tab="users">By User</button>
+        <button class="usage-tab {% if active_tab == 'service' %}active{% endif %}" data-tab="service">Service Costs</button>
+        <button class="usage-tab {% if active_tab == 'invoice' %}active{% endif %}" data-tab="invoice">Invoice</button>
+        <button class="usage-tab {% if active_tab == 'channels' %}active{% endif %}" data-tab="channels">By Channel</button>
     </div>
 
     {# ── Tab: Individual Runs ────────────────────────────────────── #}
-    <div id="tab-runs" class="usage-tab-content">
+    <div id="tab-runs" class="usage-tab-content {% if active_tab != 'runs' %}hidden{% endif %}">
         {% if runs %}
         <table class="sk-admin-table">
             <thead>
@@ -153,7 +162,7 @@
     </div>
 
     {# ── Tab: By User ────────────────────────────────────────────── #}
-    <div id="tab-users" class="usage-tab-content hidden">
+    <div id="tab-users" class="usage-tab-content {% if active_tab != 'users' %}hidden{% endif %}">
         {% if agg_rows %}
         <table class="sk-admin-table">
             <thead>
@@ -195,7 +204,7 @@
     </div>
 
     {# ── Tab: Service Costs ──────────────────────────────────────── #}
-    <div id="tab-service" class="usage-tab-content hidden">
+    <div id="tab-service" class="usage-tab-content {% if active_tab != 'service' %}hidden{% endif %}">
         <p style="margin: 1rem 0; opacity: .7;">
             Internal service costs (profiler, etc.) &mdash;
             {{ "{:,}".format(svc_total_invocations) }} invocation{{ 's' if svc_total_invocations != 1 else '' }},
@@ -266,6 +275,143 @@
         </div>
         {% else %}
         <p class="sk-no-items">No service usage recorded yet.</p>
+        {% endif %}
+    </div>
+
+    {# ── Tab: Invoice ────────────────────────────────────────────── #}
+    <div id="tab-invoice" class="usage-tab-content {% if active_tab != 'invoice' %}hidden{% endif %}">
+        <form method="get" action="/admin/usage" class="usage-month-form">
+            <input type="hidden" name="tab" value="invoice">
+            <label for="month-invoice"><strong>Billing month</strong></label>
+            <select name="month" id="month-invoice">
+                {% for m in months %}
+                <option value="{{ m }}" {% if m == selected_month %}selected{% endif %}>{{ m }}</option>
+                {% endfor %}
+            </select>
+            <button type="submit" class="sk-btn-outline sk-btn-small">Apply</button>
+        </form>
+
+        {% if invoice_providers %}
+        <p class="usage-invoice-summary">
+            {{ selected_month }} &middot;
+            {{ "{:,}".format(invoice_totals.input_tokens) }} input &middot;
+            {{ "{:,}".format(invoice_totals.output_tokens) }} output &middot;
+            {{ "{:,}".format(invoice_totals.cache_read_tokens) }} cache read &middot;
+            {{ "{:,}".format(invoice_totals.cache_write_tokens) }} cache write tokens &middot;
+            <strong>${{ "{:.4f}".format(invoice_totals.cost) }} total</strong>
+        </p>
+
+        {% for provider in invoice_providers %}
+        <div class="sk-panel usage-invoice-panel">
+            <div class="sk-panel-head usage-invoice-panel-head">
+                <strong>{{ provider.label }}</strong>
+                <span class="usage-invoice-subtotal">${{ "{:.4f}".format(provider.cost) }}</span>
+            </div>
+            <div class="sk-panel-body" style="padding: 0;">
+                <table class="sk-admin-table">
+                    <thead>
+                        <tr>
+                            <th>Model</th>
+                            <th>Reasoning</th>
+                            <th>Source</th>
+                            <th class="usage-td-num">Input</th>
+                            <th class="usage-td-num">Output</th>
+                            <th class="usage-td-num">Cache Read</th>
+                            <th class="usage-td-num">Cache Write</th>
+                            <th class="usage-td-num">Cost</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for model in provider.models %}
+                        <tr class="usage-invoice-model-row">
+                            <td class="usage-td-model" title="{{ model.name }}">{{ model.name }}</td>
+                            <td></td>
+                            <td></td>
+                            <td class="usage-td-num">{{ "{:,}".format(model.input_tokens) }}</td>
+                            <td class="usage-td-num">{{ "{:,}".format(model.output_tokens) }}</td>
+                            <td class="usage-td-num">{{ "{:,}".format(model.cache_read_tokens) }}</td>
+                            <td class="usage-td-num">{{ "{:,}".format(model.cache_write_tokens) }}</td>
+                            <td class="usage-td-num">${{ "{:.4f}".format(model.cost) }}</td>
+                        </tr>
+                        {% for row in model.rows %}
+                        <tr>
+                            <td></td>
+                            <td>{{ row.reasoning }}</td>
+                            <td><span class="sk-pill">{{ row.source }}</span></td>
+                            <td class="usage-td-num">{{ "{:,}".format(row.input_tokens) }}</td>
+                            <td class="usage-td-num">{{ "{:,}".format(row.output_tokens) }}</td>
+                            <td class="usage-td-num">{{ "{:,}".format(row.cache_read_tokens) }}</td>
+                            <td class="usage-td-num">{{ "{:,}".format(row.cache_write_tokens) }}</td>
+                            <td class="usage-td-num">${{ "{:.4f}".format(row.cost) }}</td>
+                        </tr>
+                        {% endfor %}
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        {% endfor %}
+        {% else %}
+        <p class="sk-no-items">No LLM usage recorded for {{ selected_month or 'this month' }}.</p>
+        {% endif %}
+    </div>
+
+    {# ── Tab: By Channel ─────────────────────────────────────────── #}
+    <div id="tab-channels" class="usage-tab-content {% if active_tab != 'channels' %}hidden{% endif %}">
+        <form method="get" action="/admin/usage" class="usage-month-form">
+            <input type="hidden" name="tab" value="channels">
+            <label for="month-channels"><strong>Billing month</strong></label>
+            <select name="month" id="month-channels">
+                {% for m in months %}
+                <option value="{{ m }}" {% if m == selected_month %}selected{% endif %}>{{ m }}</option>
+                {% endfor %}
+            </select>
+            <button type="submit" class="sk-btn-outline sk-btn-small">Apply</button>
+        </form>
+
+        {% if channels %}
+        {% for channel in channels %}
+        <div class="sk-panel usage-invoice-panel">
+            <div class="sk-panel-head usage-invoice-panel-head">
+                <strong>{{ channel.display_name }}</strong>
+                <span class="usage-invoice-subtotal">
+                    {{ "{:,}".format(channel.input_tokens) }} in &middot;
+                    {{ "{:,}".format(channel.output_tokens) }} out &middot;
+                    ${{ "{:.4f}".format(channel.cost) }}
+                </span>
+            </div>
+            <div class="sk-panel-body" style="padding: 0;">
+                <table class="sk-admin-table">
+                    <thead>
+                        <tr>
+                            <th>Provider</th>
+                            <th>Model</th>
+                            <th>Reasoning</th>
+                            <th>Source</th>
+                            <th class="usage-td-num">Input</th>
+                            <th class="usage-td-num">Output</th>
+                            <th class="usage-td-num">Cost</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for row in channel.rows %}
+                        <tr>
+                            <td>{{ row.provider_label }}</td>
+                            <td class="usage-td-model" title="{{ row.model_name }}">{{ row.model_name }}</td>
+                            <td>{{ row.reasoning }}</td>
+                            <td><span class="sk-pill">{{ row.source }}</span></td>
+                            <td class="usage-td-num">{{ "{:,}".format(row.input_tokens) }}</td>
+                            <td class="usage-td-num">{{ "{:,}".format(row.output_tokens) }}</td>
+                            <td class="usage-td-num">${{ "{:.4f}".format(row.cost) }}</td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        {% endfor %}
+        {% else %}
+        <p class="sk-no-items">No channel usage recorded for {{ selected_month or 'this month' }}.</p>
         {% endif %}
     </div>
 </div>

--- a/tests/bot/agents/test_chat_agent_override.py
+++ b/tests/bot/agents/test_chat_agent_override.py
@@ -6,6 +6,7 @@ import pytest
 
 import smarter_dev.bot.agents.chat_agent as chat_agent
 from smarter_dev.bot.agents.chat_agent import get_chat_agent
+from smarter_dev.bot.agents.chat_agent import resolved_reasoning_level
 
 
 @pytest.fixture(autouse=True)
@@ -66,3 +67,34 @@ def test_none_resolves_to_env_default_and_is_singleton_equivalent(monkeypatch):
     explicit_default = get_chat_agent(chat_agent.DEFAULT_MODEL)
     assert default_first is default_second
     assert default_first is explicit_default
+
+
+def test_resolved_reasoning_level_returns_supported_choice():
+    # gpt-5.4 supports "high" — an explicit supported pick passes through.
+    assert resolved_reasoning_level("gpt-5.4", "high") == "high"
+
+
+def test_resolved_reasoning_level_clamps_unsupported_choice():
+    # Gemini's thinking_level tops out at "high"; "max" clamps down to it.
+    assert resolved_reasoning_level("gemini-3.1-flash-lite", "max") == "high"
+
+
+def test_resolved_reasoning_level_falls_back_to_model_default():
+    # No explicit choice -> the catalog model's default_reasoning (MEDIUM here).
+    assert resolved_reasoning_level("gpt-5.4", None) == "medium"
+
+
+def test_resolved_reasoning_level_none_for_model_without_knob():
+    # Kimi K2.6 has no reasoning ladder -> always None.
+    assert resolved_reasoning_level("kimi-k2.6", "high") is None
+
+
+def test_resolved_reasoning_level_none_for_adhoc_model():
+    # A non-catalog ad-hoc model id maps to no ReasoningLevel.
+    assert resolved_reasoning_level("some-unlisted-model", "high") is None
+
+
+def test_resolved_reasoning_level_default_model_when_id_omitted(monkeypatch):
+    # None model id resolves to the env/default (a catalog Gemini, default MEDIUM).
+    monkeypatch.delenv(chat_agent.MODEL_ENV_VAR, raising=False)
+    assert resolved_reasoning_level(None, None) == "medium"

--- a/tests/bot/services/test_chat_conversation_persistence.py
+++ b/tests/bot/services/test_chat_conversation_persistence.py
@@ -125,6 +125,7 @@ async def test_persist_turn_serialises_compaction_events_and_delta():
         summarizer_tokens_input=42,
         summarizer_tokens_output=7,
         summarizer_model_name="stub-model",
+        summarizer_reasoning_level="low",
     )
     await ccp.persist_turn(
         bot=bot,
@@ -139,6 +140,7 @@ async def test_persist_turn_serialises_compaction_events_and_delta():
         chat_tokens_input=500,
         chat_tokens_output=100,
         chat_model_name="gemini-3.1-flash-lite-preview",
+        chat_reasoning_level="high",
         voice_tokens_input=80,
         voice_tokens_output=20,
         voice_model_name="gemini-2.5-flash-preview-tts",
@@ -154,6 +156,7 @@ async def test_persist_turn_serialises_compaction_events_and_delta():
     assert body["turn_kind"] == "followup"
     assert body["output_kind"] == "send_response"
     assert body["chat_tokens_input"] == 500
+    assert body["chat_reasoning_level"] == "high"
     assert body["voice_tokens_input"] == 80
     assert body["voice_sent_ok"] is True
     assert body["model_messages_delta"] == []
@@ -162,6 +165,31 @@ async def test_persist_turn_serialises_compaction_events_and_delta():
     assert posted_event["event_kind"] == "user_prompt"
     assert posted_event["original_chars"] == 12000
     assert posted_event["summarizer_tokens_input"] == 42
+    assert posted_event["summarizer_reasoning_level"] == "low"
+
+
+@pytest.mark.asyncio
+async def test_persist_turn_defaults_reasoning_level_to_none():
+    post = AsyncMock(return_value=SimpleNamespace(status_code=201))
+    bot = _bot_with_api_client(post)
+    await ccp.persist_turn(
+        bot=bot,
+        engagement_id=uuid4(),
+        request_id="abcd1234",
+        turn_kind="initial",
+        output_kind="no_response",
+        triggering_messages=[],
+        agent_output={"kind": "no_response", "topic": "x"},
+        new_model_messages=[],
+        duration_ms=10,
+        chat_tokens_input=0,
+        chat_tokens_output=0,
+        chat_model_name=None,
+    )
+    post.assert_awaited_once()
+    _, kwargs = post.call_args
+    # Field is always present so an unset value round-trips as an explicit None.
+    assert kwargs["json_data"]["chat_reasoning_level"] is None
 
 
 @pytest.mark.asyncio

--- a/tests/web/test_api_native/test_chat_conversations.py
+++ b/tests/web/test_api_native/test_chat_conversations.py
@@ -178,6 +178,7 @@ class TestCreateTurn:
                 "agent_output": {"topic": "greetings", "notes": "friendly"},
                 "chat_tokens_input": 100,
                 "chat_tokens_output": 50,
+                "chat_reasoning_level": "high",
             },
         )
         assert response.status_code == 201
@@ -190,12 +191,35 @@ class TestCreateTurn:
 
         turns = (await session.execute(select(ChatAgentTurn))).scalars().all()
         assert len(turns) == 1
+        assert turns[0].chat_reasoning_level == "high"
 
         await session.refresh(engagement)
         assert engagement.total_chat_tokens_input == 100
         assert engagement.total_chat_tokens_output == 50
         assert engagement.last_topic == "greetings"
         assert engagement.last_notes == "friendly"
+
+    async def test_reasoning_level_defaults_to_null_when_absent(
+        self, client: AsyncClient, session
+    ):
+        engagement = await _seed_engagement(session)
+
+        response = await client.post(
+            "/api/chat-conversations/turns",
+            json={
+                "engagement_id": str(engagement.id),
+                "request_id": "req-noreason",
+                "turn_kind": "initial",
+                "output_kind": "no_response",
+                "triggering_messages": [],
+                "agent_output": {},
+            },
+        )
+        assert response.status_code == 201
+
+        turns = (await session.execute(select(ChatAgentTurn))).scalars().all()
+        assert len(turns) == 1
+        assert turns[0].chat_reasoning_level is None
 
     async def test_persists_compaction_events(self, client: AsyncClient, session):
         engagement = await _seed_engagement(session)
@@ -217,6 +241,7 @@ class TestCreateTurn:
                         "summary": "a",
                         "original_chars": 4,
                         "summary_chars": 1,
+                        "summarizer_reasoning_level": "low",
                     }
                 ],
             },
@@ -228,6 +253,7 @@ class TestCreateTurn:
         ).scalars().all()
         assert len(events) == 1
         assert events[0].chars_saved == 3
+        assert events[0].summarizer_reasoning_level == "low"
 
     async def test_captures_blog_topic_candidates(self, client: AsyncClient, session):
         engagement = await _seed_engagement(session)

--- a/tests/web/usage_admin_invoice_test.py
+++ b/tests/web/usage_admin_invoice_test.py
@@ -1,0 +1,167 @@
+"""Tests for the invoice/channel tree builders behind the admin usage dashboard."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from smarter_dev.web.usage_admin import build_channel_tree, build_invoice_tree
+from smarter_dev.web.usage_invoice import ChannelUsageLine, InvoiceLine
+
+
+def _invoice_line(**overrides) -> InvoiceLine:
+    defaults = dict(
+        provider_key="openai",
+        provider_label="OpenAI",
+        model_name="gpt-5.4",
+        reasoning_level="high",
+        source="chat",
+        input_tokens=1000,
+        output_tokens=200,
+        cache_read_tokens=0,
+        cache_write_tokens=0,
+        cost_usd=Decimal("0.010000"),
+    )
+    defaults.update(overrides)
+    return InvoiceLine(**defaults)
+
+
+def _channel_line(**overrides) -> ChannelUsageLine:
+    defaults = dict(
+        guild_id="g1",
+        channel_id="c1",
+        channel_name="general",
+        provider_key="openai",
+        provider_label="OpenAI",
+        model_name="gpt-5.4",
+        reasoning_level="high",
+        source="chat",
+        input_tokens=1000,
+        output_tokens=200,
+        cost_usd=Decimal("0.010000"),
+    )
+    defaults.update(overrides)
+    return ChannelUsageLine(**defaults)
+
+
+class TestBuildInvoiceTree:
+    def test_empty_lines_produce_empty_tree_and_zero_totals(self):
+        providers, totals = build_invoice_tree([])
+
+        assert providers == []
+        assert totals["cost"] == Decimal("0")
+        assert totals["input_tokens"] == 0
+        assert totals["output_tokens"] == 0
+        assert totals["cache_read_tokens"] == 0
+        assert totals["cache_write_tokens"] == 0
+
+    def test_groups_by_provider_then_model_with_subtotals(self):
+        lines = [
+            _invoice_line(model_name="gpt-5.4", reasoning_level="high",
+                          cost_usd=Decimal("0.30")),
+            _invoice_line(model_name="gpt-5.4", reasoning_level="low",
+                          input_tokens=500, output_tokens=100,
+                          cost_usd=Decimal("0.10")),
+            _invoice_line(provider_key="google", provider_label="Google",
+                          model_name="gemini-3.1-pro", reasoning_level=None,
+                          source="scan", cache_read_tokens=400,
+                          cache_write_tokens=50, cost_usd=Decimal("0.20")),
+        ]
+
+        providers, totals = build_invoice_tree(lines)
+
+        assert [p["label"] for p in providers] == ["OpenAI", "Google"]
+        openai = providers[0]
+        assert openai["cost"] == Decimal("0.40")
+        assert openai["input_tokens"] == 1500
+        assert openai["output_tokens"] == 300
+        assert [m["name"] for m in openai["models"]] == ["gpt-5.4"]
+        gpt = openai["models"][0]
+        assert gpt["cost"] == Decimal("0.40")
+        # Rows within a model sort by cost descending.
+        assert [r["cost"] for r in gpt["rows"]] == [Decimal("0.30"), Decimal("0.10")]
+        assert gpt["rows"][0]["reasoning"] == "High"
+        assert gpt["rows"][0]["source"] == "Chat"
+
+        google = providers[1]
+        assert google["models"][0]["cache_read_tokens"] == 400
+        assert google["models"][0]["cache_write_tokens"] == 50
+        assert google["models"][0]["rows"][0]["reasoning"] == "—"
+
+        assert totals["cost"] == Decimal("0.60")
+        assert totals["input_tokens"] == 2500
+        assert totals["cache_read_tokens"] == 400
+
+    def test_providers_and_models_sort_by_cost_descending(self):
+        lines = [
+            _invoice_line(provider_key="google", provider_label="Google",
+                          model_name="gemini-3.1-flash", cost_usd=Decimal("0.50")),
+            _invoice_line(model_name="gpt-5.4-mini", cost_usd=Decimal("0.05")),
+            _invoice_line(model_name="gpt-5.4", cost_usd=Decimal("0.25")),
+        ]
+
+        providers, _ = build_invoice_tree(lines)
+
+        assert [p["label"] for p in providers] == ["Google", "OpenAI"]
+        assert [m["name"] for m in providers[1]["models"]] == ["gpt-5.4", "gpt-5.4-mini"]
+
+    def test_unknown_reasoning_level_passes_through_verbatim(self):
+        providers, _ = build_invoice_tree(
+            [_invoice_line(reasoning_level="turbo-think")]
+        )
+
+        assert providers[0]["models"][0]["rows"][0]["reasoning"] == "turbo-think"
+
+    def test_costs_stay_decimal(self):
+        providers, totals = build_invoice_tree(
+            [_invoice_line(cost_usd=Decimal("0.000123"))]
+        )
+
+        assert isinstance(totals["cost"], Decimal)
+        assert isinstance(providers[0]["cost"], Decimal)
+        assert providers[0]["models"][0]["rows"][0]["cost"] == Decimal("0.000123")
+
+
+class TestBuildChannelTree:
+    def test_groups_by_channel_with_subtotals_sorted_by_cost(self):
+        lines = [
+            _channel_line(channel_id="c1", channel_name="general",
+                          cost_usd=Decimal("0.10")),
+            _channel_line(channel_id="c1", channel_name="general",
+                          model_name="gemini-3.1-flash", provider_key="google",
+                          provider_label="Google", reasoning_level="low",
+                          input_tokens=300, output_tokens=60,
+                          cost_usd=Decimal("0.30")),
+            _channel_line(channel_id="c2", channel_name="bot-lab",
+                          cost_usd=Decimal("0.90")),
+        ]
+
+        channels = build_channel_tree(lines)
+
+        assert [c["channel_id"] for c in channels] == ["c2", "c1"]
+        bot_lab = channels[0]
+        assert bot_lab["display_name"] == "#bot-lab"
+        assert bot_lab["cost"] == Decimal("0.90")
+        general = channels[1]
+        assert general["cost"] == Decimal("0.40")
+        assert general["input_tokens"] == 1300
+        assert general["output_tokens"] == 260
+        # Rows within a channel sort by cost descending.
+        assert [r["cost"] for r in general["rows"]] == [
+            Decimal("0.30"), Decimal("0.10")
+        ]
+        assert general["rows"][0]["model_name"] == "gemini-3.1-flash"
+        assert general["rows"][0]["reasoning"] == "Low"
+
+    def test_display_name_falls_back_to_channel_id_then_unknown(self):
+        channels = build_channel_tree([
+            _channel_line(channel_id="123456", channel_name=None),
+            _channel_line(guild_id=None, channel_id=None, channel_name=None,
+                          cost_usd=Decimal("0.01")),
+        ])
+
+        names = {c["channel_id"]: c["display_name"] for c in channels}
+        assert names["123456"] == "123456"
+        assert names[None] == "unknown channel"
+
+    def test_empty_lines_produce_empty_list(self):
+        assert build_channel_tree([]) == []

--- a/tests/web/usage_invoice_test.py
+++ b/tests/web/usage_invoice_test.py
@@ -1,0 +1,498 @@
+"""Tests for the monthly-invoice / per-channel usage aggregation module."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+
+import pytest
+
+from smarter_dev.web.models import (
+    ChatAgentCompactionEvent,
+    ChatAgentEngagement,
+    ChatAgentTurn,
+    ResearchSession,
+    ScanServiceUsage,
+)
+from smarter_dev.web.usage_invoice import (
+    PROVIDER_LABELS,
+    available_months,
+    bare_model_name,
+    channel_breakdown,
+    month_bounds,
+    monthly_invoice,
+    provider_key_from_model_name,
+)
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+def test_provider_key_maps_every_known_prefix():
+    assert provider_key_from_model_name("google-gla:gemini-3.1") == "google"
+    assert provider_key_from_model_name("google:gemini-3.1") == "google"
+    assert provider_key_from_model_name("openai:gpt-5.4") == "openai"
+    assert provider_key_from_model_name("openai-responses:gpt-5.4") == "openai"
+    assert provider_key_from_model_name("anthropic:claude-sonnet-5") == "anthropic"
+    assert provider_key_from_model_name("digitalocean:some-model") == "digitalocean"
+
+
+def test_provider_key_resolves_flat_wire_ids_via_catalog():
+    # Chat/voice/summarizer buckets store flat provider-less wire ids; the
+    # model catalog says which provider serves each one.
+    assert provider_key_from_model_name("gemini-3.1-flash-lite") == "google"
+    assert provider_key_from_model_name("gpt-5.4") == "openai"
+    assert provider_key_from_model_name("claude-sonnet-5") == "anthropic"
+    assert provider_key_from_model_name("kimi-k2.6") == "digitalocean"
+
+
+def test_provider_key_unknown_for_uncatalogued_names_and_unknown_prefix():
+    assert provider_key_from_model_name("some-ad-hoc-model") == "unknown"
+    assert provider_key_from_model_name("mystery:model") == "unknown"
+    assert provider_key_from_model_name(None) == "unknown"
+
+
+def test_provider_labels_cover_every_key():
+    for key in ("google", "openai", "anthropic", "digitalocean", "unknown"):
+        assert key in PROVIDER_LABELS
+    assert PROVIDER_LABELS["google"] == "Google"
+    assert PROVIDER_LABELS["openai"] == "OpenAI"
+    assert PROVIDER_LABELS["anthropic"] == "Anthropic"
+    assert PROVIDER_LABELS["digitalocean"] == "DigitalOcean"
+    assert PROVIDER_LABELS["unknown"] == "Unknown"
+
+
+def test_bare_model_name_strips_prefix_and_handles_none():
+    assert bare_model_name("google-gla:gemini-3.1-flash-lite") == "gemini-3.1-flash-lite"
+    assert bare_model_name("gemini-3.1-flash-lite") == "gemini-3.1-flash-lite"
+    assert bare_model_name(None) == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# month_bounds
+# ---------------------------------------------------------------------------
+
+
+def test_month_bounds_half_open_utc_range():
+    start, end = month_bounds("2026-07")
+    assert start == datetime(2026, 7, 1, tzinfo=timezone.utc)
+    assert end == datetime(2026, 8, 1, tzinfo=timezone.utc)
+
+
+def test_month_bounds_wraps_year_in_december():
+    start, end = month_bounds("2026-12")
+    assert start == datetime(2026, 12, 1, tzinfo=timezone.utc)
+    assert end == datetime(2027, 1, 1, tzinfo=timezone.utc)
+
+
+@pytest.mark.parametrize("bad", ["2026", "2026-13", "2026-00", "not-a-month", "26-07", ""])
+def test_month_bounds_rejects_bad_input(bad):
+    with pytest.raises(ValueError):
+        month_bounds(bad)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / row builders
+# ---------------------------------------------------------------------------
+
+
+def _engagement(guild_id="G1", channel_id="C1", channel_name=None):
+    return ChatAgentEngagement(
+        guild_id=guild_id,
+        channel_id=channel_id,
+        channel_name=channel_name,
+        activation_user_id="U1",
+        activation_username="alice",
+        activation_message_id="M1",
+    )
+
+
+def _turn(engagement, *, started_at, **kwargs):
+    defaults = dict(
+        request_id="req1",
+        turn_kind="initial",
+        output_kind="send_response",
+        triggering_messages=[],
+        agent_output={},
+    )
+    defaults.update(kwargs)
+    return ChatAgentTurn(engagement=engagement, started_at=started_at, **defaults)
+
+
+def _at(day=15):
+    return datetime(2026, 7, day, 12, 0, tzinfo=timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# monthly_invoice
+# ---------------------------------------------------------------------------
+
+
+async def test_empty_month_returns_no_lines(db_session):
+    assert await monthly_invoice(db_session, "2026-07") == []
+
+
+async def test_multi_source_aggregation_with_mixed_reasoning(db_session):
+    engagement = _engagement()
+    # Two chat turns on the same model but different reasoning levels ->
+    # two distinct lines. Third turn shares (model, high) with the first.
+    turn_high_a = _turn(
+        engagement,
+        started_at=_at(2),
+        chat_model_name="gpt-5.4",
+        chat_reasoning_level="high",
+        chat_tokens_input=100,
+        chat_tokens_output=40,
+        chat_cost_usd=Decimal("0.010000"),
+    )
+    turn_high_b = _turn(
+        engagement,
+        started_at=_at(3),
+        chat_model_name="gpt-5.4",
+        chat_reasoning_level="high",
+        chat_tokens_input=10,
+        chat_tokens_output=5,
+        chat_cost_usd=Decimal("0.002000"),
+    )
+    turn_low = _turn(
+        engagement,
+        started_at=_at(4),
+        chat_model_name="gpt-5.4",
+        chat_reasoning_level="low",
+        chat_tokens_input=1,
+        chat_tokens_output=1,
+        chat_cost_usd=Decimal("0.000500"),
+    )
+    # A voice call rides on turn_high_a.
+    turn_high_a.voice_model_name = "gemini-2.5-flash-preview-tts"
+    turn_high_a.voice_tokens_input = 20
+    turn_high_a.voice_tokens_output = 300
+    turn_high_a.voice_cost_usd = Decimal("0.030000")
+
+    compaction = ChatAgentCompactionEvent(
+        turn=turn_high_a,
+        event_kind="assistant_text",
+        original_content="x",
+        summary="y",
+        original_chars=1,
+        summary_chars=1,
+        chars_saved=0,
+        summarizer_model_name="gemini-3.1-flash-lite",
+        summarizer_reasoning_level="low",
+        summarizer_tokens_input=200,
+        summarizer_tokens_output=50,
+        summarizer_cost_usd=Decimal("0.001000"),
+    )
+    research = ResearchSession(
+        query="q",
+        status="complete",
+        guild_id="G1",
+        channel_id="C1",
+        model_name="google-gla:gemini-3.1-flash-lite-preview",
+        input_tokens=1000,
+        output_tokens=500,
+        cache_read_tokens=200,
+        cache_write_tokens=10,
+        cost_usd=Decimal("0.050000"),
+        created_at=_at(6),
+    )
+    service = ScanServiceUsage(
+        task_type="profile",
+        model_name="gemini-3.1-flash-lite",
+        input_tokens=300,
+        output_tokens=100,
+        cache_read_tokens=0,
+        cache_write_tokens=0,
+        cost_usd=Decimal("0.004000"),
+        created_at=_at(7),
+    )
+    db_session.add_all(
+        [engagement, turn_high_a, turn_high_b, turn_low, compaction, research, service]
+    )
+    await db_session.commit()
+
+    lines = await monthly_invoice(db_session, "2026-07")
+
+    by_key = {(l.source, l.model_name, l.reasoning_level): l for l in lines}
+
+    chat_high = by_key[("chat", "gpt-5.4", "high")]
+    assert chat_high.provider_key == "openai"  # flat wire name, resolved via catalog
+    assert chat_high.input_tokens == 110
+    assert chat_high.output_tokens == 45
+    assert chat_high.cost_usd == Decimal("0.012000")
+
+    chat_low = by_key[("chat", "gpt-5.4", "low")]
+    assert chat_low.input_tokens == 1
+    assert chat_low.cost_usd == Decimal("0.000500")
+
+    voice = by_key[("voice", "gemini-2.5-flash-preview-tts", None)]
+    assert voice.output_tokens == 300
+    assert voice.cost_usd == Decimal("0.030000")
+
+    compaction_line = by_key[("compaction", "gemini-3.1-flash-lite", "low")]
+    assert compaction_line.input_tokens == 200
+    assert compaction_line.cost_usd == Decimal("0.001000")
+
+    scan = by_key[("scan", "gemini-3.1-flash-lite-preview", None)]
+    assert scan.provider_key == "google"  # research names ARE prefixed
+    assert scan.provider_label == "Google"
+    assert scan.cache_read_tokens == 200
+    assert scan.cache_write_tokens == 10
+    assert scan.cost_usd == Decimal("0.050000")
+
+    scan_service = by_key[("scan_service", "gemini-3.1-flash-lite", None)]
+    assert scan_service.input_tokens == 300
+    assert scan_service.cost_usd == Decimal("0.004000")
+
+    # Sorted by cost descending.
+    costs = [l.cost_usd for l in lines]
+    assert costs == sorted(costs, reverse=True)
+
+
+async def test_month_filter_excludes_out_of_range_rows(db_session):
+    engagement = _engagement()
+    inside = _turn(
+        engagement,
+        started_at=_at(15),
+        chat_model_name="m",
+        chat_tokens_input=100,
+        chat_cost_usd=Decimal("0.001000"),
+    )
+    before = _turn(
+        engagement,
+        started_at=datetime(2026, 6, 30, 23, 59, tzinfo=timezone.utc),
+        chat_model_name="m",
+        chat_tokens_input=999,
+        chat_cost_usd=Decimal("9.000000"),
+    )
+    after = _turn(
+        engagement,
+        started_at=datetime(2026, 8, 1, 0, 0, tzinfo=timezone.utc),
+        chat_model_name="m",
+        chat_tokens_input=999,
+        chat_cost_usd=Decimal("9.000000"),
+    )
+    db_session.add_all([engagement, inside, before, after])
+    await db_session.commit()
+
+    lines = await monthly_invoice(db_session, "2026-07")
+    assert len(lines) == 1
+    assert lines[0].input_tokens == 100
+    assert lines[0].cost_usd == Decimal("0.001000")
+
+
+async def test_null_cost_sums_coalesce_to_decimal_zero(db_session):
+    research = ResearchSession(
+        query="q",
+        status="complete",
+        model_name="google-gla:gemini-3.1",
+        input_tokens=10,
+        output_tokens=5,
+        cost_usd=None,
+        created_at=_at(9),
+    )
+    db_session.add(research)
+    await db_session.commit()
+
+    lines = await monthly_invoice(db_session, "2026-07")
+    assert len(lines) == 1
+    assert lines[0].cost_usd == Decimal("0")
+    assert isinstance(lines[0].cost_usd, Decimal)
+
+
+async def test_voice_lines_only_appear_when_a_voice_call_happened(db_session):
+    engagement = _engagement()
+    # A chat-only turn (no voice model) must NOT create a voice line.
+    turn = _turn(
+        engagement,
+        started_at=_at(10),
+        chat_model_name="m",
+        chat_tokens_input=5,
+        chat_cost_usd=Decimal("0.001000"),
+    )
+    db_session.add_all([engagement, turn])
+    await db_session.commit()
+
+    lines = await monthly_invoice(db_session, "2026-07")
+    assert [l.source for l in lines] == ["chat"]
+
+
+# ---------------------------------------------------------------------------
+# channel_breakdown
+# ---------------------------------------------------------------------------
+
+
+async def test_channel_breakdown_joins_engagement_for_identity(db_session):
+    busy = _engagement(channel_id="C-busy", channel_name="general")
+    quiet = _engagement(channel_id="C-quiet")
+    db_session.add_all(
+        [
+            busy,
+            quiet,
+            _turn(
+                busy,
+                started_at=_at(2),
+                chat_model_name="m",
+                chat_reasoning_level="high",
+                chat_tokens_input=100,
+                chat_tokens_output=50,
+                chat_cost_usd=Decimal("0.100000"),
+            ),
+            _turn(
+                quiet,
+                started_at=_at(3),
+                chat_model_name="m",
+                chat_reasoning_level="high",
+                chat_tokens_input=10,
+                chat_tokens_output=5,
+                chat_cost_usd=Decimal("0.010000"),
+            ),
+        ]
+    )
+    await db_session.commit()
+
+    lines = await channel_breakdown(db_session, "2026-07")
+    assert [(l.channel_id, l.cost_usd) for l in lines] == [
+        ("C-busy", Decimal("0.100000")),
+        ("C-quiet", Decimal("0.010000")),
+    ]
+    busy_line = next(l for l in lines if l.channel_id == "C-busy")
+    assert busy_line.guild_id == "G1"
+    assert busy_line.channel_name == "general"
+    assert busy_line.model_name == "m"
+    assert busy_line.reasoning_level == "high"
+    assert busy_line.source == "chat"
+
+
+async def test_channel_breakdown_aggregates_engagements_sharing_a_channel(db_session):
+    first = _engagement(channel_id="C1", channel_name="general")
+    second = _engagement(channel_id="C1", channel_name=None)
+    db_session.add_all(
+        [
+            first,
+            second,
+            _turn(
+                first,
+                started_at=_at(2),
+                chat_model_name="m",
+                chat_tokens_input=100,
+                chat_cost_usd=Decimal("0.010000"),
+            ),
+            _turn(
+                second,
+                started_at=_at(3),
+                chat_model_name="m",
+                chat_tokens_input=50,
+                chat_cost_usd=Decimal("0.005000"),
+            ),
+        ]
+    )
+    await db_session.commit()
+
+    lines = await channel_breakdown(db_session, "2026-07")
+    assert len(lines) == 1
+    line = lines[0]
+    assert line.input_tokens == 150
+    assert line.cost_usd == Decimal("0.015000")
+    # Name fallback: the non-null snapshot wins over the NULL one.
+    assert line.channel_name == "general"
+
+
+async def test_channel_breakdown_includes_research_without_channel_name(db_session):
+    research = ResearchSession(
+        query="q",
+        status="complete",
+        guild_id="G9",
+        channel_id="C9",
+        model_name="google-gla:gemini-3.1",
+        input_tokens=1000,
+        output_tokens=200,
+        cost_usd=Decimal("0.200000"),
+        created_at=_at(5),
+    )
+    db_session.add(research)
+    await db_session.commit()
+
+    lines = await channel_breakdown(db_session, "2026-07")
+    assert len(lines) == 1
+    line = lines[0]
+    assert line.source == "scan"
+    assert line.guild_id == "G9"
+    assert line.channel_id == "C9"
+    assert line.channel_name is None
+    assert line.provider_key == "google"
+    assert line.cost_usd == Decimal("0.200000")
+
+
+async def test_channel_breakdown_skips_scan_service(db_session):
+    db_session.add(
+        ScanServiceUsage(
+            task_type="profile",
+            model_name="gemini-3.1-flash-lite",
+            input_tokens=100,
+            output_tokens=50,
+            cost_usd=Decimal("0.010000"),
+            created_at=_at(5),
+        )
+    )
+    await db_session.commit()
+
+    lines = await channel_breakdown(db_session, "2026-07")
+    assert lines == []
+
+
+async def test_channel_breakdown_excludes_out_of_range_rows(db_session):
+    engagement = _engagement(channel_id="C1")
+    db_session.add_all(
+        [
+            engagement,
+            _turn(
+                engagement,
+                started_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
+                chat_model_name="m",
+                chat_tokens_input=999,
+                chat_cost_usd=Decimal("9.000000"),
+            ),
+        ]
+    )
+    await db_session.commit()
+
+    assert await channel_breakdown(db_session, "2026-07") == []
+
+
+# ---------------------------------------------------------------------------
+# available_months
+# ---------------------------------------------------------------------------
+
+
+async def test_available_months_span_from_earliest_record_to_now_descending(db_session):
+    engagement = _engagement()
+    db_session.add_all(
+        [
+            engagement,
+            _turn(
+                engagement,
+                started_at=datetime(2026, 5, 10, tzinfo=timezone.utc),
+                chat_model_name="m",
+                chat_tokens_input=1,
+            ),
+        ]
+    )
+    await db_session.commit()
+
+    months = await available_months(db_session)
+    now = datetime.now(timezone.utc)
+    current = f"{now.year:04d}-{now.month:02d}"
+    assert months[0] == current  # descending: newest first
+    assert months[-1] == "2026-05"  # earliest record's month
+    # Strictly descending, no duplicates.
+    assert months == sorted(set(months), reverse=True)
+    assert "2026-05" in months
+
+
+async def test_available_months_defaults_to_current_month_when_empty(db_session):
+    months = await available_months(db_session)
+    now = datetime.now(timezone.utc)
+    assert months == [f"{now.year:04d}-{now.month:02d}"]


### PR DESCRIPTION
## Summary
- Adds a **Invoice** tab to `/admin/usage`: billing-month picker, provider → model → reasoning-level breakdown of token spend with per-model/provider subtotals and grand total (all 5 cost sources: chat, voice, compaction, scan research, scan services).
- Adds a **By Channel** tab: per-Discord-channel token/cost breakdown by model × reasoning level × source.
- Tracks the resolved reasoning level on usage records (new nullable `chat_agent_turns.chat_reasoning_level` and `chat_agent_compaction_events.summarizer_reasoning_level`, migration `a3f9c1e7b4d2`), threaded bot → API → DB, backward-compatible with old bot payloads.
- New pure aggregation module `smarter_dev/web/usage_invoice.py` (SQLite-testable, Decimal-exact). Provider identity resolves flat wire model ids via the model catalog plus the `openai-responses:` prefix Scan uses.

## Notes
- Reasoning-level breakdowns populate only for usage recorded after this deploys; historical rows show "—".
- Verified no double-counting between `ResearchSession.cost_usd` and `ScanServiceUsage.cost_usd`.
- Migration runs automatically via the deploy workflow's migrate job.

## Testing
- 1890 passed, 13 skipped (`uv run pytest -m "not llm" --ignore=tests/bot/services/test_integration.py`; ignored module is pre-broken by a missing `fastapi` dep, and the one perf-test failure is timing-flaky, passes in isolation).
- semgrep/gitleaks clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MwN5wcdiYWVpYpSP8jiyME