### PR TITLE
fix(bot): judge redirecting mentions by conversation topic in response gate

### DIFF
--- a/smarter_dev/bot/agents/message_gate.py
+++ b/smarter_dev/bot/agents/message_gate.py
@@ -37,6 +37,9 @@ You are given:
 - INSTRUCTIONS: the admin's filter describing which messages the bot should \
 respond to. They are about the TOPIC and CONTENT of a message, never about who \
 wrote it — ignore the author when deciding.
+- CHANNEL (optional): the name of the channel the messages were sent in. For a \
+forum post or thread this is its title — often the clearest statement of what \
+the conversation is about. Treat it like CONTEXT when interpreting candidates.
 - CONTEXT: recent channel messages, oldest first, provided only so you can \
 interpret the candidates. These are NOT candidates; never return a context id.
 - CANDIDATES: the messages to judge. Return the ids of the candidates the \
@@ -51,6 +54,18 @@ fall under the instructions — lean ALLOW.
 - Use the CONTEXT only to interpret a candidate (e.g. a short reply that only \
 makes sense given the prior messages); a candidate that is on-topic given the \
 conversation should be allowed even if it looks thin in isolation.
+- Some candidates REDIRECT rather than state a topic of their own: follow-ups, \
+nudges, and questions about the conversation itself ("do you have an answer?", \
+"any update on this?", "what do you think?"). Never judge these on their bare \
+words, and never classify them as meta-chatter. Instead, judge such a \
+candidate exactly as if it restated the conversation's current topic — taken \
+from the CHANNEL title and the CONTEXT. If that topic matches the \
+instructions the candidate is allowed; if it does not, drop it. Example: with \
+instructions "only cooking questions", in a thread asking how to keep risotto \
+creamy, the candidate "do you have an answer?" inherits the topic "keeping \
+risotto creamy" — a cooking question — and is allowed; the same candidate \
+amid car-repair chatter is dropped. Only when neither the channel nor the context reveals any topic does \
+the ambiguity rule above apply.
 
 Set allowed_message_ids to the ids of the candidates (and only the candidates) \
 that the instructions allow, in any order."""
@@ -100,8 +115,11 @@ def _render_prompt(
     response_filter: str,
     candidates: list[GateMessage],
     grounding: list[GateMessage],
+    channel_name: str | None,
 ) -> str:
     sections = [f"INSTRUCTIONS:\n{response_filter.strip()}"]
+    if channel_name and channel_name.strip():
+        sections.append(f"CHANNEL:\n{channel_name.strip()}")
     if grounding:
         rendered = "\n".join(_render_message(message) for message in grounding)
         sections.append(
@@ -117,15 +135,18 @@ async def filter_messages(
     response_filter: str,
     candidates: list[GateMessage],
     grounding: list[GateMessage],
+    channel_name: str | None = None,
 ) -> list[str]:
     """Return the candidate message ids the ``response_filter`` allows.
 
     Ids are returned in candidate order. An empty ``candidates`` list returns
     ``[]`` without a model call, and an empty/whitespace ``response_filter``
-    allows every candidate without a model call. Any exception from the model is
-    logged and fails open — every candidate id is returned — so a Nano outage
-    never silences the bot. The model's answer is intersected with the real
-    candidate ids, since it may hallucinate ids that were never offered.
+    allows every candidate without a model call. ``channel_name`` — for a forum
+    post or thread, its title — is extra interpretive context and may be None.
+    Any exception from the model is logged and fails open — every candidate id
+    is returned — so a Nano outage never silences the bot. The model's answer
+    is intersected with the real candidate ids, since it may hallucinate ids
+    that were never offered.
     """
     if not candidates:
         return []
@@ -134,7 +155,9 @@ async def filter_messages(
         return candidate_ids
     agent = get_message_gate_agent()
     try:
-        result = await agent.run(_render_prompt(response_filter, candidates, grounding))
+        result = await agent.run(
+            _render_prompt(response_filter, candidates, grounding, channel_name)
+        )
     except Exception:
         logger.warning(
             "message gate model call failed; allowing all %d candidate(s) (fail-open)",

--- a/smarter_dev/bot/services/chat_engine.py
+++ b/smarter_dev/bot/services/chat_engine.py
@@ -69,6 +69,7 @@ from smarter_dev.bot.services.chat_conversation_persistence import start_engagem
 from smarter_dev.bot.services.chat_memory import get_chat_memory
 from smarter_dev.bot.services.user_message_limit import DIRECTED_SCORE_THRESHOLD
 from smarter_dev.bot.services.user_message_limit import record_directed_messages
+from smarter_dev.bot.utils.messages import fetch_channel_info
 from smarter_dev.bot.utils.stop_detection import is_stop_request
 from smarter_dev.bot.utils.stop_detection import set_channel_cooldown
 from smarter_dev.bot.views.model_override_views import (
@@ -1140,6 +1141,24 @@ class ChannelEngine:
         fetched.reverse()
         return [self._to_gate_message(message) for message in fetched]
 
+    async def _fetch_gate_channel_name(self) -> str | None:
+        """The channel's name for the response gate — a forum post's title.
+
+        Best-effort: any lookup failure degrades to None (debug log) so the
+        gate judges without the name rather than erroring the turn.
+        """
+        try:
+            info = await fetch_channel_info(self.bot, self.channel_id)
+        except Exception:
+            logger.debug(
+                "could not fetch channel name for response-filter gate in "
+                "channel %s",
+                self.channel_id,
+                exc_info=True,
+            )
+            return None
+        return info.get("channel_name") or None
+
     async def _gate_allows(
         self, response_filter: str, candidates: list[Any]
     ) -> set[str]:
@@ -1148,7 +1167,8 @@ class ChannelEngine:
         Wraps the (already fail-open) message gate so an unexpected error still
         runs the turn unfiltered — a wasted reply is far cheaper than a channel
         that goes mute. ``candidates`` are hikari messages; grounding is up to
-        five channel messages immediately preceding them.
+        five channel messages immediately preceding them plus the channel name
+        (a forum post's title), so short follow-ups are judged in context.
         """
         candidate_messages = [
             self._to_gate_message(message)
@@ -1158,9 +1178,13 @@ class ChannelEngine:
         if not candidate_messages:
             return set()
         grounding = await self._fetch_gate_grounding(candidates)
+        channel_name = await self._fetch_gate_channel_name()
         try:
             allowed = await filter_messages(
-                response_filter, candidate_messages, grounding
+                response_filter,
+                candidate_messages,
+                grounding,
+                channel_name=channel_name,
             )
         except Exception:
             logger.warning(

--- a/tests/bot/agents/test_message_gate.py
+++ b/tests/bot/agents/test_message_gate.py
@@ -96,6 +96,72 @@ async def test_blank_filter_allows_all_without_model():
 
 
 @pytest.mark.asyncio
+async def test_system_prompt_covers_redirecting_candidates():
+    """A candidate like "do you have an answer?" names no topic itself; the
+    system prompt must direct the model to resolve what such a message points
+    at from the context and judge that subject, not the bare words."""
+    captured: dict[str, object] = {}
+
+    def _echo(messages, info: AgentInfo):
+        captured["system"] = messages[0].parts[0].content
+        return ModelResponse(
+            parts=[ToolCallPart(tool_name="final_result", args={"allowed_message_ids": []})]
+        )
+
+    agent = message_gate.get_message_gate_agent()
+    with agent.override(model=FunctionModel(_echo)):
+        await filter_messages("only coding questions", _candidates(), [])
+
+    system_prompt = captured["system"]
+    assert "REDIRECT" in system_prompt
+    assert "do you have an answer?" in system_prompt
+
+
+@pytest.mark.asyncio
+async def test_channel_name_is_rendered_as_context():
+    """In a forum post or thread the channel name is its title — often the
+    clearest statement of the conversation's topic — so it must reach the
+    model, and the system prompt must explain what it is."""
+    captured: dict[str, object] = {}
+
+    def _echo(messages, info: AgentInfo):
+        captured["system"] = messages[0].parts[0].content
+        captured["prompt"] = messages[-1].parts[-1].content
+        return ModelResponse(
+            parts=[ToolCallPart(tool_name="final_result", args={"allowed_message_ids": []})]
+        )
+
+    agent = message_gate.get_message_gate_agent()
+    with agent.override(model=FunctionModel(_echo)):
+        await filter_messages(
+            "only coding questions",
+            _candidates(),
+            [],
+            channel_name="How Does Logits Work?",
+        )
+
+    assert "How Does Logits Work?" in captured["prompt"]
+    assert "CHANNEL" in captured["system"]
+
+
+@pytest.mark.asyncio
+async def test_missing_channel_name_renders_no_channel_section():
+    captured: dict[str, object] = {}
+
+    def _echo(messages, info: AgentInfo):
+        captured["prompt"] = messages[-1].parts[-1].content
+        return ModelResponse(
+            parts=[ToolCallPart(tool_name="final_result", args={"allowed_message_ids": []})]
+        )
+
+    agent = message_gate.get_message_gate_agent()
+    with agent.override(model=FunctionModel(_echo)):
+        await filter_messages("only coding questions", _candidates(), [])
+
+    assert "CHANNEL:" not in captured["prompt"]
+
+
+@pytest.mark.asyncio
 async def test_grounding_is_rendered_but_never_returned():
     grounding = [GateMessage(message_id="g1", author_display="dan", content="earlier chatter")]
     captured: dict[str, object] = {}

--- a/tests/bot/services/test_chat_engine_override.py
+++ b/tests/bot/services/test_chat_engine_override.py
@@ -589,6 +589,50 @@ async def test_response_filter_gate_error_runs_turn_unfiltered(
     agent_mock.run.assert_awaited_once()
 
 
+@pytest.mark.asyncio
+async def test_gate_receives_channel_name(fake_redis):
+    """The gate must see the channel/thread name — for a forum post it is the
+    title, often the only statement of what the conversation is about."""
+    engine, _ = _make_engine(
+        _override("gpt-5-4", response_filter="only python questions"), fake_redis
+    )
+    gate = AsyncMock(return_value=[])
+
+    with patch(
+        "smarter_dev.bot.services.chat_engine.filter_messages", new=gate
+    ), patch(
+        "smarter_dev.bot.services.chat_engine.fetch_channel_info",
+        new=AsyncMock(return_value={"channel_name": "How Does Logits Work?"}),
+    ), patch.object(
+        engine, "_fetch_gate_grounding", new=AsyncMock(return_value=[])
+    ):
+        await engine._gate_allows("only python questions", [_fake_message(700)])
+
+    assert gate.await_args.kwargs["channel_name"] == "How Does Logits Work?"
+
+
+@pytest.mark.asyncio
+async def test_gate_channel_name_lookup_failure_degrades_to_none(fake_redis):
+    """A channel-info failure must not break the gate — it judges without the
+    name rather than erroring the turn."""
+    engine, _ = _make_engine(
+        _override("gpt-5-4", response_filter="only python questions"), fake_redis
+    )
+    gate = AsyncMock(return_value=[])
+
+    with patch(
+        "smarter_dev.bot.services.chat_engine.filter_messages", new=gate
+    ), patch(
+        "smarter_dev.bot.services.chat_engine.fetch_channel_info",
+        new=AsyncMock(side_effect=RuntimeError("discord hiccup")),
+    ), patch.object(
+        engine, "_fetch_gate_grounding", new=AsyncMock(return_value=[])
+    ):
+        await engine._gate_allows("only python questions", [_fake_message(700)])
+
+    assert gate.await_args.kwargs["channel_name"] is None
+
+
 # --------------------------------------------------------------------------- #
 # Feature 2 — fallback model on budget exhaustion
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary
- A restricted channel's response filter (GPT-5.4 Nano gate) judged messages like "do you have an answer?" on their bare words and silently dropped them even when the thread was on-topic (prod incident 2026-07-21 in the "How Does Logits Work?" forum thread)
- The gate system prompt now treats redirecting candidates (follow-ups, nudges) as restating the conversation's current topic, with a worked example; meta-chatter classification is explicitly forbidden
- The gate now also receives the channel name (a forum post's title) as interpretive context, fetched fail-soft via the cached channel-info helper

## Verification
- 4 new unit tests (prompt wiring, title pass-through, fail-soft lookup); all 31 gate/engine tests pass
- Live A/B eval against the production gate model, 20 trials/scenario: on-topic nudge allowed 20/20 with title, 18/20 without (was ~10% before); off-topic nudge still dropped 19/20

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KfoN4B5Vzn9Ywnqhp9xbyB