### PR TITLE
fix: price DigitalOcean-served models and backfill historical costs

### DIFF
--- a/alembic/main/versions/20260721_170000_b7d4e2f8c1a5_backfill_digitalocean_costs.py
+++ b/alembic/main/versions/20260721_170000_b7d4e2f8c1a5_backfill_digitalocean_costs.py
@@ -1,0 +1,143 @@
+"""backfill costs for DigitalOcean-served chat models
+
+Historically every DigitalOcean-served chat turn was priced at $0: the
+models are unknown to genai-prices and calc_cost swallowed the lookup
+failure. Token counts were always recorded, so the true cost is
+recomputable. This migration re-prices those rows at DigitalOcean's
+serverless-inference rates (docs.digitalocean.com, 2026-07, USD per
+million tokens — deliberately inlined so this migration stays a frozen
+snapshot independent of application code) and rebuilds the denormalised
+engagement cost rollups for every affected engagement.
+
+Only rows whose cost is currently 0/NULL are touched, so re-running or
+running after the new pricing code is live never clobbers a real cost.
+
+Revision ID: b7d4e2f8c1a5
+Revises: a3f9c1e7b4d2
+Create Date: 2026-07-21 17:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "b7d4e2f8c1a5"
+down_revision: Union[str, None] = "a3f9c1e7b4d2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+# model wire id -> (input $/Mtok, output $/Mtok)
+DIGITALOCEAN_RATES: dict[str, tuple[str, str]] = {
+    "kimi-k2.6": ("0.76", "3.20"),
+    "glm-5.2": ("1.05", "4.40"),
+    "deepseek-4-flash": ("0.112", "0.224"),
+    "gemma-4-31B-it": ("0.18", "0.50"),
+    "qwen3.5-397b-a17b": ("0.385", "2.45"),
+}
+
+_AFFECTED_ENGAGEMENTS = """
+    SELECT DISTINCT t.engagement_id
+    FROM chat_agent_turns t
+    WHERE t.chat_model_name IN :model_ids
+    UNION
+    SELECT DISTINCT t2.engagement_id
+    FROM chat_agent_compaction_events ce
+    JOIN chat_agent_turns t2 ON ce.turn_id = t2.id
+    WHERE ce.summarizer_model_name IN :model_ids
+"""
+
+
+def _rebuild_engagement_rollups(connection) -> None:
+    model_ids = tuple(DIGITALOCEAN_RATES)
+    connection.execute(
+        sa.text(
+            f"""
+            UPDATE chat_agent_engagements e
+            SET total_chat_cost_usd = COALESCE((
+                    SELECT SUM(t.chat_cost_usd)
+                    FROM chat_agent_turns t
+                    WHERE t.engagement_id = e.id
+                ), 0),
+                total_compaction_cost_usd = COALESCE((
+                    SELECT SUM(ce.summarizer_cost_usd)
+                    FROM chat_agent_compaction_events ce
+                    JOIN chat_agent_turns t2 ON ce.turn_id = t2.id
+                    WHERE t2.engagement_id = e.id
+                ), 0)
+            WHERE e.id IN ({_AFFECTED_ENGAGEMENTS})
+            """
+        ).bindparams(sa.bindparam("model_ids", expanding=True)),
+        {"model_ids": list(model_ids)},
+    )
+    connection.execute(
+        sa.text(
+            f"""
+            UPDATE chat_agent_engagements e
+            SET total_cost_usd = COALESCE(e.total_chat_cost_usd, 0)
+                + COALESCE(e.total_voice_cost_usd, 0)
+                + COALESCE(e.total_compaction_cost_usd, 0)
+            WHERE e.id IN ({_AFFECTED_ENGAGEMENTS})
+            """
+        ).bindparams(sa.bindparam("model_ids", expanding=True)),
+        {"model_ids": list(model_ids)},
+    )
+
+
+def upgrade() -> None:
+    connection = op.get_bind()
+    for model_id, (input_rate, output_rate) in DIGITALOCEAN_RATES.items():
+        connection.execute(
+            sa.text(
+                f"""
+                UPDATE chat_agent_turns
+                SET chat_cost_usd =
+                    (chat_tokens_input * {input_rate}
+                     + chat_tokens_output * {output_rate}) / 1000000
+                WHERE chat_model_name = :model_id
+                  AND COALESCE(chat_cost_usd, 0) = 0
+                """
+            ),
+            {"model_id": model_id},
+        )
+        connection.execute(
+            sa.text(
+                f"""
+                UPDATE chat_agent_compaction_events
+                SET summarizer_cost_usd =
+                    (summarizer_tokens_input * {input_rate}
+                     + summarizer_tokens_output * {output_rate}) / 1000000
+                WHERE summarizer_model_name = :model_id
+                  AND COALESCE(summarizer_cost_usd, 0) = 0
+                """
+            ),
+            {"model_id": model_id},
+        )
+    _rebuild_engagement_rollups(connection)
+
+
+def downgrade() -> None:
+    connection = op.get_bind()
+    model_ids = list(DIGITALOCEAN_RATES)
+    connection.execute(
+        sa.text(
+            """
+            UPDATE chat_agent_turns
+            SET chat_cost_usd = 0
+            WHERE chat_model_name IN :model_ids
+            """
+        ).bindparams(sa.bindparam("model_ids", expanding=True)),
+        {"model_ids": model_ids},
+    )
+    connection.execute(
+        sa.text(
+            """
+            UPDATE chat_agent_compaction_events
+            SET summarizer_cost_usd = 0
+            WHERE summarizer_model_name IN :model_ids
+            """
+        ).bindparams(sa.bindparam("model_ids", expanding=True)),
+        {"model_ids": model_ids},
+    )
+    _rebuild_engagement_rollups(connection)

--- a/smarter_dev/web/llm_pricing.py
+++ b/smarter_dev/web/llm_pricing.py
@@ -6,10 +6,13 @@ then exposes calc_session_cost() for computing per-session costs.
 
 from __future__ import annotations
 
+import logging
 from decimal import Decimal
 
 from genai_prices import calc_price, types
 from genai_prices.data_snapshot import find_provider_by_id, get_snapshot
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Patch missing models into the genai-prices snapshot
@@ -114,6 +117,69 @@ _patch_provider(
 
 
 # ---------------------------------------------------------------------------
+# DigitalOcean serverless inference pricing
+# ---------------------------------------------------------------------------
+# genai-prices has no DigitalOcean provider, and DO resells these open-weight
+# models at its own rates (not the origin vendors'), so they are priced
+# directly from this table. USD per million tokens, from
+# https://docs.digitalocean.com/products/inference/details/pricing/ (2026-07).
+
+_DIGITALOCEAN_PRICES: dict[str, types.ModelPrice] = {
+    "kimi-k2.6": types.ModelPrice(
+        input_mtok=Decimal("0.76"),
+        output_mtok=Decimal("3.20"),
+        cache_read_mtok=Decimal("0.19"),
+    ),
+    "glm-5.2": types.ModelPrice(
+        input_mtok=Decimal("1.05"),
+        output_mtok=Decimal("4.40"),
+        cache_read_mtok=Decimal("0.21"),
+    ),
+    "deepseek-4-flash": types.ModelPrice(
+        input_mtok=Decimal("0.112"),
+        output_mtok=Decimal("0.224"),
+        cache_read_mtok=Decimal("0.028"),
+    ),
+    "gemma-4-31B-it": types.ModelPrice(
+        input_mtok=Decimal("0.18"),
+        output_mtok=Decimal("0.50"),
+    ),
+    "qwen3.5-397b-a17b": types.ModelPrice(
+        input_mtok=Decimal("0.385"),
+        output_mtok=Decimal("2.45"),
+        cache_read_mtok=Decimal("0.111"),
+    ),
+}
+
+_TOKENS_PER_MTOK = Decimal("1000000")
+
+
+def _digitalocean_cost(
+    input_tokens: int,
+    output_tokens: int,
+    cache_read_tokens: int,
+    cache_write_tokens: int,
+    price: types.ModelPrice,
+) -> Decimal:
+    """Direct cost computation for a DO-served model.
+
+    DO bills cached reads at the model's prompt-caching rate when it has one
+    (otherwise as plain input) and has no separate cache-write tier, so
+    writes bill as plain input.
+    """
+    input_rate = price.input_mtok
+    cache_read_rate = (
+        price.cache_read_mtok if price.cache_read_mtok is not None else input_rate
+    )
+    return (
+        Decimal(input_tokens) * input_rate
+        + Decimal(output_tokens) * price.output_mtok
+        + Decimal(cache_read_tokens) * cache_read_rate
+        + Decimal(cache_write_tokens) * input_rate
+    ) / _TOKENS_PER_MTOK
+
+
+# ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
@@ -145,6 +211,20 @@ def calc_session_cost(
     else:
         provider_id, model_ref = None, parts[0]
 
+    # DO-served models are unknown to genai-prices and billed at DO's own
+    # rates; price them directly. Chat/voice/summarizer names arrive flat
+    # (provider_id None), a "digitalocean:" prefix also resolves here.
+    if provider_id in (None, "digitalocean"):
+        digitalocean_price = _DIGITALOCEAN_PRICES.get(model_ref)
+        if digitalocean_price is not None:
+            return _digitalocean_cost(
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                cache_read_tokens=cache_read_tokens,
+                cache_write_tokens=cache_write_tokens,
+                price=digitalocean_price,
+            )
+
     usage = types.Usage(
         input_tokens=input_tokens,
         output_tokens=output_tokens,
@@ -166,8 +246,8 @@ def calc_cost(
     Same provider/model resolution as ``calc_session_cost`` but without
     cache-token bookkeeping. Used by per-turn cost computations on the
     chat agent (chat, compaction, voice buckets each call this once).
-    Returns Decimal("0") on any unknown-model failure so callers don't
-    have to wrap.
+    An unknown model returns Decimal("0") so the turn write still lands,
+    but logs loudly — a $0 model means this module needs a price entry.
     """
     try:
         return calc_session_cost(
@@ -177,5 +257,10 @@ def calc_cost(
             cache_write_tokens=0,
             model_name=model_name,
         )
-    except Exception:
+    except LookupError:
+        logger.warning(
+            "No pricing found for model %r — recording cost as $0. "
+            "Add rates to llm_pricing (or genai-prices) to bill this model.",
+            model_name,
+        )
         return Decimal("0")

--- a/tests/web/llm_pricing_test.py
+++ b/tests/web/llm_pricing_test.py
@@ -1,0 +1,88 @@
+"""Tests for LLM cost calculation, especially DigitalOcean-served models.
+
+genai-prices has no DigitalOcean provider, so DO models are priced from a
+local rate table (DO serverless-inference rates, July 2026). These tests pin
+the exact Decimal math so a silent pricing regression cannot reappear.
+"""
+
+from __future__ import annotations
+
+import logging
+from decimal import Decimal
+
+from smarter_dev.web.llm_pricing import calc_cost, calc_session_cost
+
+
+class TestDigitalOceanPricing:
+    def test_kimi_k26_input_and_output_rates(self):
+        # 1M input @ $0.76 + 1M output @ $3.20
+        assert calc_cost(1_000_000, 1_000_000, "kimi-k2.6") == Decimal("3.96")
+
+    def test_glm_52_rates(self):
+        assert calc_cost(1_000_000, 0, "glm-5.2") == Decimal("1.05")
+        assert calc_cost(0, 1_000_000, "glm-5.2") == Decimal("4.40")
+
+    def test_deepseek_4_flash_rates(self):
+        assert calc_cost(1_000_000, 1_000_000, "deepseek-4-flash") == Decimal(
+            "0.336"
+        )
+
+    def test_gemma_4_rates(self):
+        assert calc_cost(1_000_000, 1_000_000, "gemma-4-31B-it") == Decimal("0.68")
+
+    def test_qwen_35_rates(self):
+        assert calc_cost(1_000_000, 1_000_000, "qwen3.5-397b-a17b") == Decimal(
+            "2.835"
+        )
+
+    def test_small_token_counts_stay_exact_decimal(self):
+        # 110 input + 45 output on kimi-k2.6:
+        # (110 * 0.76 + 45 * 3.20) / 1_000_000
+        cost = calc_cost(110, 45, "kimi-k2.6")
+        assert cost == Decimal("110") * Decimal("0.76") / Decimal(
+            "1000000"
+        ) + Decimal("45") * Decimal("3.20") / Decimal("1000000")
+        assert isinstance(cost, Decimal)
+
+    def test_digitalocean_prefixed_name_also_resolves(self):
+        assert calc_cost(1_000_000, 0, "digitalocean:kimi-k2.6") == Decimal("0.76")
+
+    def test_cache_read_tokens_use_prompt_caching_rate(self):
+        # kimi-k2.6 prompt caching: $0.19 per 1M tokens
+        cost = calc_session_cost(
+            input_tokens=0,
+            output_tokens=0,
+            cache_read_tokens=1_000_000,
+            cache_write_tokens=0,
+            model_name="kimi-k2.6",
+        )
+        assert cost == Decimal("0.19")
+
+    def test_cache_tokens_without_caching_rate_bill_as_input(self):
+        # gemma-4 has no prompt-caching tier on DO; cached reads/writes are
+        # billed at the plain input rate.
+        cost = calc_session_cost(
+            input_tokens=0,
+            output_tokens=0,
+            cache_read_tokens=1_000_000,
+            cache_write_tokens=1_000_000,
+            model_name="gemma-4-31B-it",
+        )
+        assert cost == Decimal("0.36")
+
+
+class TestUnknownModelFallback:
+    def test_unknown_model_returns_zero_and_logs_warning(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="smarter_dev.web.llm_pricing"):
+            cost = calc_cost(1000, 500, "totally-unknown-model-xyz")
+
+        assert cost == Decimal("0")
+        assert any(
+            "totally-unknown-model-xyz" in record.message
+            for record in caplog.records
+        )
+
+    def test_known_genai_prices_model_still_priced(self):
+        # The patched google model must keep flowing through genai-prices.
+        cost = calc_cost(1_000_000, 0, "google-gla:gemini-3.1-flash-lite")
+        assert cost == Decimal("0.25")


### PR DESCRIPTION
## Summary
- **Root cause:** `genai-prices` has no DigitalOcean provider; `calc_cost` swallowed the `LookupError` as `Decimal("0")`, so all DO-served chat turns (`kimi-k2.6`, `glm-5.2`, `deepseek-4-flash`, `gemma-4-31B-it`, `qwen3.5-397b-a17b`) were stored at $0. Tokens were always recorded correctly.
- Adds a DO serverless-inference rate table to `llm_pricing.py` (official DO pricing docs, 2026-07: kimi $0.76/$3.20, glm $1.05/$4.40, deepseek-flash $0.112/$0.224, gemma $0.18/$0.50, qwen $0.385/$2.45 per Mtok, plus cached-input rates), consulted before delegating to genai-prices.
- Narrows the unknown-model fallback to `LookupError` and logs a warning so the next unpriced model can't hide silently.
- **Backfill migration `b7d4e2f8c1a5`:** re-prices historical $0 DO rows (chat turns + compaction events) from stored token counts and rebuilds the engagement cost rollups. Only touches rows whose cost is currently 0/NULL; reversible downgrade.

## Verification
- Migration rehearsed end-to-end against a disposable Postgres (podman): full skrift+app chain applied, seeded $0 DO rows + one already-priced row, upgraded, and confirmed exact expected Decimals (0.002360 / 0.004720 / 0.000755; priced row untouched; rollups correct incl. preserved voice cost).
- 11 new pricing tests pin the exact rate math; full suite: 1902 passed, 13 skipped.
- semgrep/gitleaks clean on changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MwN5wcdiYWVpYpSP8jiyME