### PR TITLE
feat: capture prompt-cache tokens for chat usage and price the cache discount

### DIFF
--- a/alembic/main/versions/20260721_130000_c4a1d9f2e6b8_chat_cache_tokens.py
+++ b/alembic/main/versions/20260721_130000_c4a1d9f2e6b8_chat_cache_tokens.py
@@ -1,0 +1,59 @@
+"""add prompt-cache token split to chat usage records
+
+Adds nullable prompt-cache token counts to each chat usage row so the
+operator dashboard can attribute cached vs. uncached input spend:
+
+- ``chat_agent_turns.chat_cache_read_tokens`` /
+  ``chat_agent_turns.chat_cache_write_tokens`` — the cache split for the chat
+  model call. Both a SUBSET of ``chat_tokens_input``.
+- ``chat_agent_compaction_events.summarizer_cache_read_tokens`` /
+  ``chat_agent_compaction_events.summarizer_cache_write_tokens`` — the cache
+  split for the summarizer call.
+
+All four nullable, no backfill — the historical split is unknowable.
+
+Revision ID: c4a1d9f2e6b8
+Revises: b7d4e2f8c1a5
+Create Date: 2026-07-21 13:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "c4a1d9f2e6b8"
+down_revision: Union[str, None] = "b7d4e2f8c1a5"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "chat_agent_turns",
+        sa.Column("chat_cache_read_tokens", sa.Integer(), nullable=True),
+    )
+    op.add_column(
+        "chat_agent_turns",
+        sa.Column("chat_cache_write_tokens", sa.Integer(), nullable=True),
+    )
+    op.add_column(
+        "chat_agent_compaction_events",
+        sa.Column("summarizer_cache_read_tokens", sa.Integer(), nullable=True),
+    )
+    op.add_column(
+        "chat_agent_compaction_events",
+        sa.Column("summarizer_cache_write_tokens", sa.Integer(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column(
+        "chat_agent_compaction_events", "summarizer_cache_write_tokens"
+    )
+    op.drop_column(
+        "chat_agent_compaction_events", "summarizer_cache_read_tokens"
+    )
+    op.drop_column("chat_agent_turns", "chat_cache_write_tokens")
+    op.drop_column("chat_agent_turns", "chat_cache_read_tokens")

--- a/smarter_dev/bot/agents/chat_compaction.py
+++ b/smarter_dev/bot/agents/chat_compaction.py
@@ -179,6 +179,10 @@ class CompactionEvent:
     summarizer_tokens_output: int
     summarizer_model_name: str
     summarizer_reasoning_level: str | None
+    # Prompt-cache split for the summarizer call. A SUBSET of
+    # summarizer_tokens_input. None when not captured.
+    summarizer_cache_read_tokens: int | None = None
+    summarizer_cache_write_tokens: int | None = None
 
 
 _collected: ContextVar[list[CompactionEvent] | None] = ContextVar(
@@ -272,6 +276,8 @@ class _SummariseResult:
     tokens_input: int
     tokens_output: int
     model_name: str
+    cache_read_tokens: int = 0
+    cache_write_tokens: int = 0
 
 
 async def _summarise_conversation(transcript: str) -> _SummariseResult | None:
@@ -282,6 +288,8 @@ async def _summarise_conversation(transcript: str) -> _SummariseResult | None:
     """
     tokens_input = 0
     tokens_output = 0
+    cache_read_tokens = 0
+    cache_write_tokens = 0
     model_name = os.getenv(COMPACT_MODEL_ENV_VAR, DEFAULT_COMPACT_MODEL)
     try:
         result = await get_summarizer_agent().run(user_prompt=transcript)
@@ -297,6 +305,8 @@ async def _summarise_conversation(transcript: str) -> _SummariseResult | None:
         if usage is not None:
             tokens_input = int(usage.input_tokens or 0)
             tokens_output = int(usage.output_tokens or 0)
+            cache_read_tokens = int(getattr(usage, "cache_read_tokens", 0) or 0)
+            cache_write_tokens = int(getattr(usage, "cache_write_tokens", 0) or 0)
     except Exception:
         pass
     if len(summary) > MAX_SUMMARY_CHARS:
@@ -306,6 +316,8 @@ async def _summarise_conversation(transcript: str) -> _SummariseResult | None:
         tokens_input=tokens_input,
         tokens_output=tokens_output,
         model_name=model_name,
+        cache_read_tokens=cache_read_tokens,
+        cache_write_tokens=cache_write_tokens,
     )
 
 
@@ -464,6 +476,8 @@ async def compact_history(messages: list[ModelMessage]) -> list[ModelMessage]:
             summarizer_tokens_output=summary.tokens_output,
             summarizer_model_name=summary.model_name,
             summarizer_reasoning_level=SUMMARIZER_REASONING_LEVEL.value,
+            summarizer_cache_read_tokens=summary.cache_read_tokens,
+            summarizer_cache_write_tokens=summary.cache_write_tokens,
         )
     )
 

--- a/smarter_dev/bot/services/chat_conversation_persistence.py
+++ b/smarter_dev/bot/services/chat_conversation_persistence.py
@@ -120,6 +120,8 @@ async def persist_turn(
     chat_tokens_output: int,
     chat_model_name: str | None,
     chat_reasoning_level: str | None = None,
+    chat_cache_read_tokens: int | None = None,
+    chat_cache_write_tokens: int | None = None,
     voice_tokens_input: int = 0,
     voice_tokens_output: int = 0,
     voice_model_name: str | None = None,
@@ -152,6 +154,8 @@ async def persist_turn(
             "summarizer_tokens_output": ev.summarizer_tokens_output,
             "summarizer_model_name": ev.summarizer_model_name,
             "summarizer_reasoning_level": ev.summarizer_reasoning_level,
+            "summarizer_cache_read_tokens": ev.summarizer_cache_read_tokens,
+            "summarizer_cache_write_tokens": ev.summarizer_cache_write_tokens,
         }
         for ev in (compaction_events or [])
     ]
@@ -169,6 +173,8 @@ async def persist_turn(
         "chat_tokens_output": chat_tokens_output,
         "chat_model_name": chat_model_name,
         "chat_reasoning_level": chat_reasoning_level,
+        "chat_cache_read_tokens": chat_cache_read_tokens,
+        "chat_cache_write_tokens": chat_cache_write_tokens,
         "voice_tokens_input": voice_tokens_input,
         "voice_tokens_output": voice_tokens_output,
         "voice_model_name": voice_model_name,

--- a/smarter_dev/bot/services/chat_engine.py
+++ b/smarter_dev/bot/services/chat_engine.py
@@ -715,6 +715,12 @@ class ChannelEngine:
                 chat_usage = result.usage()
                 chat_in = int(getattr(chat_usage, "input_tokens", 0) or 0)
                 chat_out = int(getattr(chat_usage, "output_tokens", 0) or 0)
+                chat_cache_read = int(
+                    getattr(chat_usage, "cache_read_tokens", 0) or 0
+                )
+                chat_cache_write = int(
+                    getattr(chat_usage, "cache_write_tokens", 0) or 0
+                )
 
                 voice = dispatch.voice
                 duration_ms = int(
@@ -739,6 +745,8 @@ class ChannelEngine:
                         chat_tokens_output=chat_out,
                         chat_model_name=resolved_model_name,
                         chat_reasoning_level=resolved_reasoning_wire,
+                        chat_cache_read_tokens=chat_cache_read,
+                        chat_cache_write_tokens=chat_cache_write,
                         voice_tokens_input=(
                             voice.tokens_input if voice else 0
                         ),

--- a/smarter_dev/web/api_native/chat_conversations.py
+++ b/smarter_dev/web/api_native/chat_conversations.py
@@ -226,7 +226,13 @@ class ChatConversationController(Controller):
         """Persist one agent turn + its compaction events. Bumps engagement totals."""
         # Cost calculations — best-effort, returns 0 on unknown models.
         chat_cost = (
-            calc_cost(data.chat_tokens_input, data.chat_tokens_output, data.chat_model_name)
+            calc_cost(
+                data.chat_tokens_input,
+                data.chat_tokens_output,
+                data.chat_model_name,
+                cache_read_tokens=data.chat_cache_read_tokens or 0,
+                cache_write_tokens=data.chat_cache_write_tokens or 0,
+            )
             if data.chat_model_name
             else Decimal("0")
         )
@@ -252,6 +258,8 @@ class ChatConversationController(Controller):
             chat_tokens_output=data.chat_tokens_output,
             chat_model_name=data.chat_model_name,
             chat_reasoning_level=data.chat_reasoning_level,
+            chat_cache_read_tokens=data.chat_cache_read_tokens,
+            chat_cache_write_tokens=data.chat_cache_write_tokens,
             chat_cost_usd=chat_cost,
             voice_tokens_input=data.voice_tokens_input,
             voice_tokens_output=data.voice_tokens_output,
@@ -269,6 +277,8 @@ class ChatConversationController(Controller):
                     ev.summarizer_tokens_input,
                     ev.summarizer_tokens_output,
                     ev.summarizer_model_name,
+                    cache_read_tokens=ev.summarizer_cache_read_tokens or 0,
+                    cache_write_tokens=ev.summarizer_cache_write_tokens or 0,
                 )
                 if ev.summarizer_model_name
                 else Decimal("0")
@@ -290,6 +300,8 @@ class ChatConversationController(Controller):
                     summarizer_tokens_output=ev.summarizer_tokens_output,
                     summarizer_model_name=ev.summarizer_model_name,
                     summarizer_reasoning_level=ev.summarizer_reasoning_level,
+                    summarizer_cache_read_tokens=ev.summarizer_cache_read_tokens,
+                    summarizer_cache_write_tokens=ev.summarizer_cache_write_tokens,
                     summarizer_cost_usd=ev_cost,
                 )
             )

--- a/smarter_dev/web/api_native/schemas.py
+++ b/smarter_dev/web/api_native/schemas.py
@@ -686,6 +686,8 @@ class ChatAgentCompactionEventCreate(BaseAPIModel):
     summarizer_tokens_output: int = 0
     summarizer_model_name: Optional[str] = None
     summarizer_reasoning_level: Optional[str] = None
+    summarizer_cache_read_tokens: Optional[int] = None
+    summarizer_cache_write_tokens: Optional[int] = None
 
 
 class ChatAgentTurnCreate(BaseAPIModel):
@@ -701,6 +703,8 @@ class ChatAgentTurnCreate(BaseAPIModel):
     chat_tokens_output: int = 0
     chat_model_name: Optional[str] = None
     chat_reasoning_level: Optional[str] = None
+    chat_cache_read_tokens: Optional[int] = None
+    chat_cache_write_tokens: Optional[int] = None
     voice_tokens_input: int = 0
     voice_tokens_output: int = 0
     voice_model_name: Optional[str] = None

--- a/smarter_dev/web/llm_pricing.py
+++ b/smarter_dev/web/llm_pricing.py
@@ -163,16 +163,23 @@ def _digitalocean_cost(
 ) -> Decimal:
     """Direct cost computation for a DO-served model.
 
-    DO bills cached reads at the model's prompt-caching rate when it has one
-    (otherwise as plain input) and has no separate cache-write tier, so
-    writes bill as plain input.
+    Cache tokens follow the provider-reporting convention (same one
+    genai-prices assumes): they are a SUBSET of ``input_tokens``. The
+    uncached share bills at the input rate, cached reads at the model's
+    prompt-caching rate when it has one (otherwise plain input), and cache
+    writes at plain input (DO has no separate write tier). The uncached
+    share is clamped at zero in case a provider reports cache tokens
+    without folding them into ``input_tokens``.
     """
     input_rate = price.input_mtok
     cache_read_rate = (
         price.cache_read_mtok if price.cache_read_mtok is not None else input_rate
     )
+    uncached_input_tokens = max(
+        input_tokens - cache_read_tokens - cache_write_tokens, 0
+    )
     return (
-        Decimal(input_tokens) * input_rate
+        Decimal(uncached_input_tokens) * input_rate
         + Decimal(output_tokens) * price.output_mtok
         + Decimal(cache_read_tokens) * cache_read_rate
         + Decimal(cache_write_tokens) * input_rate
@@ -240,21 +247,25 @@ def calc_cost(
     input_tokens: int,
     output_tokens: int,
     model_name: str,
+    cache_read_tokens: int = 0,
+    cache_write_tokens: int = 0,
 ) -> Decimal:
-    """Cheaper-to-call cost helper for ad-hoc input/output token totals.
+    """Cheaper-to-call cost helper for per-turn token totals.
 
-    Same provider/model resolution as ``calc_session_cost`` but without
-    cache-token bookkeeping. Used by per-turn cost computations on the
-    chat agent (chat, compaction, voice buckets each call this once).
-    An unknown model returns Decimal("0") so the turn write still lands,
-    but logs loudly — a $0 model means this module needs a price entry.
+    Same provider/model resolution as ``calc_session_cost``. Cache tokens
+    follow the provider-reporting convention: a subset of ``input_tokens``,
+    billed at the cache rates instead of the full input rate. Used by
+    per-turn cost computations on the chat agent (chat, compaction, voice
+    buckets each call this once). An unknown model returns Decimal("0") so
+    the turn write still lands, but logs loudly — a $0 model means this
+    module needs a price entry.
     """
     try:
         return calc_session_cost(
             input_tokens=input_tokens,
             output_tokens=output_tokens,
-            cache_read_tokens=0,
-            cache_write_tokens=0,
+            cache_read_tokens=cache_read_tokens,
+            cache_write_tokens=cache_write_tokens,
             model_name=model_name,
         )
     except LookupError:

--- a/smarter_dev/web/models.py
+++ b/smarter_dev/web/models.py
@@ -4008,6 +4008,15 @@ class ChatAgentTurn(Base):
     chat_reasoning_level: Mapped[str | None] = mapped_column(
         String(16), nullable=True, default=None
     )
+    # Prompt-cache split for the chat model call. A SUBSET of chat_tokens_input
+    # (provider-reporting convention). NULL on historical rows written before
+    # the split was captured — the split for those is unknowable.
+    chat_cache_read_tokens: Mapped[int | None] = mapped_column(
+        Integer, nullable=True, default=None
+    )
+    chat_cache_write_tokens: Mapped[int | None] = mapped_column(
+        Integer, nullable=True, default=None
+    )
     chat_cost_usd: Mapped[Decimal] = mapped_column(
         Numeric(10, 6), nullable=False, default=Decimal("0")
     )
@@ -4073,6 +4082,15 @@ class ChatAgentCompactionEvent(Base):
     # runs at a fixed level), or NULL when it has no reasoning knob configured.
     summarizer_reasoning_level: Mapped[str | None] = mapped_column(
         String(16), nullable=True, default=None
+    )
+    # Prompt-cache split for the summarizer call. A SUBSET of
+    # summarizer_tokens_input (provider-reporting convention). NULL on
+    # historical rows written before the split was captured.
+    summarizer_cache_read_tokens: Mapped[int | None] = mapped_column(
+        Integer, nullable=True, default=None
+    )
+    summarizer_cache_write_tokens: Mapped[int | None] = mapped_column(
+        Integer, nullable=True, default=None
     )
     summarizer_cost_usd: Mapped[Decimal] = mapped_column(
         Numeric(10, 6), nullable=False, default=Decimal("0")

--- a/smarter_dev/web/usage_invoice.py
+++ b/smarter_dev/web/usage_invoice.py
@@ -273,6 +273,8 @@ async def monthly_invoice(db_session: AsyncSession, month: str) -> list[InvoiceL
             ChatAgentTurn.chat_reasoning_level,
             _tokens(ChatAgentTurn.chat_tokens_input).label("input_tokens"),
             _tokens(ChatAgentTurn.chat_tokens_output).label("output_tokens"),
+            _tokens(ChatAgentTurn.chat_cache_read_tokens).label("cache_read_tokens"),
+            _tokens(ChatAgentTurn.chat_cache_write_tokens).label("cache_write_tokens"),
             _cost(ChatAgentTurn.chat_cost_usd).label("cost_usd"),
         )
         .where(ChatAgentTurn.started_at >= start)
@@ -287,8 +289,8 @@ async def monthly_invoice(db_session: AsyncSession, month: str) -> list[InvoiceL
                 source="chat",
                 input_tokens=row.input_tokens,
                 output_tokens=row.output_tokens,
-                cache_read_tokens=0,
-                cache_write_tokens=0,
+                cache_read_tokens=row.cache_read_tokens,
+                cache_write_tokens=row.cache_write_tokens,
                 cost_usd=row.cost_usd,
             )
         )
@@ -329,6 +331,8 @@ async def monthly_invoice(db_session: AsyncSession, month: str) -> list[InvoiceL
             ChatAgentCompactionEvent.summarizer_reasoning_level,
             _tokens(ChatAgentCompactionEvent.summarizer_tokens_input).label("input_tokens"),
             _tokens(ChatAgentCompactionEvent.summarizer_tokens_output).label("output_tokens"),
+            _tokens(ChatAgentCompactionEvent.summarizer_cache_read_tokens).label("cache_read_tokens"),
+            _tokens(ChatAgentCompactionEvent.summarizer_cache_write_tokens).label("cache_write_tokens"),
             _cost(ChatAgentCompactionEvent.summarizer_cost_usd).label("cost_usd"),
         )
         .where(ChatAgentCompactionEvent.created_at >= start)
@@ -346,8 +350,8 @@ async def monthly_invoice(db_session: AsyncSession, month: str) -> list[InvoiceL
                 source="compaction",
                 input_tokens=row.input_tokens,
                 output_tokens=row.output_tokens,
-                cache_read_tokens=0,
-                cache_write_tokens=0,
+                cache_read_tokens=row.cache_read_tokens,
+                cache_write_tokens=row.cache_write_tokens,
                 cost_usd=row.cost_usd,
             )
         )

--- a/tests/bot/agents/test_chat_compaction.py
+++ b/tests/bot/agents/test_chat_compaction.py
@@ -29,6 +29,7 @@ from smarter_dev.bot.agents.chat_compaction import (
     KEEP_RECENT_CHARS,
     CompactionEvent,
     _should_fold,
+    _summarise_conversation,
     compact_history,
     drain_collection,
     set_last_model_call,
@@ -46,6 +47,8 @@ def _stub_result():
         tokens_input=10,
         tokens_output=5,
         model_name="stub-model",
+        cache_read_tokens=4,
+        cache_write_tokens=0,
     )
 
 
@@ -332,6 +335,8 @@ async def test_events_recorded_when_collector_active(patched_summarise):
     assert ev.summary == STUB_SUMMARY_TEXT
     assert ev.original_chars > 0
     assert ev.summarizer_model_name == "stub-model"
+    assert ev.summarizer_cache_read_tokens == 4
+    assert ev.summarizer_cache_write_tokens == 0
 
 
 @pytest.mark.asyncio
@@ -339,6 +344,50 @@ async def test_events_dropped_without_collector(patched_summarise):
     drain_collection()  # ensure no active bucket
     await compact_history(_long_history(5) + _current_turn())
     assert drain_collection() == []
+
+
+@pytest.mark.asyncio
+async def test_summarise_reads_cache_tokens_from_usage():
+    """The summariser folds the usage object's cache split onto the result."""
+    from types import SimpleNamespace
+
+    usage = SimpleNamespace(
+        input_tokens=200,
+        output_tokens=20,
+        cache_read_tokens=150,
+        cache_write_tokens=5,
+    )
+    run_result = SimpleNamespace(
+        output="a concise summary", usage=lambda: usage
+    )
+    stub_agent = SimpleNamespace(run=AsyncMock(return_value=run_result))
+    with patch(
+        "smarter_dev.bot.agents.chat_compaction.get_summarizer_agent",
+        return_value=stub_agent,
+    ):
+        result = await _summarise_conversation("some transcript")
+    assert result is not None
+    assert result.tokens_input == 200
+    assert result.cache_read_tokens == 150
+    assert result.cache_write_tokens == 5
+
+
+@pytest.mark.asyncio
+async def test_summarise_defaults_cache_tokens_when_usage_lacks_them():
+    """A usage object without cache attrs yields a zero cache split."""
+    from types import SimpleNamespace
+
+    usage = SimpleNamespace(input_tokens=200, output_tokens=20)
+    run_result = SimpleNamespace(output="summary", usage=lambda: usage)
+    stub_agent = SimpleNamespace(run=AsyncMock(return_value=run_result))
+    with patch(
+        "smarter_dev.bot.agents.chat_compaction.get_summarizer_agent",
+        return_value=stub_agent,
+    ):
+        result = await _summarise_conversation("some transcript")
+    assert result is not None
+    assert result.cache_read_tokens == 0
+    assert result.cache_write_tokens == 0
 
 
 @pytest.mark.asyncio

--- a/tests/bot/services/test_chat_conversation_persistence.py
+++ b/tests/bot/services/test_chat_conversation_persistence.py
@@ -126,6 +126,8 @@ async def test_persist_turn_serialises_compaction_events_and_delta():
         summarizer_tokens_output=7,
         summarizer_model_name="stub-model",
         summarizer_reasoning_level="low",
+        summarizer_cache_read_tokens=30,
+        summarizer_cache_write_tokens=0,
     )
     await ccp.persist_turn(
         bot=bot,
@@ -141,6 +143,8 @@ async def test_persist_turn_serialises_compaction_events_and_delta():
         chat_tokens_output=100,
         chat_model_name="gemini-3.1-flash-lite-preview",
         chat_reasoning_level="high",
+        chat_cache_read_tokens=120,
+        chat_cache_write_tokens=0,
         voice_tokens_input=80,
         voice_tokens_output=20,
         voice_model_name="gemini-2.5-flash-preview-tts",
@@ -157,6 +161,8 @@ async def test_persist_turn_serialises_compaction_events_and_delta():
     assert body["output_kind"] == "send_response"
     assert body["chat_tokens_input"] == 500
     assert body["chat_reasoning_level"] == "high"
+    assert body["chat_cache_read_tokens"] == 120
+    assert body["chat_cache_write_tokens"] == 0
     assert body["voice_tokens_input"] == 80
     assert body["voice_sent_ok"] is True
     assert body["model_messages_delta"] == []
@@ -166,6 +172,8 @@ async def test_persist_turn_serialises_compaction_events_and_delta():
     assert posted_event["original_chars"] == 12000
     assert posted_event["summarizer_tokens_input"] == 42
     assert posted_event["summarizer_reasoning_level"] == "low"
+    assert posted_event["summarizer_cache_read_tokens"] == 30
+    assert posted_event["summarizer_cache_write_tokens"] == 0
 
 
 @pytest.mark.asyncio
@@ -190,6 +198,8 @@ async def test_persist_turn_defaults_reasoning_level_to_none():
     _, kwargs = post.call_args
     # Field is always present so an unset value round-trips as an explicit None.
     assert kwargs["json_data"]["chat_reasoning_level"] is None
+    assert kwargs["json_data"]["chat_cache_read_tokens"] is None
+    assert kwargs["json_data"]["chat_cache_write_tokens"] is None
 
 
 @pytest.mark.asyncio

--- a/tests/web/llm_pricing_test.py
+++ b/tests/web/llm_pricing_test.py
@@ -47,8 +47,34 @@ class TestDigitalOceanPricing:
     def test_digitalocean_prefixed_name_also_resolves(self):
         assert calc_cost(1_000_000, 0, "digitalocean:kimi-k2.6") == Decimal("0.76")
 
-    def test_cache_read_tokens_use_prompt_caching_rate(self):
-        # kimi-k2.6 prompt caching: $0.19 per 1M tokens
+    def test_cached_reads_bill_at_caching_rate_not_input_rate(self):
+        # Providers report cache tokens as a SUBSET of input_tokens. 1M input
+        # of which 600k were cached reads on kimi-k2.6:
+        # 400k @ $0.76 + 600k @ $0.19 per Mtok.
+        cost = calc_session_cost(
+            input_tokens=1_000_000,
+            output_tokens=0,
+            cache_read_tokens=600_000,
+            cache_write_tokens=0,
+            model_name="kimi-k2.6",
+        )
+        assert cost == Decimal("0.418")
+
+    def test_cache_tokens_without_caching_rate_bill_as_input(self):
+        # gemma-4 has no prompt-caching tier on DO; the cached portion bills
+        # at the plain input rate, so the split changes nothing.
+        cost = calc_session_cost(
+            input_tokens=2_000_000,
+            output_tokens=0,
+            cache_read_tokens=1_000_000,
+            cache_write_tokens=1_000_000,
+            model_name="gemma-4-31B-it",
+        )
+        assert cost == Decimal("0.36")
+
+    def test_cache_tokens_exceeding_input_clamp_uncached_to_zero(self):
+        # Defensive: a provider reporting cache reads without folding them
+        # into input_tokens must not produce a negative uncached share.
         cost = calc_session_cost(
             input_tokens=0,
             output_tokens=0,
@@ -58,17 +84,14 @@ class TestDigitalOceanPricing:
         )
         assert cost == Decimal("0.19")
 
-    def test_cache_tokens_without_caching_rate_bill_as_input(self):
-        # gemma-4 has no prompt-caching tier on DO; cached reads/writes are
-        # billed at the plain input rate.
-        cost = calc_session_cost(
-            input_tokens=0,
-            output_tokens=0,
-            cache_read_tokens=1_000_000,
-            cache_write_tokens=1_000_000,
-            model_name="gemma-4-31B-it",
+    def test_calc_cost_accepts_cache_token_split(self):
+        cost = calc_cost(
+            1_000_000,
+            0,
+            "kimi-k2.6",
+            cache_read_tokens=600_000,
         )
-        assert cost == Decimal("0.36")
+        assert cost == Decimal("0.418")
 
 
 class TestUnknownModelFallback:

--- a/tests/web/test_api_native/test_chat_conversations.py
+++ b/tests/web/test_api_native/test_chat_conversations.py
@@ -221,6 +221,109 @@ class TestCreateTurn:
         assert len(turns) == 1
         assert turns[0].chat_reasoning_level is None
 
+    async def test_chat_cache_tokens_flow_to_row_and_discount_cost(
+        self, client: AsyncClient, session
+    ):
+        engagement = await _seed_engagement(session)
+
+        response = await client.post(
+            "/api/chat-conversations/turns",
+            json={
+                "engagement_id": str(engagement.id),
+                "request_id": "req-cache",
+                "turn_kind": "initial",
+                "output_kind": "send_response",
+                "triggering_messages": [],
+                "agent_output": {"topic": "t"},
+                "chat_tokens_input": 1000,
+                "chat_tokens_output": 500,
+                "chat_model_name": "kimi-k2.6",
+                "chat_cache_read_tokens": 400,
+                "chat_cache_write_tokens": 0,
+            },
+        )
+        assert response.status_code == 201
+        body = response.json()
+        # 600 uncached input @0.76 + 500 out @3.20 + 400 cached @0.19, per Mtok.
+        assert body["chat_cost_usd"] == "0.002132"
+
+        turns = (await session.execute(select(ChatAgentTurn))).scalars().all()
+        assert len(turns) == 1
+        assert turns[0].chat_cache_read_tokens == 400
+        assert turns[0].chat_cache_write_tokens == 0
+
+    async def test_chat_cache_tokens_absent_uses_full_input_rate(
+        self, client: AsyncClient, session
+    ):
+        engagement = await _seed_engagement(session)
+
+        response = await client.post(
+            "/api/chat-conversations/turns",
+            json={
+                "engagement_id": str(engagement.id),
+                "request_id": "req-nocache",
+                "turn_kind": "initial",
+                "output_kind": "send_response",
+                "triggering_messages": [],
+                "agent_output": {"topic": "t"},
+                "chat_tokens_input": 1000,
+                "chat_tokens_output": 500,
+                "chat_model_name": "kimi-k2.6",
+            },
+        )
+        assert response.status_code == 201
+        body = response.json()
+        # No cache split → full 1000 input @0.76 + 500 out @3.20.
+        assert body["chat_cost_usd"] == "0.00236"
+
+        turns = (await session.execute(select(ChatAgentTurn))).scalars().all()
+        assert len(turns) == 1
+        assert turns[0].chat_cache_read_tokens is None
+        assert turns[0].chat_cache_write_tokens is None
+
+    async def test_summarizer_cache_tokens_flow_to_row_and_discount_cost(
+        self, client: AsyncClient, session
+    ):
+        engagement = await _seed_engagement(session)
+
+        response = await client.post(
+            "/api/chat-conversations/turns",
+            json={
+                "engagement_id": str(engagement.id),
+                "request_id": "req-summ-cache",
+                "turn_kind": "followup",
+                "output_kind": "no_response",
+                "triggering_messages": [],
+                "agent_output": {},
+                "compaction_events": [
+                    {
+                        "event_kind": "conversation",
+                        "tool_name": None,
+                        "original_content": "aaaa",
+                        "summary": "a",
+                        "original_chars": 4,
+                        "summary_chars": 1,
+                        "summarizer_tokens_input": 2000,
+                        "summarizer_tokens_output": 100,
+                        "summarizer_model_name": "kimi-k2.6",
+                        "summarizer_cache_read_tokens": 1500,
+                        "summarizer_cache_write_tokens": 0,
+                    }
+                ],
+            },
+        )
+        assert response.status_code == 201
+        body = response.json()
+        # 500 uncached @0.76 + 100 out @3.20 + 1500 cached @0.19, per Mtok.
+        assert body["summarizer_cost_usd_total"] == "0.000985"
+
+        events = (
+            await session.execute(select(ChatAgentCompactionEvent))
+        ).scalars().all()
+        assert len(events) == 1
+        assert events[0].summarizer_cache_read_tokens == 1500
+        assert events[0].summarizer_cache_write_tokens == 0
+
     async def test_persists_compaction_events(self, client: AsyncClient, session):
         engagement = await _seed_engagement(session)
 

--- a/tests/web/usage_invoice_test.py
+++ b/tests/web/usage_invoice_test.py
@@ -251,6 +251,88 @@ async def test_multi_source_aggregation_with_mixed_reasoning(db_session):
     assert costs == sorted(costs, reverse=True)
 
 
+async def test_chat_and_compaction_cache_tokens_sum_with_null_coalesce(db_session):
+    engagement = _engagement()
+    # Two chat turns share (model, reasoning): one carries cache tokens, the
+    # other leaves the cache columns NULL (historical / not-captured row).
+    # coalesce must treat NULL as zero so the line still sums cleanly.
+    turn_cached = _turn(
+        engagement,
+        started_at=_at(2),
+        chat_model_name="kimi-k2.6",
+        chat_reasoning_level="high",
+        chat_tokens_input=1000,
+        chat_tokens_output=500,
+        chat_cache_read_tokens=400,
+        chat_cache_write_tokens=60,
+        chat_cost_usd=Decimal("0.010000"),
+    )
+    turn_null_cache = _turn(
+        engagement,
+        started_at=_at(3),
+        chat_model_name="kimi-k2.6",
+        chat_reasoning_level="high",
+        chat_tokens_input=200,
+        chat_tokens_output=100,
+        chat_cache_read_tokens=None,
+        chat_cache_write_tokens=None,
+        chat_cost_usd=Decimal("0.002000"),
+    )
+    compaction_cached = ChatAgentCompactionEvent(
+        turn=turn_cached,
+        event_kind="assistant_text",
+        original_content="x",
+        summary="y",
+        original_chars=1,
+        summary_chars=1,
+        chars_saved=0,
+        summarizer_model_name="gemini-3.1-flash-lite",
+        summarizer_reasoning_level="low",
+        summarizer_tokens_input=2000,
+        summarizer_tokens_output=100,
+        summarizer_cache_read_tokens=1500,
+        summarizer_cache_write_tokens=25,
+        summarizer_cost_usd=Decimal("0.001000"),
+    )
+    compaction_null_cache = ChatAgentCompactionEvent(
+        turn=turn_null_cache,
+        event_kind="assistant_text",
+        original_content="x",
+        summary="y",
+        original_chars=1,
+        summary_chars=1,
+        chars_saved=0,
+        summarizer_model_name="gemini-3.1-flash-lite",
+        summarizer_reasoning_level="low",
+        summarizer_tokens_input=300,
+        summarizer_tokens_output=20,
+        summarizer_cache_read_tokens=None,
+        summarizer_cache_write_tokens=None,
+        summarizer_cost_usd=Decimal("0.000500"),
+    )
+    db_session.add_all(
+        [
+            engagement,
+            turn_cached,
+            turn_null_cache,
+            compaction_cached,
+            compaction_null_cache,
+        ]
+    )
+    await db_session.commit()
+
+    lines = await monthly_invoice(db_session, "2026-07")
+    by_key = {(l.source, l.model_name, l.reasoning_level): l for l in lines}
+
+    chat = by_key[("chat", "kimi-k2.6", "high")]
+    assert chat.cache_read_tokens == 400  # 400 + NULL(->0)
+    assert chat.cache_write_tokens == 60  # 60 + NULL(->0)
+
+    compaction = by_key[("compaction", "gemini-3.1-flash-lite", "low")]
+    assert compaction.cache_read_tokens == 1500  # 1500 + NULL(->0)
+    assert compaction.cache_write_tokens == 25  # 25 + NULL(->0)
+
+
 async def test_month_filter_excludes_out_of_range_rows(db_session):
     engagement = _engagement()
     inside = _turn(


### PR DESCRIPTION
## Summary
- Chat pipeline previously discarded the `cache_read_tokens`/`cache_write_tokens` that pydantic-ai reports (a subset of `input_tokens` for all our providers), so cached tokens billed at the full input rate and the invoice cache columns were structurally 0.
- New nullable columns `chat_agent_turns.chat_cache_read_tokens`/`chat_cache_write_tokens` and `chat_agent_compaction_events.summarizer_cache_read_tokens`/`summarizer_cache_write_tokens` (migration `c4a1d9f2e6b8`, reversible), captured in the chat engine + summarizer and threaded bot → API → DB, backward-compatible with old bot payloads.
- `calc_cost`/`calc_session_cost` are now cache-aware with subset semantics: uncached input at input rate, cached reads at the prompt-caching rate (DO path clamps a negative uncached share defensively; genai-prices path handles the split natively).
- Invoice aggregation reads the real cache columns for chat + compaction (NULL coalesces to 0); UI already rendered the columns.

## Notes
- Historical rows keep NULL cache tokens — the split was never recorded, so accurate cache-discounted accounting starts at this deploy.
- Voice (TTS) has no prompt caching; unchanged.

## Testing
- Full suite: 1910 passed, 13 skipped (pre-broken fastapi module ignored).
- Exact-Decimal pricing tests (e.g. kimi-k2.6: 1M input with 600k cached = $0.418 vs $0.76 uncached) and flow tests bot→payload→API→row incl. absent-field case.
- semgrep/gitleaks clean on changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MwN5wcdiYWVpYpSP8jiyME