### PR TITLE
Gemini 3.6 Flash + 3.5 Flash Lite, temporary default-model override

### DIFF
--- a/alembic/main/versions/20260721_180000_e9b2c6d4a8f1_gemini_3_6_flash_model_key.py
+++ b/alembic/main/versions/20260721_180000_e9b2c6d4a8f1_gemini_3_6_flash_model_key.py
@@ -1,0 +1,51 @@
+"""remap gemini-3-5-flash channel overrides to gemini-3-6-flash
+
+Gemini 3.6 Flash replaced 3.5 Flash in the model catalog (2026-07-21), so the
+``gemini-3-5-flash`` catalog key no longer resolves. Any channel override
+pinned to it (as the primary model or as the fallback) would silently fall
+back to the server default; remap those rows to ``gemini-3-6-flash`` instead.
+
+Historical usage rows keep their stored ``gemini-3.5-flash`` wire id — they
+record what actually ran and are priced against that id.
+
+Revision ID: e9b2c6d4a8f1
+Revises: c4a1d9f2e6b8
+Create Date: 2026-07-21 18:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "e9b2c6d4a8f1"
+down_revision: Union[str, None] = "c4a1d9f2e6b8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_OLD_KEY = "gemini-3-5-flash"
+_NEW_KEY = "gemini-3-6-flash"
+
+
+def _remap(from_key: str, to_key: str) -> None:
+    op.execute(
+        sa.text(
+            "UPDATE channel_model_overrides SET model_key = :to_key "
+            "WHERE model_key = :from_key"
+        ).bindparams(from_key=from_key, to_key=to_key)
+    )
+    op.execute(
+        sa.text(
+            "UPDATE channel_model_overrides SET fallback_model_key = :to_key "
+            "WHERE fallback_model_key = :from_key"
+        ).bindparams(from_key=from_key, to_key=to_key)
+    )
+
+
+def upgrade() -> None:
+    _remap(_OLD_KEY, _NEW_KEY)
+
+
+def downgrade() -> None:
+    _remap(_NEW_KEY, _OLD_KEY)

--- a/scripts/chat_eval_matrix.py
+++ b/scripts/chat_eval_matrix.py
@@ -50,7 +50,7 @@ from smarter_dev.bot.agents.chat_tools import ChatDeps  # noqa: E402
 MODELS = {
     "Gemini 3.1 Flash Lite": ("google", "gemini-3.1-flash-lite"),
     "Gemini 3 Flash": ("google", "gemini-3-flash-preview"),
-    "Gemini 3.5 Flash": ("google", "gemini-3.5-flash"),
+    "Gemini 3.6 Flash": ("google", "gemini-3.6-flash"),
     "GPT 5.4 Nano": ("openai", "gpt-5.4-nano"),
     "GPT 5.4 Mini": ("openai", "gpt-5.4-mini"),
 }

--- a/scripts/eval_prices.py
+++ b/scripts/eval_prices.py
@@ -17,9 +17,17 @@ from genai_prices import data_snapshot, types
 # provider_id -> { api_id: (display_name, input_mtok, output_mtok, cache_read_mtok) }
 CUSTOM_PRICES: dict[str, dict[str, tuple[str, str, str, str | None]]] = {
     "google": {
+        # Gemini 3.5 Flash Lite — launched 2026-07-21. $0.30 in / $2.50 out / $0.03 cached.
+        # Must precede gemini-3.5-flash: that id's "gemini-3.5-flash-" prefix
+        # matcher would otherwise swallow the lite id.
+        # https://ai.google.dev/gemini-api/docs/pricing
+        "gemini-3.5-flash-lite": ("Gemini 3.5 Flash Lite", "0.3", "2.5", "0.03"),
         # Gemini 3.5 Flash — launched 2026-05-19. $1.50 in / $9.00 out / $0.15 cached.
         # https://devtk.ai/en/models/gemini-3-5-flash/ , https://pricepertoken.com/pricing-page/model/google-gemini-3.5-flash
         "gemini-3.5-flash": ("Gemini 3.5 Flash", "1.5", "9", "0.15"),
+        # Gemini 3.6 Flash — launched 2026-07-21. $1.50 in / $7.50 out / $0.15 cached.
+        # https://ai.google.dev/gemini-api/docs/pricing
+        "gemini-3.6-flash": ("Gemini 3.6 Flash", "1.5", "7.5", "0.15"),
         # Gemini 3.1 Flash Lite — GA 2026-05-07. $0.25 in / $1.50 out.
         # https://devtk.ai/en/models/gemini-3-1-flash-lite/
         "gemini-3.1-flash-lite": ("Gemini 3.1 Flash Lite", "0.25", "1.5", None),

--- a/smarter_dev/bot/plugins/model_override.py
+++ b/smarter_dev/bot/plugins/model_override.py
@@ -29,12 +29,16 @@ from typing import Any
 
 import hikari
 import lightbulb
+from redis.exceptions import RedisError
 
 from smarter_dev.bot.plugins.admin_gate import deny_if_not_admin
 from smarter_dev.bot.plugins.admin_gate import is_admin
 from smarter_dev.bot.services.channel_token_budget import fallback_ended_key
 from smarter_dev.bot.services.channel_token_budget import fallback_flag_key
 from smarter_dev.bot.services.chat_engine_registry import get_chat_engine_registry
+from smarter_dev.bot.services.default_model_override import DefaultModelOverride
+from smarter_dev.bot.services.default_model_override import parse_end_date_utc
+from smarter_dev.bot.services.default_model_override import set_default_model_override
 from smarter_dev.bot.services.exceptions import APIError
 from smarter_dev.bot.services.model_override_service import ModelOverrideService
 from smarter_dev.bot.services.models import ChannelModelOverride
@@ -54,6 +58,8 @@ from smarter_dev.bot.views.model_override_views import create_settings_modal
 from smarter_dev.bot.views.model_override_views import create_settings_panel
 from smarter_dev.bot.views.model_override_views import parse_budget
 from smarter_dev.bot.views.model_override_views import parse_panel_state
+from smarter_dev.shared.model_catalog import ALL_REASONING_LEVELS
+from smarter_dev.shared.model_catalog import MODEL_CATALOG
 from smarter_dev.shared.model_catalog import CatalogModel
 from smarter_dev.shared.model_catalog import get_model
 from smarter_dev.shared.model_catalog import is_valid_model_key
@@ -215,6 +221,97 @@ async def chat_bot_settings(ctx: lightbulb.Context) -> None:
     await ctx.respond(
         "Select a model for this channel. Pick **Server default** to remove any override.",
         components=create_model_select_message(current),
+        flags=hikari.MessageFlag.EPHEMERAL,
+    )
+
+
+@plugin.command
+@lightbulb.option(
+    "end_date",
+    "UTC end — YYYY-MM-DD (lasts through that day) or YYYY-MM-DD HH:MM",
+    type=hikari.OptionType.STRING,
+    required=True,
+)
+@lightbulb.option(
+    "reasoning",
+    "Reasoning level (clamped to what the model supports)",
+    type=hikari.OptionType.STRING,
+    choices=[
+        hikari.CommandChoice(name=level.label, value=level.value)
+        for level in ALL_REASONING_LEVELS
+    ],
+    required=True,
+)
+@lightbulb.option(
+    "model",
+    "Model to run as the temporary default",
+    type=hikari.OptionType.STRING,
+    choices=[
+        hikari.CommandChoice(name=catalog_model.label, value=catalog_model.key)
+        for catalog_model in MODEL_CATALOG
+    ],
+    required=True,
+)
+@lightbulb.command(
+    "chat-default-model-override",
+    "Temporarily switch the default chat model until a UTC end date (admin only)",
+)
+@lightbulb.implements(lightbulb.SlashCommand)
+async def chat_default_model_override(ctx: lightbulb.Context) -> None:
+    """Store a self-expiring bot-wide default-model override in Redis.
+
+    Applies to every channel *without* its own ``/chat-bot-settings`` override;
+    the chat engine reads it per turn, and the Redis ``EXAT`` reverts the
+    default automatically at the end date.
+    """
+    if await deny_if_not_admin(ctx, ADMIN_DENIAL_MESSAGE):
+        return
+
+    model = get_model(ctx.options.model)
+    if model is None:
+        await ctx.respond(
+            "❌ That model is no longer available.",
+            flags=hikari.MessageFlag.EPHEMERAL,
+        )
+        return
+
+    try:
+        expires_at = parse_end_date_utc(ctx.options.end_date, datetime.now(UTC))
+    except ValueError as exc:
+        await ctx.respond(f"❌ {exc}", flags=hikari.MessageFlag.EPHEMERAL)
+        return
+
+    redis = _budget_redis(ctx.bot)
+    if redis is None:
+        await ctx.respond(
+            "❌ Couldn't reach the override store — please try again shortly.",
+            flags=hikari.MessageFlag.EPHEMERAL,
+        )
+        return
+
+    expires_at_epoch = int(expires_at.timestamp())
+    try:
+        await set_default_model_override(
+            redis,
+            DefaultModelOverride(
+                model_key=model.key,
+                reasoning_level=ctx.options.reasoning,
+                expires_at_epoch=expires_at_epoch,
+            ),
+        )
+    except RedisError:
+        logger.exception("Failed to store the temporary default-model override")
+        await ctx.respond(
+            "❌ Couldn't save the override — please try again shortly.",
+            flags=hikari.MessageFlag.EPHEMERAL,
+        )
+        return
+
+    await ctx.respond(
+        f"✅ Default chat model is temporarily **{model.label}** until "
+        f"<t:{expires_at_epoch}:f> (<t:{expires_at_epoch}:R>).\n"
+        f"• Reasoning: {_render_reasoning(model, ctx.options.reasoning)}\n"
+        "• Channels with their own `/chat-bot-settings` override are unaffected.",
         flags=hikari.MessageFlag.EPHEMERAL,
     )
 

--- a/smarter_dev/bot/services/chat_engine.py
+++ b/smarter_dev/bot/services/chat_engine.py
@@ -60,6 +60,7 @@ from smarter_dev.bot.agents.chat_tools import GeneratedImage
 from smarter_dev.shared.model_catalog import get_model
 from smarter_dev.bot.services.channel_token_budget import add_fallback_usage
 from smarter_dev.bot.services.channel_token_budget import add_usage
+from smarter_dev.bot.services.default_model_override import read_default_model_override
 from smarter_dev.bot.services.channel_token_budget import fallback_ended_key
 from smarter_dev.bot.services.channel_token_budget import fallback_flag_key
 from smarter_dev.bot.services.exceptions import APIError
@@ -581,6 +582,14 @@ class ChannelEngine:
                     if override is not None and override_model_id is not None
                     else None
                 )
+            # A temporary bot-wide default-model override (set via the admin
+            # ``/chat-default-model-override`` command, self-expiring in Redis)
+            # substitutes for the configured default — so it applies only when
+            # no channel override chose this turn's model.
+            if override_model_id is None and budget_redis is not None:
+                override_model_id, override_reasoning = (
+                    await self._resolve_temporary_default(budget_redis)
+                )
             # The model this turn actually runs on: the override's wire id when
             # one applied, otherwise the configured default. Persisted with the
             # turn so the dashboard prices tokens against the right model.
@@ -1057,6 +1066,29 @@ class ChannelEngine:
             )
             return None
         return catalog_model.model_id
+
+    async def _resolve_temporary_default(
+        self, redis: Any
+    ) -> tuple[str | None, str | None]:
+        """(wire model id, reasoning level) from the temporary bot-wide default
+        override, or ``(None, None)`` when none is active.
+
+        A stored ``model_key`` the catalog no longer knows degrades to the
+        configured default with a warning, mirroring
+        :meth:`_resolve_override_model_id`.
+        """
+        temporary_default = await read_default_model_override(redis)
+        if temporary_default is None:
+            return None, None
+        catalog_model = get_model(temporary_default.model_key)
+        if catalog_model is None:
+            logger.warning(
+                "Temporary default override names unknown model_key %r — "
+                "using the configured default model",
+                temporary_default.model_key,
+            )
+            return None, None
+        return catalog_model.model_id, temporary_default.reasoning_level
 
     def _fallback_flag_key(self) -> str:
         """Redis key for this channel's active free-fallback flag."""

--- a/smarter_dev/bot/services/default_model_override.py
+++ b/smarter_dev/bot/services/default_model_override.py
@@ -1,0 +1,122 @@
+"""Temporary bot-wide default chat model override, stored in Redis.
+
+The admin ``/chat-default-model-override`` command points the *default* chat
+model (the one used by every channel without its own ``/chat-bot-settings``
+override) at a different catalog model until a UTC end date. The value lives
+in a single Redis key whose ``EXAT`` is the end date, so the override expires
+on its own and survives bot restarts — the same time-boxed-switch pattern as
+the per-channel free-fallback window in :mod:`channel_token_budget`.
+
+Per-channel overrides always win: the chat engine consults this key only when
+no channel override chose the turn's model.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from datetime import UTC
+from datetime import datetime
+from datetime import timedelta
+
+from redis.asyncio import Redis
+from redis.exceptions import RedisError
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MODEL_OVERRIDE_KEY = "chat-default-model-override"
+
+
+@dataclass(frozen=True)
+class DefaultModelOverride:
+    """The temporary default-model choice and when it ends.
+
+    ``model_key`` is a catalog key (not a wire id); ``reasoning_level`` is a
+    :class:`~smarter_dev.shared.model_catalog.ReasoningLevel` wire value or
+    ``None`` for the model's default. ``expires_at_epoch`` is the UTC epoch
+    second the override ends (also the Redis key's ``EXAT``).
+    """
+
+    model_key: str
+    reasoning_level: str | None
+    expires_at_epoch: int
+
+
+def parse_end_date_utc(text: str, now: datetime) -> datetime:
+    """Parse the command's end-date input into an aware UTC datetime.
+
+    Accepts ``YYYY-MM-DD HH:MM`` (that exact UTC minute) or ``YYYY-MM-DD``
+    (the override lasts through the end of that UTC day). Raises ``ValueError``
+    with a user-facing message on a malformed input or an end in the past.
+    """
+    cleaned = text.strip()
+    parsed: datetime | None = None
+    for fmt in ("%Y-%m-%d %H:%M", "%Y-%m-%dT%H:%M"):
+        try:
+            parsed = datetime.strptime(cleaned, fmt).replace(tzinfo=UTC)
+            break
+        except ValueError:
+            continue
+    if parsed is None:
+        try:
+            date_only = datetime.strptime(cleaned, "%Y-%m-%d").replace(tzinfo=UTC)
+        except ValueError as exc:
+            raise ValueError(
+                "End date must be `YYYY-MM-DD` or `YYYY-MM-DD HH:MM` (UTC), "
+                f"got `{cleaned}`."
+            ) from exc
+        # A bare date means "through the end of that UTC day".
+        parsed = date_only + timedelta(days=1)
+    if parsed <= now:
+        raise ValueError(
+            f"End date `{cleaned}` is not in the future (it's currently "
+            f"{now:%Y-%m-%d %H:%M} UTC)."
+        )
+    return parsed
+
+
+async def set_default_model_override(
+    redis: Redis, override: DefaultModelOverride
+) -> None:
+    """Store ``override``, expiring it at its own ``expires_at_epoch``."""
+    payload = json.dumps(
+        {
+            "model_key": override.model_key,
+            "reasoning_level": override.reasoning_level,
+            "expires_at_epoch": override.expires_at_epoch,
+        }
+    )
+    await redis.set(
+        DEFAULT_MODEL_OVERRIDE_KEY, payload, exat=override.expires_at_epoch
+    )
+
+
+async def read_default_model_override(redis: Redis) -> DefaultModelOverride | None:
+    """The active temporary default override, or ``None`` when there is none.
+
+    Best-effort: a chat turn must never break because this read failed, so
+    Redis trouble or a corrupt/stale payload degrades to "no override" (Redis
+    expiry itself handles the time bound). Validation of the stored
+    ``model_key`` against the catalog is the caller's job — the engine already
+    treats an unknown key as "use the default".
+    """
+    try:
+        raw = await redis.get(DEFAULT_MODEL_OVERRIDE_KEY)
+    except (RedisError, TypeError):
+        logger.debug("could not read the default-model override", exc_info=True)
+        return None
+    if raw is None:
+        return None
+    try:
+        payload = json.loads(raw)
+        return DefaultModelOverride(
+            model_key=payload["model_key"],
+            reasoning_level=payload.get("reasoning_level"),
+            expires_at_epoch=int(payload["expires_at_epoch"]),
+        )
+    except (ValueError, KeyError, TypeError):
+        logger.warning(
+            "Corrupt default-model override payload %r — ignoring it", raw
+        )
+        return None

--- a/smarter_dev/shared/config.py
+++ b/smarter_dev/shared/config.py
@@ -105,7 +105,7 @@ class Settings(BaseSettings):
         description="Model that reviews candidate handler scripts (Gemini 3 Flash)",
     )
     handler_admin_second_judge_model: str = Field(
-        default="gemini-3.5-flash",
+        default="gemini-3.6-flash",
         description="Second judge for ADMIN handlers — reviews in series with the "
         "primary judge and either rejection blocks install (their observed blind "
         "spots don't overlap). Empty string disables the second judge.",

--- a/smarter_dev/shared/model_catalog.py
+++ b/smarter_dev/shared/model_catalog.py
@@ -240,11 +240,22 @@ MODEL_CATALOG: tuple[CatalogModel, ...] = (
         default_reasoning=ReasoningLevel.HIGH,
     ),
     CatalogModel(
-        key="gemini-3-5-flash",
-        label="Gemini 3.5 Flash",
+        key="gemini-3-5-flash-lite",
+        label="Gemini 3.5 Flash Lite",
         family="Gemini",
         provider=ModelProvider.GOOGLE,
-        model_id="gemini-3.5-flash",
+        model_id="gemini-3.5-flash-lite",
+        reasoning_levels=_GEMINI_THINKING,
+        default_reasoning=ReasoningLevel.MEDIUM,
+    ),
+    # Gemini 3.6 Flash replaced 3.5 Flash (2026-07-21); the old
+    # ``gemini-3-5-flash`` key was remapped to this entry by migration.
+    CatalogModel(
+        key="gemini-3-6-flash",
+        label="Gemini 3.6 Flash",
+        family="Gemini",
+        provider=ModelProvider.GOOGLE,
+        model_id="gemini-3.6-flash",
         reasoning_levels=_GEMINI_THINKING,
         default_reasoning=ReasoningLevel.MEDIUM,
     ),

--- a/smarter_dev/web/llm_pricing.py
+++ b/smarter_dev/web/llm_pricing.py
@@ -55,6 +55,50 @@ _patch_provider(
     ),
 )
 
+# Gemini 3.5 Flash Lite — not yet in genai-prices
+# NOTE: must come before gemini-3.5-flash so the more specific match wins
+_patch_provider(
+    "google",
+    types.ModelInfo(
+        id="gemini-3.5-flash-lite",
+        match=types.ClauseStartsWith(starts_with="gemini-3.5-flash-lite"),
+        prices=types.ModelPrice(
+            input_mtok=Decimal("0.30"),
+            output_mtok=Decimal("2.50"),
+            cache_read_mtok=Decimal("0.03"),
+        ),
+    ),
+)
+
+# Gemini 3.5 Flash — not yet in genai-prices. Retired as a selectable model
+# (replaced by 3.6 Flash) but historical turns still price against it.
+_patch_provider(
+    "google",
+    types.ModelInfo(
+        id="gemini-3.5-flash",
+        match=types.ClauseStartsWith(starts_with="gemini-3.5-flash"),
+        prices=types.ModelPrice(
+            input_mtok=Decimal("1.50"),
+            output_mtok=Decimal("9.00"),
+            cache_read_mtok=Decimal("0.15"),
+        ),
+    ),
+)
+
+# Gemini 3.6 Flash — not yet in genai-prices
+_patch_provider(
+    "google",
+    types.ModelInfo(
+        id="gemini-3.6-flash",
+        match=types.ClauseStartsWith(starts_with="gemini-3.6-flash"),
+        prices=types.ModelPrice(
+            input_mtok=Decimal("1.50"),
+            output_mtok=Decimal("7.50"),
+            cache_read_mtok=Decimal("0.15"),
+        ),
+    ),
+)
+
 # GPT-5.4 Nano — not yet in genai-prices
 _patch_provider(
     "openai",

--- a/smarter_dev/web/usage_invoice.py
+++ b/smarter_dev/web/usage_invoice.py
@@ -49,6 +49,8 @@ _PROVIDER_BY_FLAT_MODEL_ID: dict[str, str] = {
     catalog_model.model_id: catalog_model.provider.value
     for catalog_model in MODEL_CATALOG
 }
+# Wire ids of retired catalog models — historical usage rows still carry them.
+_PROVIDER_BY_FLAT_MODEL_ID.setdefault("gemini-3.5-flash", "google")
 
 # Provider key -> human display label.
 PROVIDER_LABELS: dict[str, str] = {

--- a/tests/bot/agents/test_model_catalog.py
+++ b/tests/bot/agents/test_model_catalog.py
@@ -78,6 +78,21 @@ def test_resolve_reasoning_level_none_for_models_without_reasoning():
     assert resolve_reasoning_level(gemma, None) is None
 
 
+def test_gemini_lineup_reflects_current_releases():
+    # 3.6 Flash replaced 3.5 Flash (2026-07-21); 3.5 Flash Lite joined the
+    # catalog; 3.1 Flash Lite stays (it is still the configured chat default).
+    assert get_model("gemini-3-5-flash") is None
+    flash_3_6 = get_model("gemini-3-6-flash")
+    assert flash_3_6 is not None
+    assert flash_3_6.model_id == "gemini-3.6-flash"
+    assert flash_3_6.provider is ModelProvider.GOOGLE
+    lite_3_5 = get_model("gemini-3-5-flash-lite")
+    assert lite_3_5 is not None
+    assert lite_3_5.model_id == "gemini-3.5-flash-lite"
+    assert lite_3_5.provider is ModelProvider.GOOGLE
+    assert get_model("gemini-3-1-flash-lite").model_id == "gemini-3.1-flash-lite"
+
+
 def test_keys_are_unique():
     keys = [model.key for model in MODEL_CATALOG]
     assert len(keys) == len(set(keys))

--- a/tests/bot/services/test_chat_engine_override.py
+++ b/tests/bot/services/test_chat_engine_override.py
@@ -8,6 +8,7 @@ skips a turn for budget, and when it meters usage.
 from __future__ import annotations
 
 import asyncio
+import json
 from datetime import UTC, datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -119,6 +120,8 @@ def fake_redis():
     # Fallback flag/marker reads default to "absent" so normal budget flow runs.
     r.exists = AsyncMock(return_value=0)
     r.delete = AsyncMock(return_value=0)
+    # The temporary default-model override read defaults to "none active".
+    r.get = AsyncMock(return_value=None)
     # The engine also records per-user message-limit charges through a
     # pipeline on this same Redis — make that path awaitable and inert.
     pipe = MagicMock()
@@ -308,6 +311,105 @@ async def test_no_override_uses_default_and_skips_enforcement_but_meters(
     get_agent_mock.assert_called_once_with(None, None)
     over_budget_mock.assert_not_called()
     add_usage_mock.assert_awaited_once_with(fake_redis, "42", 150)
+
+
+def _temporary_default_payload(
+    model_key: str = "gemini-3-6-flash", reasoning_level: str | None = "high"
+) -> str:
+    return json.dumps(
+        {
+            "model_key": model_key,
+            "reasoning_level": reasoning_level,
+            "expires_at_epoch": 1_800_000_000,
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_temporary_default_applies_without_channel_override(
+    fake_memory, fake_redis
+):
+    """With no channel override, an active temporary default-model override
+    picks the turn's model + reasoning and is the persisted model name."""
+    agent_mock = MagicMock()
+    agent_mock.run = AsyncMock(return_value=_result(_send()))
+    fake_redis.get = AsyncMock(return_value=_temporary_default_payload())
+    engine, _ = _make_engine(None, fake_redis)
+
+    persist_turn = AsyncMock()
+    get_agent = patch(
+        "smarter_dev.bot.services.chat_engine.get_chat_agent",
+        return_value=agent_mock,
+    )
+    with get_agent as get_agent_mock, _patches(
+        agent_mock=agent_mock, fake_memory=fake_memory
+    )[1], _patches(agent_mock=agent_mock, fake_memory=fake_memory)[2], patch(
+        "smarter_dev.bot.services.chat_engine.add_usage", new=AsyncMock()
+    ), patch(
+        "smarter_dev.bot.services.chat_engine.start_engagement",
+        new=AsyncMock(return_value="engagement-1"),
+    ), patch(
+        "smarter_dev.bot.services.chat_engine.persist_turn", new=persist_turn
+    ):
+        await engine._run_once(first_activation=True)
+
+    get_agent_mock.assert_called_once_with("gemini-3.6-flash", "high")
+    assert persist_turn.await_args.kwargs["chat_model_name"] == "gemini-3.6-flash"
+
+
+@pytest.mark.asyncio
+async def test_channel_override_wins_over_temporary_default(
+    fake_memory, fake_redis
+):
+    """A channel's own override stays authoritative while a temporary
+    bot-wide default override is active."""
+    agent_mock = MagicMock()
+    agent_mock.run = AsyncMock(return_value=_result(_send()))
+    fake_redis.get = AsyncMock(return_value=_temporary_default_payload())
+    engine, _ = _make_engine(_override("gpt-5-4"), fake_redis)
+
+    get_agent = patch(
+        "smarter_dev.bot.services.chat_engine.get_chat_agent",
+        return_value=agent_mock,
+    )
+    with get_agent as get_agent_mock, _patches(
+        agent_mock=agent_mock, fake_memory=fake_memory
+    )[1], _patches(agent_mock=agent_mock, fake_memory=fake_memory)[2], patch(
+        "smarter_dev.bot.services.chat_engine.over_budget_reset_epoch",
+        new=AsyncMock(return_value=None),
+    ), patch(
+        "smarter_dev.bot.services.chat_engine.add_usage", new=AsyncMock()
+    ):
+        await engine._run_once(first_activation=True)
+
+    get_agent_mock.assert_called_once_with("gpt-5.4", None)
+
+
+@pytest.mark.asyncio
+async def test_temporary_default_with_stale_key_uses_configured_default(
+    fake_memory, fake_redis
+):
+    """A temporary default naming a retired catalog key degrades to the
+    configured default model instead of breaking the turn."""
+    agent_mock = MagicMock()
+    agent_mock.run = AsyncMock(return_value=_result(_send()))
+    fake_redis.get = AsyncMock(
+        return_value=_temporary_default_payload(model_key="gemini-3-5-flash")
+    )
+    engine, _ = _make_engine(None, fake_redis)
+
+    get_agent = patch(
+        "smarter_dev.bot.services.chat_engine.get_chat_agent",
+        return_value=agent_mock,
+    )
+    with get_agent as get_agent_mock, _patches(
+        agent_mock=agent_mock, fake_memory=fake_memory
+    )[1], _patches(agent_mock=agent_mock, fake_memory=fake_memory)[2], patch(
+        "smarter_dev.bot.services.chat_engine.add_usage", new=AsyncMock()
+    ):
+        await engine._run_once(first_activation=True)
+
+    get_agent_mock.assert_called_once_with(None, None)
 
 
 @pytest.mark.asyncio

--- a/tests/bot/services/test_default_model_override.py
+++ b/tests/bot/services/test_default_model_override.py
@@ -1,0 +1,130 @@
+"""Tests for the temporary bot-wide default chat model override store."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC
+from datetime import datetime
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+
+import pytest
+from redis.exceptions import RedisError
+
+from smarter_dev.bot.services.default_model_override import (
+    DEFAULT_MODEL_OVERRIDE_KEY,
+    DefaultModelOverride,
+    parse_end_date_utc,
+    read_default_model_override,
+    set_default_model_override,
+)
+
+NOW = datetime(2026, 7, 21, 12, 0, tzinfo=UTC)
+
+
+# --------------------------------------------------------------------------- #
+# End-date parsing
+# --------------------------------------------------------------------------- #
+
+
+def test_parse_end_date_accepts_utc_minute():
+    parsed = parse_end_date_utc("2026-07-25 18:30", NOW)
+    assert parsed == datetime(2026, 7, 25, 18, 30, tzinfo=UTC)
+
+
+def test_parse_end_date_bare_date_lasts_through_that_day():
+    parsed = parse_end_date_utc("2026-07-25", NOW)
+    assert parsed == datetime(2026, 7, 26, 0, 0, tzinfo=UTC)
+
+
+def test_parse_end_date_bare_today_still_ends_in_the_future():
+    # "Today" as a bare date runs through the end of the current UTC day.
+    parsed = parse_end_date_utc("2026-07-21", NOW)
+    assert parsed == datetime(2026, 7, 22, 0, 0, tzinfo=UTC)
+
+
+def test_parse_end_date_strips_whitespace():
+    parsed = parse_end_date_utc("  2026-07-25 06:00  ", NOW)
+    assert parsed == datetime(2026, 7, 25, 6, 0, tzinfo=UTC)
+
+
+@pytest.mark.parametrize("raw", ["soon", "07/25/2026", "2026-13-01", "2026-07-25 24:99", ""])
+def test_parse_end_date_rejects_malformed_input(raw):
+    with pytest.raises(ValueError, match="YYYY-MM-DD"):
+        parse_end_date_utc(raw, NOW)
+
+
+def test_parse_end_date_rejects_past_end():
+    with pytest.raises(ValueError, match="not in the future"):
+        parse_end_date_utc("2026-07-21 11:59", NOW)
+
+
+def test_parse_end_date_rejects_yesterday():
+    with pytest.raises(ValueError, match="not in the future"):
+        parse_end_date_utc("2026-07-20", NOW)
+
+
+# --------------------------------------------------------------------------- #
+# Redis round trip
+# --------------------------------------------------------------------------- #
+
+
+def _redis_with(raw):
+    redis = MagicMock()
+    redis.get = AsyncMock(return_value=raw)
+    redis.set = AsyncMock()
+    return redis
+
+
+@pytest.mark.asyncio
+async def test_set_stores_payload_expiring_at_end_epoch():
+    redis = _redis_with(None)
+    override = DefaultModelOverride(
+        model_key="gemini-3-6-flash",
+        reasoning_level="high",
+        expires_at_epoch=1_790_000_000,
+    )
+
+    await set_default_model_override(redis, override)
+
+    redis.set.assert_awaited_once()
+    args, kwargs = redis.set.await_args
+    assert args[0] == DEFAULT_MODEL_OVERRIDE_KEY
+    assert kwargs["exat"] == 1_790_000_000
+    assert json.loads(args[1]) == {
+        "model_key": "gemini-3-6-flash",
+        "reasoning_level": "high",
+        "expires_at_epoch": 1_790_000_000,
+    }
+
+
+@pytest.mark.asyncio
+async def test_read_round_trips_a_stored_override():
+    redis = _redis_with(None)
+    override = DefaultModelOverride(
+        model_key="gemini-3-5-flash-lite",
+        reasoning_level=None,
+        expires_at_epoch=1_790_000_000,
+    )
+    await set_default_model_override(redis, override)
+    stored = redis.set.await_args.args[1]
+
+    assert await read_default_model_override(_redis_with(stored)) == override
+
+
+@pytest.mark.asyncio
+async def test_read_absent_key_returns_none():
+    assert await read_default_model_override(_redis_with(None)) is None
+
+
+@pytest.mark.asyncio
+async def test_read_corrupt_payload_returns_none():
+    assert await read_default_model_override(_redis_with("not json")) is None
+    assert await read_default_model_override(_redis_with('{"nope": 1}')) is None
+
+
+@pytest.mark.asyncio
+async def test_read_redis_error_degrades_to_none():
+    redis = MagicMock()
+    redis.get = AsyncMock(side_effect=RedisError("down"))
+    assert await read_default_model_override(redis) is None

--- a/tests/bot/test_model_override.py
+++ b/tests/bot/test_model_override.py
@@ -6,6 +6,7 @@ select + button + modal-submit interaction handlers (single settings-panel flow)
 
 from __future__ import annotations
 
+import json
 from datetime import UTC
 from datetime import datetime
 from unittest.mock import AsyncMock
@@ -462,6 +463,110 @@ async def test_chat_bot_settings_shows_select_for_admin():
     _, kwargs = ctx.respond.call_args
     assert kwargs["components"]  # a select action row was attached
     assert kwargs["flags"] == hikari.MessageFlag.EPHEMERAL
+
+
+# --------------------------------------------------------------------------- #
+# /chat-default-model-override command
+# --------------------------------------------------------------------------- #
+
+
+def _default_override_ctx(
+    redis,
+    model: str = "gemini-3-6-flash",
+    reasoning: str = "high",
+    end_date: str = "2030-01-01",
+):
+    ctx = Mock()
+    ctx.member = Mock(spec=hikari.InteractionMember)
+    ctx.guild_id = "G"
+    ctx.channel_id = "C"
+    ctx.respond = AsyncMock()
+    ctx.bot = Mock()
+    ctx.bot.d = {"chat_memory_redis": redis} if redis is not None else {}
+    ctx.options = Mock()
+    ctx.options.model = model
+    ctx.options.reasoning = reasoning
+    ctx.options.end_date = end_date
+    return ctx
+
+
+async def test_chat_default_model_override_denies_non_admin():
+    redis = Mock()
+    redis.set = AsyncMock()
+    ctx = _default_override_ctx(redis)
+    with patch(PERMS_TARGET, return_value=NONE):
+        await model_override.chat_default_model_override(ctx)
+
+    redis.set.assert_not_called()
+    ctx.respond.assert_called_once()
+    _, kwargs = ctx.respond.call_args
+    assert kwargs.get("flags") == hikari.MessageFlag.EPHEMERAL
+
+
+async def test_chat_default_model_override_stores_self_expiring_override():
+    redis = Mock()
+    redis.set = AsyncMock()
+    ctx = _default_override_ctx(redis, end_date="2030-01-01")
+    with patch(PERMS_TARGET, return_value=ADMIN):
+        await model_override.chat_default_model_override(ctx)
+
+    # A bare end date lasts through that whole UTC day.
+    expected_epoch = int(datetime(2030, 1, 2, tzinfo=UTC).timestamp())
+    redis.set.assert_awaited_once()
+    args, kwargs = redis.set.await_args
+    assert kwargs["exat"] == expected_epoch
+    assert json.loads(args[1]) == {
+        "model_key": "gemini-3-6-flash",
+        "reasoning_level": "high",
+        "expires_at_epoch": expected_epoch,
+    }
+    message = ctx.respond.call_args.args[0]
+    assert "Gemini 3.6 Flash" in message
+    assert f"<t:{expected_epoch}:f>" in message
+
+
+async def test_chat_default_model_override_accepts_utc_minute_end():
+    redis = Mock()
+    redis.set = AsyncMock()
+    ctx = _default_override_ctx(redis, end_date="2030-01-01 18:30")
+    with patch(PERMS_TARGET, return_value=ADMIN):
+        await model_override.chat_default_model_override(ctx)
+
+    expected_epoch = int(datetime(2030, 1, 1, 18, 30, tzinfo=UTC).timestamp())
+    assert redis.set.await_args.kwargs["exat"] == expected_epoch
+
+
+async def test_chat_default_model_override_rejects_bad_end_date():
+    redis = Mock()
+    redis.set = AsyncMock()
+    ctx = _default_override_ctx(redis, end_date="whenever")
+    with patch(PERMS_TARGET, return_value=ADMIN):
+        await model_override.chat_default_model_override(ctx)
+
+    redis.set.assert_not_called()
+    message = ctx.respond.call_args.args[0]
+    assert "YYYY-MM-DD" in message
+
+
+async def test_chat_default_model_override_rejects_past_end_date():
+    redis = Mock()
+    redis.set = AsyncMock()
+    ctx = _default_override_ctx(redis, end_date="2020-01-01")
+    with patch(PERMS_TARGET, return_value=ADMIN):
+        await model_override.chat_default_model_override(ctx)
+
+    redis.set.assert_not_called()
+    message = ctx.respond.call_args.args[0]
+    assert "not in the future" in message
+
+
+async def test_chat_default_model_override_without_redis_reports_error():
+    ctx = _default_override_ctx(None)
+    with patch(PERMS_TARGET, return_value=ADMIN):
+        await model_override.chat_default_model_override(ctx)
+
+    message = ctx.respond.call_args.args[0]
+    assert "Couldn't reach the override store" in message
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Model catalog refresh

- **Gemini 3.5 Flash → 3.6 Flash** everywhere it was used: catalog entry (new key `gemini-3-6-flash`, wire id `gemini-3.6-flash`), the ADMIN-handler second judge, and the chat eval matrix. Migration `e9b2c6d4a8f1` remaps stored channel-override keys (primary and fallback) so no channel silently falls back to the server default.
- **Gemini 3.5 Flash Lite** added as a selectable channel model (`gemini-3.5-flash-lite`, $0.30/$2.50).
- **Gemini 3.1 Flash Lite untouched** — still the configured default chat model.
- Pricing patches for both new models (rates from Google's pricing page), plus the previously **missing `gemini-3.5-flash` price entry — its turns were recording \$0**. Retired wire ids keep resolving to Google on the usage invoice.

## `/chat-default-model-override`

Admin command taking a **model**, **reasoning level**, and **end date UTC** (`YYYY-MM-DD` lasts through that day, or `YYYY-MM-DD HH:MM`). Stores a single Redis key with `EXAT` at the end date — self-expires, survives restarts, no scheduler. The chat engine consults it only when no per-channel override chose the turn's model, so `/chat-bot-settings` overrides always win. Stale keys / corrupt payloads / Redis outages degrade to the configured default.

## Testing

- 896 tests green across the bot suite and affected web suites (catalog, engine wiring, command gate/validation, Redis round-trip, pricing, invoice, migration ownership).
- `alembic heads` shows a single head; migration runs via the in-cluster migrate job on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ThsbEtkTfXyoSFCw9uu17w