### PR TITLE
Tell the chat agent which model and reasoning level it runs on

### DIFF
--- a/smarter_dev/bot/agents/chat_agent.py
+++ b/smarter_dev/bot/agents/chat_agent.py
@@ -149,6 +149,33 @@ def resolved_reasoning_level(
     return effective.value if effective is not None else None
 
 
+def _model_identity_prompt(resolved_id: str, reasoning_level: str | None) -> str:
+    """System-prompt section telling the agent which model it is running on.
+
+    Members sometimes ask the bot which model answered them; the agent can
+    only answer truthfully if it is told. Appended per cached agent — the
+    cache is keyed by (model id, reasoning level), so each agent's identity
+    text matches its actual configuration, including channel overrides and
+    the temporary default override.
+    """
+    catalog_model = _catalog_model_for_id(resolved_id)
+    label = catalog_model.label if catalog_model is not None else resolved_id
+    effective_level = resolved_reasoning_level(resolved_id, reasoning_level)
+    if effective_level is not None:
+        configuration = (
+            f"**{label}** (`{resolved_id}`) at reasoning level"
+            f" **{effective_level}**"
+        )
+    else:
+        configuration = f"**{label}** (`{resolved_id}`)"
+    return (
+        "\n\n## Your model\n\n"
+        f"You are currently running on {configuration}. Only share your model "
+        "or reasoning level when someone asks about it — never volunteer this "
+        "configuration unprompted."
+    )
+
+
 # One agent per resolved (model id, reasoning level). A per-channel override
 # means we can no longer share a single global agent, so agents are cached by the
 # wire model id *and* reasoning level they were built for — two channels on the
@@ -178,7 +205,8 @@ def get_chat_agent(
             build_agent_model(resolved_id),
             output_type=_output_type_for(resolved_id),
             deps_type=ChatDeps,
-            system_prompt=SYSTEM_PROMPT,
+            system_prompt=SYSTEM_PROMPT
+            + _model_identity_prompt(resolved_id, reasoning_level),
             tools=chat_tool_functions() + handler_tool_functions(),
             model_settings=_model_settings_for(resolved_id, reasoning_level),
             history_processors=[compact_history],

--- a/tests/bot/agents/test_chat_agent_override.py
+++ b/tests/bot/agents/test_chat_agent_override.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 
 import smarter_dev.bot.agents.chat_agent as chat_agent
+from smarter_dev.bot.agents.chat_agent import _model_identity_prompt
 from smarter_dev.bot.agents.chat_agent import get_chat_agent
 from smarter_dev.bot.agents.chat_agent import resolved_reasoning_level
 
@@ -67,6 +68,56 @@ def test_none_resolves_to_env_default_and_is_singleton_equivalent(monkeypatch):
     explicit_default = get_chat_agent(chat_agent.DEFAULT_MODEL)
     assert default_first is default_second
     assert default_first is explicit_default
+
+
+def test_model_identity_prompt_names_model_and_resolved_reasoning():
+    identity = _model_identity_prompt("gpt-5.4", "high")
+    assert "GPT-5.4" in identity
+    assert "`gpt-5.4`" in identity
+    assert "**high**" in identity
+
+
+def test_model_identity_prompt_reports_the_clamped_level():
+    # Gemini's thinking_level tops out at "high" — the identity must reflect
+    # what actually runs, not the raw stored choice.
+    identity = _model_identity_prompt("gemini-3.1-flash-lite", "max")
+    assert "**high**" in identity
+    assert "max" not in identity
+
+
+def test_model_identity_prompt_omits_reasoning_without_knob():
+    identity = _model_identity_prompt("kimi-k2.6", "high")
+    assert "Kimi K2.6" in identity
+    assert "at reasoning level" not in identity
+
+
+def test_model_identity_prompt_handles_adhoc_model_id():
+    identity = _model_identity_prompt("some-unlisted-model", None)
+    assert "`some-unlisted-model`" in identity
+    assert "at reasoning level" not in identity
+
+
+def test_model_identity_prompt_is_share_on_request_only():
+    identity = _model_identity_prompt("gpt-5.4", None)
+    assert "when someone asks" in identity
+    assert "never volunteer" in identity
+
+
+def test_agent_system_prompt_carries_its_model_identity():
+    _reset_cache()
+    agent = get_chat_agent("gpt-5.4", "high")
+    prompt = "".join(agent._system_prompts)
+    assert "## Your model" in prompt
+    assert "`gpt-5.4`" in prompt
+    assert "**high**" in prompt
+
+
+def test_default_agent_system_prompt_names_the_default_model(monkeypatch):
+    _reset_cache()
+    monkeypatch.delenv(chat_agent.MODEL_ENV_VAR, raising=False)
+    agent = get_chat_agent()
+    prompt = "".join(agent._system_prompts)
+    assert f"`{chat_agent.DEFAULT_MODEL}`" in prompt
 
 
 def test_resolved_reasoning_level_returns_supported_choice():


### PR DESCRIPTION
The chat agent's system prompt now ends with a "Your model" section naming the catalog label, wire id, and the **resolved** reasoning level (clamped to what the model supports — the level that actually runs, not the raw stored choice). Because agents are cached per (model id, reasoning level), each cached agent's identity text always matches its real configuration, including per-channel overrides and the temporary default-model override.

The agent is instructed to share its model/reasoning only when someone asks and never volunteer it.

Covered by unit tests for the identity text (label/id/level, clamping, no-knob and ad-hoc models, share-on-request phrasing) and the built agent's system prompt; full bot suite green (833 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ThsbEtkTfXyoSFCw9uu17w