### PR TITLE
Chat-bot settings rework, per-turn model identity, overlong-reply fitting

### DIFF
--- a/alembic/main/versions/20260721_200000_f4a7d1c9e3b6_nullable_override_model_key.py
+++ b/alembic/main/versions/20260721_200000_f4a7d1c9e3b6_nullable_override_model_key.py
@@ -1,0 +1,43 @@
+"""allow channel model overrides without a pinned model
+
+``channel_model_overrides.model_key`` becomes nullable: NULL means "keep the
+server default model" while the row's budgets, auto-respond flag, fallback
+model, and response filter still apply. Previously picking "Server default"
+in ``/chat-bot-settings`` could only delete the whole row, so budgets etc.
+could not be configured for a default-model channel.
+
+Revision ID: f4a7d1c9e3b6
+Revises: e9b2c6d4a8f1
+Create Date: 2026-07-21 20:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "f4a7d1c9e3b6"
+down_revision: Union[str, None] = "e9b2c6d4a8f1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "channel_model_overrides",
+        "model_key",
+        existing_type=sa.String(length=64),
+        nullable=True,
+    )
+
+
+def downgrade() -> None:
+    # Rows without a pinned model cannot survive a non-nullable column.
+    op.execute("DELETE FROM channel_model_overrides WHERE model_key IS NULL")
+    op.alter_column(
+        "channel_model_overrides",
+        "model_key",
+        existing_type=sa.String(length=64),
+        nullable=False,
+    )

--- a/smarter_dev/bot/agents/chat_agent.py
+++ b/smarter_dev/bot/agents/chat_agent.py
@@ -149,33 +149,6 @@ def resolved_reasoning_level(
     return effective.value if effective is not None else None
 
 
-def _model_identity_prompt(resolved_id: str, reasoning_level: str | None) -> str:
-    """System-prompt section telling the agent which model it is running on.
-
-    Members sometimes ask the bot which model answered them; the agent can
-    only answer truthfully if it is told. Appended per cached agent — the
-    cache is keyed by (model id, reasoning level), so each agent's identity
-    text matches its actual configuration, including channel overrides and
-    the temporary default override.
-    """
-    catalog_model = _catalog_model_for_id(resolved_id)
-    label = catalog_model.label if catalog_model is not None else resolved_id
-    effective_level = resolved_reasoning_level(resolved_id, reasoning_level)
-    if effective_level is not None:
-        configuration = (
-            f"**{label}** (`{resolved_id}`) at reasoning level"
-            f" **{effective_level}**"
-        )
-    else:
-        configuration = f"**{label}** (`{resolved_id}`)"
-    return (
-        "\n\n## Your model\n\n"
-        f"You are currently running on {configuration}. Only share your model "
-        "or reasoning level when someone asks about it — never volunteer this "
-        "configuration unprompted."
-    )
-
-
 # One agent per resolved (model id, reasoning level). A per-channel override
 # means we can no longer share a single global agent, so agents are cached by the
 # wire model id *and* reasoning level they were built for — two channels on the
@@ -205,8 +178,7 @@ def get_chat_agent(
             build_agent_model(resolved_id),
             output_type=_output_type_for(resolved_id),
             deps_type=ChatDeps,
-            system_prompt=SYSTEM_PROMPT
-            + _model_identity_prompt(resolved_id, reasoning_level),
+            system_prompt=SYSTEM_PROMPT,
             tools=chat_tool_functions() + handler_tool_functions(),
             model_settings=_model_settings_for(resolved_id, reasoning_level),
             history_processors=[compact_history],

--- a/smarter_dev/bot/agents/chat_input_format.py
+++ b/smarter_dev/bot/agents/chat_input_format.py
@@ -23,6 +23,12 @@ from smarter_dev.bot.agents.chat_models import (
     Message,
 )
 from smarter_dev.bot.agents.url_registry import register_escaped_url
+from smarter_dev.shared.model_catalog import MODEL_CATALOG
+
+# Wire model id -> human label, for the per-turn ``<your-model>`` metadata tag.
+_MODEL_LABEL_BY_ID: dict[str, str] = {
+    catalog_model.model_id: catalog_model.label for catalog_model in MODEL_CATALOG
+}
 
 
 def _attr(value: str | bool | None) -> str | None:
@@ -150,6 +156,8 @@ def render_metadata_xml(
     topic: str | None,
     notes: str | None,
     image_quota: dict | None = None,
+    model_name: str | None = None,
+    reasoning_level: str | None = None,
 ) -> str:
     """Render the per-turn metadata block (me / channel / now / topic / notes)."""
     return _render_metadata(
@@ -159,6 +167,8 @@ def render_metadata_xml(
         topic=topic,
         notes=notes,
         image_quota=image_quota,
+        model_name=model_name,
+        reasoning_level=reasoning_level,
     )
 
 
@@ -166,6 +176,8 @@ def build_agent_call(
     agent_input: InitialAgentInput | FollowupAgentInput,
     prior_history: list[ModelMessage],
     image_quota: dict | None = None,
+    model_name: str | None = None,
+    reasoning_level: str | None = None,
 ) -> tuple[str, list[ModelMessage]]:
     """Convert a turn input into (user_prompt, message_history) for ``agent.run``.
 
@@ -201,6 +213,8 @@ def build_agent_call(
                 topic=agent_input.topic,
                 notes=agent_input.notes,
                 image_quota=image_quota,
+                model_name=model_name,
+                reasoning_level=reasoning_level,
             ),
             history,
         )
@@ -224,6 +238,8 @@ def build_agent_call(
         topic=agent_input.topic,
         notes=agent_input.notes,
         image_quota=image_quota,
+        model_name=model_name,
+        reasoning_level=reasoning_level,
     )
     latest_xml = render_message_xml(latest, me=me, authors=authors)
     user_prompt = f"{metadata}\n\n{latest_xml}"
@@ -238,6 +254,8 @@ def _render_metadata(
     topic: str | None,
     notes: str | None,
     image_quota: dict | None = None,
+    model_name: str | None = None,
+    reasoning_level: str | None = None,
 ) -> str:
     chunks: list[str] = []
     chunks.append(_empty_tag("me", {"user-id": me.user_id, "username": me.username}))
@@ -252,6 +270,21 @@ def _render_metadata(
         )
     )
     chunks.append(_empty_tag("now", {"utc": _format_utc(now_utc)}))
+    if model_name:
+        # Which model (and effective reasoning level) is answering this turn.
+        # Rendered per turn — not in the system prompt — because pydantic-ai
+        # only applies the system prompt when history is empty, and the model
+        # can change mid-engagement (override edits, the temporary default).
+        chunks.append(
+            _empty_tag(
+                "your-model",
+                {
+                    "id": model_name,
+                    "name": _MODEL_LABEL_BY_ID.get(model_name),
+                    "reasoning-level": reasoning_level,
+                },
+            )
+        )
     if image_quota is not None:
         # How many technical images can still be generated this hour, and when
         # the window resets — so the agent knows up front whether it can draw.

--- a/smarter_dev/bot/agents/prompts/chat_agent.md
+++ b/smarter_dev/bot/agents/prompts/chat_agent.md
@@ -14,7 +14,14 @@ now. Older messages live in your conversation history as prior
 succession appear as two distinct entries — not one concatenated block.
 
 Metadata block (refreshed every turn): `<me user-id="…" username="…"/>`,
-`<channel …/>`, `<now utc="…"/>`, optional `<topic>` / `<notes>`.
+`<channel …/>`, `<now utc="…"/>`, `<your-model …/>`, optional
+`<topic>` / `<notes>`.
+
+`<your-model>` names the model you are currently running on (`name` /
+`id`, plus `reasoning-level` when the model has one). It can change
+between turns. Only share this configuration when someone asks — e.g.
+which model you are or what reasoning level you're on — never volunteer
+it unprompted.
 
 Read `<message>` attributes — don't infer from position:
 

--- a/smarter_dev/bot/agents/response_fitting.py
+++ b/smarter_dev/bot/agents/response_fitting.py
@@ -1,0 +1,204 @@
+"""Fit an overlong chat reply into Discord's 2000-character message cap.
+
+Three tiers, cheapest first:
+
+1. ``len <= 2000`` — send as-is (no work; :func:`split_for_discord` is a
+   pass-through).
+2. ``2000 < len <= 3000`` — :func:`split_for_discord` splits it into two
+   messages at the last newline before the 1500-character mark (falling back
+   to the last space, then a hard cut), keeping both parts under the cap.
+3. ``len > 3000`` — :func:`fit_overlong_response` first asks the chat agent
+   itself to rewrite the reply shorter (it has the full conversation context);
+   if the rewrite is still over 3000 characters (or the run fails), a cheap
+   Gemini 3.5 Flash Lite summarizer condenses the original; if even that
+   overruns, the text is hard-truncated as a last resort. The result then
+   flows through tier 1/2 for sending.
+
+The shorten re-run uses the turn's own agent + history, so its tokens are the
+chat model's and are folded into the turn's metering/pricing by the engine.
+The Flash Lite summarizer runs its own model; like chat compaction, its
+(small) spend is logged but not metered against the channel budget.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from pydantic_ai import Agent
+from pydantic_ai.messages import ModelMessage
+
+from smarter_dev.bot.agents.chat_agent import build_agent_model
+from smarter_dev.bot.agents.model_router import model_settings_for
+from smarter_dev.shared.model_catalog import ReasoningLevel
+from smarter_dev.shared.model_catalog import get_model
+
+logger = logging.getLogger(__name__)
+
+DISCORD_MESSAGE_LIMIT = 2000
+# Where the two-message split aims to break: the last newline at or before
+# this index.
+SPLIT_TARGET = 1500
+# Above this, splitting in two can't stay under the cap — rewrite instead.
+SUMMARIZE_THRESHOLD = 3000
+
+# Catalog key of the model that summarizes as the second resort.
+LENGTH_SUMMARIZER_MODEL_KEY = "gemini-3-5-flash-lite"
+
+_SHORTEN_PROMPT_TEMPLATE = (
+    "<length-notice>Your drafted reply could not be sent: it is {length} "
+    "characters and Discord caps messages at 2000. Rewrite it to under 1500 "
+    "characters — keep the essential answer and any code or links that are "
+    "load-bearing, cut the rest. Respond again with the rewritten message, "
+    "targeting the same message as before.</length-notice>"
+)
+
+_SUMMARIZER_SYSTEM_PROMPT = (
+    "You condense overlong Discord messages written by a chat bot. Rewrite "
+    "the given message to under 1500 characters while keeping its essential "
+    "answer, any load-bearing code or links, and its tone. Output ONLY the "
+    "rewritten message — no preamble, no commentary."
+)
+
+
+@dataclass(frozen=True)
+class FitResult:
+    """Outcome of fitting an overlong reply.
+
+    ``text`` is guaranteed to be at most :data:`SUMMARIZE_THRESHOLD` characters
+    (so :func:`split_for_discord` can always send it in at most two messages).
+    ``extra_input_tokens`` / ``extra_output_tokens`` are the shorten re-run's
+    chat-model spend for the engine to meter; ``method`` records which tier
+    produced the text ("shortened" / "summarized" / "truncated").
+    """
+
+    text: str
+    extra_input_tokens: int
+    extra_output_tokens: int
+    method: str
+
+
+def split_for_discord(text: str) -> list[str]:
+    """Split ``text`` into Discord-sendable chunks (at most two).
+
+    At or under the 2000-character cap the text passes through unchanged. Up
+    to 3000 characters it splits at the last newline before the
+    1500-character mark — falling back to the last space, then a hard cut —
+    constrained so the second part also fits the cap. Anything longer should
+    have gone through :func:`fit_overlong_response` first; as a defensive
+    last resort the second part is truncated with an ellipsis.
+    """
+    stripped = text.strip()
+    if len(stripped) <= DISCORD_MESSAGE_LIMIT:
+        return [stripped] if stripped else []
+
+    # The split index must leave the tail under the cap too (a newline very
+    # early in the text would otherwise push part two over 2000).
+    earliest = max(0, len(stripped) - DISCORD_MESSAGE_LIMIT)
+    split_at = stripped.rfind("\n", earliest, SPLIT_TARGET + 1)
+    if split_at <= 0:
+        split_at = stripped.rfind(" ", earliest, SPLIT_TARGET + 1)
+    if split_at <= 0:
+        split_at = SPLIT_TARGET
+    head = stripped[:split_at].rstrip()
+    tail = stripped[split_at:].strip()
+    if len(tail) > DISCORD_MESSAGE_LIMIT:
+        tail = tail[: DISCORD_MESSAGE_LIMIT - 1] + "…"
+    return [part for part in (head, tail) if part]
+
+
+_length_summarizer: Agent | None = None
+
+
+def get_length_summarizer() -> Agent:
+    """The cached Flash Lite summarizer agent (plain-text output)."""
+    global _length_summarizer
+    if _length_summarizer is None:
+        catalog_model = get_model(LENGTH_SUMMARIZER_MODEL_KEY)
+        _length_summarizer = Agent(
+            build_agent_model(catalog_model.model_id),
+            output_type=str,
+            system_prompt=_SUMMARIZER_SYSTEM_PROMPT,
+            model_settings=model_settings_for(catalog_model, ReasoningLevel.LOW),
+        )
+    return _length_summarizer
+
+
+async def _shorten_with_agent(
+    message: str,
+    agent: Agent,
+    deps: Any,
+    message_history: list[ModelMessage],
+) -> tuple[str | None, int, int]:
+    """Ask the turn's own agent to rewrite its overlong reply.
+
+    Returns ``(rewritten_text, input_tokens, output_tokens)``; the text is
+    ``None`` when the run fails or the agent declines to respond, so the
+    caller can fall through to the summarizer. Failures must never break the
+    turn — the original reply is still deliverable via later tiers.
+    """
+    prompt = _SHORTEN_PROMPT_TEMPLATE.format(length=len(message))
+    try:
+        result = await agent.run(
+            user_prompt=prompt, message_history=message_history, deps=deps
+        )
+    except Exception:
+        logger.exception("Shorten re-run failed — falling back to summarizer")
+        return None, 0, 0
+    usage = result.usage()
+    input_tokens = int(getattr(usage, "input_tokens", 0) or 0)
+    output_tokens = int(getattr(usage, "output_tokens", 0) or 0)
+    response = result.output.response
+    text = response.message.strip() if response and response.message else None
+    return text or None, input_tokens, output_tokens
+
+
+async def _summarize_with_flash_lite(message: str) -> str | None:
+    """Condense ``message`` with the Flash Lite summarizer (fail-soft)."""
+    try:
+        result = await get_length_summarizer().run(user_prompt=message)
+    except Exception:
+        logger.exception("Length summarizer failed — falling back to truncation")
+        return None
+    usage = result.usage()
+    logger.info(
+        "Length summarizer condensed %d chars -> %d (tokens in=%s out=%s)",
+        len(message),
+        len(result.output or ""),
+        getattr(usage, "input_tokens", 0),
+        getattr(usage, "output_tokens", 0),
+    )
+    text = (result.output or "").strip()
+    return text or None
+
+
+async def fit_overlong_response(
+    message: str,
+    *,
+    agent: Agent,
+    deps: Any,
+    message_history: list[ModelMessage],
+) -> FitResult:
+    """Bring a > :data:`SUMMARIZE_THRESHOLD` reply down to a sendable size.
+
+    Tries the chat agent's own rewrite first (context-aware), then the Flash
+    Lite summarizer on the original text, then a hard truncation so a reply
+    is always delivered.
+    """
+    shortened, input_tokens, output_tokens = await _shorten_with_agent(
+        message, agent, deps, message_history
+    )
+    if shortened is not None and len(shortened) <= SUMMARIZE_THRESHOLD:
+        return FitResult(shortened, input_tokens, output_tokens, "shortened")
+
+    summary = await _summarize_with_flash_lite(message)
+    if summary is not None and len(summary) <= SUMMARIZE_THRESHOLD:
+        return FitResult(summary, input_tokens, output_tokens, "summarized")
+
+    return FitResult(
+        message[: DISCORD_MESSAGE_LIMIT - 1].rstrip() + "…",
+        input_tokens,
+        output_tokens,
+        "truncated",
+    )

--- a/smarter_dev/bot/plugins/events.py
+++ b/smarter_dev/bot/plugins/events.py
@@ -21,6 +21,7 @@ from smarter_dev.bot.plugins.model_override import handle_model_override_next
 from smarter_dev.bot.plugins.model_override import (
     handle_model_override_reasoning_select,
 )
+from smarter_dev.bot.plugins.model_override import handle_model_override_reset
 from smarter_dev.bot.plugins.model_override import handle_model_override_save
 from smarter_dev.bot.plugins.model_override import handle_model_override_select
 from smarter_dev.bot.views.beacon_views import handle_beacon_modal_submit
@@ -271,6 +272,8 @@ async def handle_component_interaction(event: hikari.InteractionCreateEvent) -> 
             await handle_model_override_continue(event)
         elif custom_id.startswith("cbs_save:"):
             await handle_model_override_save(event)
+        elif custom_id == "cbs_reset":
+            await handle_model_override_reset(event)
         elif custom_id.startswith("model_budget_fallback:"):
             await handle_model_budget_fallback(event)
         else:

--- a/smarter_dev/bot/plugins/model_override.py
+++ b/smarter_dev/bot/plugins/model_override.py
@@ -8,7 +8,9 @@ daily/hourly token budgets and an optional response filter. A separate Save
 button persists panel changes immediately while retaining the stored budgets
 and filter; modal submit persists everything in one call via
 :class:`~smarter_dev.bot.services.model_override_service.ModelOverrideService`.
-Picking the "server default" sentinel clears the override instead.
+Picking the "server default" sentinel opens the same panel minus the reasoning
+select and persists a NULL ``model_key`` (budgets/behaviour still apply); the
+panel's "Reset all" button deletes the whole override.
 
 The interaction handlers here are dispatched from
 :mod:`smarter_dev.bot.plugins.events` by ``custom_id``: the model select
@@ -143,6 +145,35 @@ def _render_fallback(fallback_model_key: str | None) -> str:
     return fallback.label if fallback is not None else fallback_model_key
 
 
+def _confirmation_message(
+    model: CatalogModel | None,
+    state: PanelState,
+    response_filter: str | None,
+    daily_budget: int,
+    hourly_budget: int,
+) -> str:
+    """Render the saved-settings confirmation (``model`` None = server default)."""
+    model_line = (
+        f"✅ This channel now uses **{model.label}**."
+        if model is not None
+        else "✅ This channel keeps the **server default model**."
+    )
+    reasoning = (
+        _render_reasoning(model, state.reasoning_level)
+        if model is not None
+        else "model default"
+    )
+    return (
+        f"{model_line}\n"
+        f"• Reasoning: {reasoning}\n"
+        f"• Auto-respond: {'on' if state.auto_respond else 'off'}\n"
+        f"• Fallback model: {_render_fallback(state.fallback_model_key)}\n"
+        f"• Response filter: {'set' if response_filter else 'none'}\n"
+        f"• Daily budget: {_render_budget(daily_budget)}\n"
+        f"• Hourly budget: {_render_budget(hourly_budget)}"
+    )
+
+
 def _read_modal_text_values(
     interaction: hikari.ModalInteraction,
 ) -> dict[str, str]:
@@ -169,23 +200,46 @@ async def _load_current_override(
         return None
 
 
+def _stored_model_key(state: PanelState) -> str | None:
+    """The ``model_key`` to persist for ``state`` — ``None`` for the sentinel."""
+    return None if state.model_key == SENTINEL_DEFAULT else state.model_key
+
+
+def _panel_model(state: PanelState) -> tuple[CatalogModel | None, bool]:
+    """Resolve the panel's model: ``(model, is_valid)``.
+
+    The server-default sentinel resolves to ``(None, True)``; an unknown
+    catalog key to ``(None, False)`` so callers can reject stale state.
+    """
+    if state.model_key == SENTINEL_DEFAULT:
+        return None, True
+    model = get_model(state.model_key)
+    return model, model is not None
+
+
 async def _render_panel(
     interaction: hikari.ComponentInteraction, state: PanelState
 ) -> None:
     """Re-render the settings panel for ``state`` as a message update."""
-    model = get_model(state.model_key)
-    if model is None:
+    model, is_valid = _panel_model(state)
+    if not is_valid:
         await interaction.create_initial_response(
             hikari.ResponseType.MESSAGE_UPDATE,
             content="❌ That model is no longer available. Please run `/chat-bot-settings` again.",
             components=[],
         )
         return
+    configuring = (
+        f"**{model.label}**"
+        if model is not None
+        else "the **server default model**"
+    )
     await interaction.create_initial_response(
         hikari.ResponseType.MESSAGE_UPDATE,
         content=(
-            f"Configuring **{model.label}** for this channel. Adjust the settings "
-            "below, then choose **Save** or open **Budgets & filter…**."
+            f"Configuring {configuring} for this channel. Adjust the settings "
+            "below, then choose **Save** or open **Budgets & filter…**. "
+            "**Reset all** removes every stored setting."
         ),
         components=create_settings_panel(
             model,
@@ -219,7 +273,8 @@ async def chat_bot_settings(ctx: lightbulb.Context) -> None:
         logger.warning("Could not load current model override for prefill: %s", exc)
 
     await ctx.respond(
-        "Select a model for this channel. Pick **Server default** to remove any override.",
+        "Select a model for this channel — **Server default** keeps the default "
+        "model while still letting you set budgets and behaviour.",
         components=create_model_select_message(current),
         flags=hikari.MessageFlag.EPHEMERAL,
     )
@@ -352,32 +407,19 @@ async def _advance_from_model_selection(
     interaction: hikari.ComponentInteraction,
     selected: str | None,
 ) -> None:
-    """Clear the override or render the panel for a selected model."""
+    """Render the settings panel for a selected model (or the server default).
+
+    Picking the server-default sentinel no longer clears the override — it
+    opens the same panel (minus the reasoning select) so budgets, auto-respond,
+    fallback, and the response filter stay configurable for a default-model
+    channel. The panel's "Reset all" button is what deletes the override now.
+    """
     guild_id = str(interaction.guild_id)
     channel_id = str(interaction.channel_id)
 
-    if selected == SENTINEL_DEFAULT:
-        service = _get_override_service(event.app)
-        try:
-            await service.clear_override(guild_id, channel_id)
-        except APIError as exc:
-            logger.error(
-                "Failed to clear model override for channel %s: %s", channel_id, exc
-            )
-            await interaction.create_initial_response(
-                hikari.ResponseType.MESSAGE_UPDATE,
-                content="❌ Couldn't remove the override — please try again shortly.",
-                components=[],
-            )
-            return
-        await interaction.create_initial_response(
-            hikari.ResponseType.MESSAGE_UPDATE,
-            content="✅ Removed this channel's model override — using the server default.",
-            components=[],
-        )
-        return
-
-    if not selected or not is_valid_model_key(selected):
+    if not selected or (
+        selected != SENTINEL_DEFAULT and not is_valid_model_key(selected)
+    ):
         await interaction.create_initial_response(
             hikari.ResponseType.MESSAGE_UPDATE,
             content="❌ That model is no longer available. Please run `/chat-bot-settings` again.",
@@ -392,9 +434,16 @@ async def _advance_from_model_selection(
     fallback_key = current.fallback_model_key if current is not None else None
     if fallback_key == selected:
         fallback_key = None
+    # The server default carries no pinned reasoning level: the underlying
+    # default model can change, so a stored level would silently stop matching.
+    reasoning_level = (
+        current.reasoning_level
+        if current is not None and selected != SENTINEL_DEFAULT
+        else None
+    )
     state = PanelState(
         model_key=selected,
-        reasoning_level=current.reasoning_level if current is not None else None,
+        reasoning_level=reasoning_level,
         auto_respond=current.auto_respond if current is not None else False,
         fallback_model_key=fallback_key,
     )
@@ -512,7 +561,7 @@ async def handle_model_override_continue(
         return
 
     state = parse_panel_state(interaction.custom_id, CONTINUE_CUSTOM_ID_PREFIX)
-    if state is None or get_model(state.model_key) is None:
+    if state is None or not _panel_model(state)[1]:
         logger.error("Invalid continue custom_id: %s", interaction.custom_id)
         await interaction.create_initial_response(
             hikari.ResponseType.MESSAGE_UPDATE,
@@ -548,8 +597,8 @@ async def handle_model_override_save(
         return
 
     state = parse_panel_state(interaction.custom_id, SAVE_CUSTOM_ID_PREFIX)
-    model = get_model(state.model_key) if state is not None else None
-    if state is None or model is None:
+    model, is_valid = _panel_model(state) if state is not None else (None, False)
+    if state is None or not is_valid:
         logger.error("Invalid save custom_id: %s", interaction.custom_id)
         await interaction.create_initial_response(
             hikari.ResponseType.MESSAGE_UPDATE,
@@ -569,7 +618,7 @@ async def handle_model_override_save(
         await service.set_override(
             guild_id,
             channel_id,
-            state.model_key,
+            _stored_model_key(state),
             daily_budget,
             hourly_budget,
             reasoning_level=state.reasoning_level,
@@ -590,14 +639,45 @@ async def handle_model_override_save(
 
     await interaction.create_initial_response(
         hikari.ResponseType.MESSAGE_UPDATE,
+        content=_confirmation_message(
+            model, state, response_filter, daily_budget, hourly_budget
+        ),
+        components=[],
+    )
+
+
+async def handle_model_override_reset(
+    event: hikari.InteractionCreateEvent,
+) -> None:
+    """Handle the panel's "Reset all" button: delete the whole override row so
+    the channel returns to server defaults (model, budgets, and behaviour)."""
+    interaction = event.interaction
+    if not isinstance(interaction, hikari.ComponentInteraction):
+        return
+    if await _deny_interaction_if_not_admin(event):
+        return
+
+    service = _get_override_service(event.app)
+    guild_id = str(interaction.guild_id)
+    channel_id = str(interaction.channel_id)
+    try:
+        await service.clear_override(guild_id, channel_id)
+    except APIError as exc:
+        logger.error(
+            "Failed to reset chat-bot settings for channel %s: %s", channel_id, exc
+        )
+        await interaction.create_initial_response(
+            hikari.ResponseType.MESSAGE_UPDATE,
+            content="❌ Couldn't reset the settings — please try again shortly.",
+            components=[],
+        )
+        return
+
+    await interaction.create_initial_response(
+        hikari.ResponseType.MESSAGE_UPDATE,
         content=(
-            f"✅ This channel now uses **{model.label}**.\n"
-            f"• Reasoning: {_render_reasoning(model, state.reasoning_level)}\n"
-            f"• Auto-respond: {'on' if state.auto_respond else 'off'}\n"
-            f"• Fallback model: {_render_fallback(state.fallback_model_key)}\n"
-            f"• Response filter: {'set' if response_filter else 'none'}\n"
-            f"• Daily budget: {_render_budget(daily_budget)}\n"
-            f"• Hourly budget: {_render_budget(hourly_budget)}"
+            "✅ Reset this channel's chat-bot settings — model, budgets, and "
+            "behaviour are back to the server defaults."
         ),
         components=[],
     )
@@ -625,8 +705,8 @@ async def handle_model_override_modal_submit(
         )
         return
 
-    model = get_model(state.model_key)
-    if model is None:
+    model, is_valid = _panel_model(state)
+    if not is_valid:
         await interaction.create_initial_response(
             hikari.ResponseType.MESSAGE_CREATE,
             content="❌ That model is no longer available. Please run `/chat-bot-settings` again.",
@@ -654,7 +734,7 @@ async def handle_model_override_modal_submit(
         await service.set_override(
             str(interaction.guild_id),
             str(interaction.channel_id),
-            state.model_key,
+            _stored_model_key(state),
             daily_budget,
             hourly_budget,
             reasoning_level=state.reasoning_level,
@@ -680,14 +760,8 @@ async def handle_model_override_modal_submit(
 
     await interaction.create_initial_response(
         hikari.ResponseType.MESSAGE_CREATE,
-        content=(
-            f"✅ This channel now uses **{model.label}**.\n"
-            f"• Reasoning: {_render_reasoning(model, state.reasoning_level)}\n"
-            f"• Auto-respond: {'on' if state.auto_respond else 'off'}\n"
-            f"• Fallback model: {_render_fallback(state.fallback_model_key)}\n"
-            f"• Response filter: {'set' if response_filter else 'none'}\n"
-            f"• Daily budget: {_render_budget(daily_budget)}\n"
-            f"• Hourly budget: {_render_budget(hourly_budget)}"
+        content=_confirmation_message(
+            model, state, response_filter, daily_budget, hourly_budget
         ),
         flags=hikari.MessageFlag.EPHEMERAL,
     )

--- a/smarter_dev/bot/services/chat_engine.py
+++ b/smarter_dev/bot/services/chat_engine.py
@@ -966,25 +966,43 @@ class ChannelEngine:
     ) -> bool:
         # A reply over Discord's 2000-char cap goes out as two messages, split
         # at the last newline before the 1500-char mark (see split_for_discord).
-        # The reply anchor and any images ride on the first message; the
-        # continuation follows as a plain message.
-        parts = split_for_discord(message)
-        content = parts[0] if parts else ""
-        continuations = parts[1:]
-        base_kwargs: dict[str, Any] = {"content": content}
-        if reply_to is not None:
-            base_kwargs["reply"] = reply_to
+        # The reply anchor rides on the first message; any images ride on the
+        # LAST message so an attachment never visually interrupts the text.
+        parts = split_for_discord(message) or [""]
         attachments = (
             [hikari.Bytes(img.data, img.filename, img.mime_type) for img in images]
             if images
             else []
         )
+        last_index = len(parts) - 1
+        for index, part in enumerate(parts):
+            sent = await self._send_message_part(
+                part,
+                reply_to=reply_to if index == 0 else None,
+                attachments=attachments if index == last_index else [],
+            )
+            if not sent:
+                # A failed lead means the reply didn't land. A failed
+                # continuation is logged only — the lead already delivered
+                # the reply's opening.
+                return index > 0
+        return True
+
+    async def _send_message_part(
+        self,
+        content: str,
+        reply_to: int | None,
+        attachments: list[hikari.Bytes],
+    ) -> bool:
+        """Send one message of a (possibly split) reply."""
+        base_kwargs: dict[str, Any] = {"content": content}
+        if reply_to is not None:
+            base_kwargs["reply"] = reply_to
         try:
             kwargs = dict(base_kwargs)
             if attachments:
                 kwargs["attachments"] = attachments
             await self.bot.rest.create_message(self.channel_id, **kwargs)
-            await self._send_continuations(continuations)
             return True
         except Exception as err:
             if not attachments:
@@ -1009,7 +1027,6 @@ class ChannelEngine:
                 text_only["content"] = (content + _ATTACH_PERM_NOTE)[:2000]
             try:
                 await self.bot.rest.create_message(self.channel_id, **text_only)
-                await self._send_continuations(continuations)
                 return True
             except Exception:
                 logger.exception(
@@ -1018,22 +1035,6 @@ class ChannelEngine:
                     self.channel_id,
                 )
                 return False
-
-    async def _send_continuations(self, parts: list[str]) -> None:
-        """Send a split reply's follow-up message(s), best-effort.
-
-        The lead message already delivered the reply's opening, so a failed
-        continuation is logged rather than failing the whole send.
-        """
-        for part in parts:
-            try:
-                await self.bot.rest.create_message(self.channel_id, content=part)
-            except Exception:
-                logger.exception(
-                    "Failed to send reply continuation in channel %s",
-                    self.channel_id,
-                )
-                return
 
     async def _post_images(
         self, images: list[GeneratedImage], reply_to: int | None

--- a/smarter_dev/bot/services/chat_engine.py
+++ b/smarter_dev/bot/services/chat_engine.py
@@ -640,7 +640,11 @@ class ChannelEngine:
             set_last_model_call(self._last_model_call_at)
             image_quota = await self._fetch_image_quota()
             user_prompt, message_history = build_agent_call(
-                agent_input, history, image_quota=image_quota
+                agent_input,
+                history,
+                image_quota=image_quota,
+                model_name=resolved_model_name,
+                reasoning_level=resolved_reasoning_wire,
             )
             try:
                 result = await agent.run(
@@ -1051,10 +1055,12 @@ class ChannelEngine:
     def _resolve_override_model_id(self, override: Any | None) -> str | None:
         """Wire model id for ``override``, or None to use the default agent.
 
-        A stored ``model_key`` the catalog no longer knows (stale) falls back to
-        the default model with a warning rather than crashing the turn.
+        A ``model_key`` of ``None`` means the override pins no model (budgets/
+        behaviour only — the channel keeps the server default). A stored
+        ``model_key`` the catalog no longer knows (stale) falls back to the
+        default model with a warning rather than crashing the turn.
         """
-        if override is None:
+        if override is None or override.model_key is None:
             return None
         catalog_model = get_model(override.model_key)
         if catalog_model is None:
@@ -1267,8 +1273,16 @@ class ChannelEngine:
             return
         if not cleared:
             return
-        model = get_model(override.model_key)
-        label = model.label if model is not None else override.model_key
+        model = (
+            get_model(override.model_key)
+            if override.model_key is not None
+            else None
+        )
+        label = (
+            model.label
+            if model is not None
+            else override.model_key or "the default model"
+        )
         await self._post_notice(
             f"Budget reset — **{label}** is answering again.",
             reply_to=None,

--- a/smarter_dev/bot/services/chat_engine.py
+++ b/smarter_dev/bot/services/chat_engine.py
@@ -55,6 +55,9 @@ from smarter_dev.bot.agents.message_gate import GateMessage
 from smarter_dev.bot.agents.message_gate import filter_messages
 from smarter_dev.bot.agents.chat_models import ResponseBody
 from smarter_dev.bot.agents.chat_models import TurnDecision
+from smarter_dev.bot.agents.response_fitting import SUMMARIZE_THRESHOLD
+from smarter_dev.bot.agents.response_fitting import fit_overlong_response
+from smarter_dev.bot.agents.response_fitting import split_for_discord
 from smarter_dev.bot.agents.chat_tools import ChatDeps
 from smarter_dev.bot.agents.chat_tools import GeneratedImage
 from smarter_dev.shared.model_catalog import get_model
@@ -681,6 +684,41 @@ class ChannelEngine:
 
             output = result.output
             tokens = _extract_tokens(result.usage())
+            # A reply too long to send in two messages gets rewritten before
+            # dispatch: the agent shortens its own draft (context-aware),
+            # falling back to a Flash Lite summary, then truncation. The
+            # shorten re-run spends chat-model tokens, so they're folded into
+            # this turn's metering and persisted totals.
+            fit_extra_input = 0
+            fit_extra_output = 0
+            if (
+                output.response is not None
+                and output.response.message
+                and len(output.response.message) > SUMMARIZE_THRESHOLD
+            ):
+                fit = await fit_overlong_response(
+                    output.response.message,
+                    agent=agent,
+                    deps=deps,
+                    message_history=list(result.all_messages()),
+                )
+                logger.info(
+                    "[%s] Overlong reply (%d chars) fitted via %s to %d chars",
+                    request_id,
+                    len(output.response.message),
+                    fit.method,
+                    len(fit.text),
+                )
+                output = output.model_copy(
+                    update={
+                        "response": output.response.model_copy(
+                            update={"message": fit.text}
+                        )
+                    }
+                )
+                fit_extra_input = fit.extra_input_tokens
+                fit_extra_output = fit.extra_output_tokens
+                tokens += fit_extra_input + fit_extra_output
             # Meter this turn's chat tokens against the channel's usage windows.
             # Every channel is metered (so ``/bot-usage`` always has numbers);
             # the budgets that *enforce* only exist on override channels.
@@ -727,8 +765,14 @@ class ChannelEngine:
                     else [m.model_dump(mode="json") for m in agent_input.new_messages]
                 )
                 chat_usage = result.usage()
-                chat_in = int(getattr(chat_usage, "input_tokens", 0) or 0)
-                chat_out = int(getattr(chat_usage, "output_tokens", 0) or 0)
+                chat_in = (
+                    int(getattr(chat_usage, "input_tokens", 0) or 0)
+                    + fit_extra_input
+                )
+                chat_out = (
+                    int(getattr(chat_usage, "output_tokens", 0) or 0)
+                    + fit_extra_output
+                )
                 chat_cache_read = int(
                     getattr(chat_usage, "cache_read_tokens", 0) or 0
                 )
@@ -920,7 +964,13 @@ class ChannelEngine:
         reply_to: int | None,
         images: list[GeneratedImage] | None = None,
     ) -> bool:
-        content = message.strip()[:2000]
+        # A reply over Discord's 2000-char cap goes out as two messages, split
+        # at the last newline before the 1500-char mark (see split_for_discord).
+        # The reply anchor and any images ride on the first message; the
+        # continuation follows as a plain message.
+        parts = split_for_discord(message)
+        content = parts[0] if parts else ""
+        continuations = parts[1:]
         base_kwargs: dict[str, Any] = {"content": content}
         if reply_to is not None:
             base_kwargs["reply"] = reply_to
@@ -934,6 +984,7 @@ class ChannelEngine:
             if attachments:
                 kwargs["attachments"] = attachments
             await self.bot.rest.create_message(self.channel_id, **kwargs)
+            await self._send_continuations(continuations)
             return True
         except Exception as err:
             if not attachments:
@@ -958,6 +1009,7 @@ class ChannelEngine:
                 text_only["content"] = (content + _ATTACH_PERM_NOTE)[:2000]
             try:
                 await self.bot.rest.create_message(self.channel_id, **text_only)
+                await self._send_continuations(continuations)
                 return True
             except Exception:
                 logger.exception(
@@ -966,6 +1018,22 @@ class ChannelEngine:
                     self.channel_id,
                 )
                 return False
+
+    async def _send_continuations(self, parts: list[str]) -> None:
+        """Send a split reply's follow-up message(s), best-effort.
+
+        The lead message already delivered the reply's opening, so a failed
+        continuation is logged rather than failing the whole send.
+        """
+        for part in parts:
+            try:
+                await self.bot.rest.create_message(self.channel_id, content=part)
+            except Exception:
+                logger.exception(
+                    "Failed to send reply continuation in channel %s",
+                    self.channel_id,
+                )
+                return
 
     async def _post_images(
         self, images: list[GeneratedImage], reply_to: int | None

--- a/smarter_dev/bot/services/model_override_service.py
+++ b/smarter_dev/bot/services/model_override_service.py
@@ -82,7 +82,7 @@ class ModelOverrideService(BaseService):
         self,
         guild_id: str,
         channel_id: str,
-        model_key: str,
+        model_key: str | None,
         daily_token_budget: int,
         hourly_token_budget: int,
         reasoning_level: str | None = None,
@@ -92,8 +92,10 @@ class ModelOverrideService(BaseService):
     ) -> ChannelModelOverride:
         """Upsert the channel's override and return the stored value.
 
-        ``reasoning_level`` of ``None`` means "use the model's default level".
-        ``auto_respond`` makes the bot reply to any message, not just @mentions;
+        ``model_key`` of ``None`` keeps the server default model while the
+        budgets and behaviour settings still apply. ``reasoning_level`` of
+        ``None`` means "use the model's default level". ``auto_respond`` makes
+        the bot reply to any message, not just @mentions;
         ``fallback_model_key`` and ``response_filter`` default to "unset".
         """
         response = await self._api_client.put(

--- a/smarter_dev/bot/services/models.py
+++ b/smarter_dev/bot/services/models.py
@@ -607,7 +607,7 @@ class ChannelModelOverride:
 
     guild_id: str
     channel_id: str
-    model_key: str
+    model_key: str | None
     daily_token_budget: int
     hourly_token_budget: int
     reasoning_level: str | None = None
@@ -623,7 +623,7 @@ class ChannelModelOverride:
         return cls(
             guild_id=data["guild_id"],
             channel_id=data["channel_id"],
-            model_key=data["model_key"],
+            model_key=data.get("model_key"),
             reasoning_level=data.get("reasoning_level"),
             daily_token_budget=data["daily_token_budget"],
             hourly_token_budget=data["hourly_token_budget"],

--- a/smarter_dev/bot/views/model_override_views.py
+++ b/smarter_dev/bot/views/model_override_views.py
@@ -17,8 +17,10 @@ response filter go in a modal:
    (chosen model, reasoning level, auto flag, fallback key) rides in every component's
    ``custom_id`` — see :func:`encode_panel_state` / :func:`parse_panel_state` —
    so each select/toggle re-renders the panel with the updated state and no
-   server-side session. Picking the server-default sentinel clears the override
-   without a panel.
+   server-side session. Picking the server-default sentinel opens the same
+   panel minus the reasoning select (model_key persists as NULL — budgets and
+   behaviour still apply); the panel's "Reset all" button deletes the whole
+   override.
 3. The "Budgets & filter…" button opens the settings modal
    (``create_settings_modal``) whose ``custom_id`` carries the full panel state;
    its text inputs collect the daily/hourly budgets and the response filter.
@@ -38,8 +40,9 @@ from smarter_dev.shared.model_catalog import CatalogModel
 from smarter_dev.shared.model_catalog import models_by_family
 from smarter_dev.shared.model_catalog import parse_reasoning_level
 
-# Model-select value that means "remove any override and fall back to the server
-# default model". Kept distinct from every catalog key.
+# Model-select value that means "pin no model — keep the server default" (stored
+# as a NULL model_key; budgets/auto-respond/filter still apply). Kept distinct
+# from every catalog key.
 SENTINEL_DEFAULT = "__default__"
 
 # Reasoning-select value that means "use the model's own default level" (stored
@@ -61,6 +64,9 @@ AUTO_TOGGLE_CUSTOM_ID_PREFIX = "cbs_auto"
 CONTINUE_CUSTOM_ID_PREFIX = "cbs_continue"
 SAVE_CUSTOM_ID_PREFIX = "cbs_save"
 MODAL_CUSTOM_ID_PREFIX = "cbs_modal"
+# The panel's "Reset all" button deletes the whole override row (model, budgets,
+# behaviour). Carries no state, so it's a bare custom_id rather than a prefix.
+RESET_CUSTOM_ID = "cbs_reset"
 
 # Prefix for the button the chat engine attaches to a budget-exhausted notice,
 # offering the channel's configured fallback model. Its only state is the budget
@@ -146,9 +152,9 @@ def build_model_options(
     """
     options: list[hikari.impl.SelectOptionBuilder] = [
         hikari.impl.SelectOptionBuilder(
-            label="Server default (remove override)",
+            label="Server default",
             value=SENTINEL_DEFAULT,
-            description="Use the server's default model for this channel",
+            description="Keep the default model — budgets and behaviour still apply",
             is_default=current_key is None,
         )
     ]
@@ -259,25 +265,32 @@ def build_fallback_options(
 
 
 def create_settings_panel(
-    model: CatalogModel,
+    model: CatalogModel | None,
     reasoning_level: str | None,
     auto_respond: bool,
     fallback_model_key: str | None,
 ) -> list[hikari.impl.MessageActionRowBuilder]:
     """Build the ephemeral settings panel for a chosen ``model``.
 
-    Holds (in order) an optional reasoning select (reasoning-capable models
-    only), a fallback-model select, and a button row with an auto-respond toggle
-    plus "Budgets & filter…" and "Save" buttons. The current panel state is
-    encoded into every component's ``custom_id`` so each interaction can
-    re-render the panel without server-side session state.
+    ``model`` of ``None`` means the server-default sentinel was chosen: the
+    panel then omits the reasoning select (the underlying default model can
+    change, so a pinned level would silently stop matching) but still offers
+    everything else. Otherwise holds (in order) an optional reasoning select
+    (reasoning-capable models only), a fallback-model select, and a button row
+    with an auto-respond toggle plus "Budgets & filter…", "Save", and
+    "Reset all" buttons. The current panel state is encoded into every
+    component's ``custom_id`` so each interaction can re-render the panel
+    without server-side session state.
     """
     state = encode_panel_state(
-        model.key, reasoning_level, auto_respond, fallback_model_key
+        model.key if model is not None else SENTINEL_DEFAULT,
+        reasoning_level,
+        auto_respond,
+        fallback_model_key,
     )
     rows: list[hikari.impl.MessageActionRowBuilder] = []
 
-    if model.supports_reasoning:
+    if model is not None and model.supports_reasoning:
         reasoning_row = hikari.impl.MessageActionRowBuilder()
         reasoning_menu = reasoning_row.add_text_menu(
             f"{REASONING_SELECT_CUSTOM_ID_PREFIX}:{state}",
@@ -301,7 +314,9 @@ def create_settings_panel(
         min_values=1,
         max_values=1,
     )
-    for option in build_fallback_options(model.key, fallback_model_key):
+    for option in build_fallback_options(
+        model.key if model is not None else SENTINEL_DEFAULT, fallback_model_key
+    ):
         fallback_menu.add_option(
             option.label,
             option.value,
@@ -325,6 +340,11 @@ def create_settings_panel(
         hikari.ButtonStyle.SUCCESS,
         f"{SAVE_CUSTOM_ID_PREFIX}:{state}",
         label="Save",
+    )
+    button_row.add_interactive_button(
+        hikari.ButtonStyle.DANGER,
+        RESET_CUSTOM_ID,
+        label="Reset all",
     )
     rows.append(button_row)
 

--- a/smarter_dev/web/api_native/schemas.py
+++ b/smarter_dev/web/api_native/schemas.py
@@ -756,7 +756,11 @@ class ChannelModelOverrideWrite(BaseAPIModel):
     rejected with 422.
     """
 
-    model_key: str = Field(description="Stable catalog key for the model")
+    model_key: str | None = Field(
+        None,
+        description="Stable catalog key for the model; null keeps the server "
+        "default model while budgets/auto-respond/filter still apply",
+    )
     reasoning_level: str | None = Field(
         None,
         description="ReasoningLevel value (e.g. 'high'); null uses the model default",
@@ -783,7 +787,9 @@ class ChannelModelOverrideWrite(BaseAPIModel):
 
     @field_validator("model_key")
     @classmethod
-    def _model_key_in_catalog(cls, value: str) -> str:
+    def _model_key_in_catalog(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
         if not is_valid_model_key(value):
             raise ValueError(f"unknown model key: {value!r}")
         return value
@@ -814,7 +820,10 @@ class ChannelModelOverrideRead(BaseAPIModel):
 
     guild_id: str = Field(description="Discord guild ID")
     channel_id: str = Field(description="Discord channel ID")
-    model_key: str = Field(description="Stable catalog key for the model")
+    model_key: str | None = Field(
+        None,
+        description="Stable catalog key for the model, or null for the server default",
+    )
     reasoning_level: str | None = Field(
         None, description="Selected reasoning level, or null for the model default"
     )

--- a/smarter_dev/web/crud.py
+++ b/smarter_dev/web/crud.py
@@ -5510,7 +5510,7 @@ async def upsert_channel_model_override(
     session: AsyncSession,
     guild_id: str,
     channel_id: str,
-    model_key: str,
+    model_key: str | None,
     daily_token_budget: int,
     hourly_token_budget: int,
     reasoning_level: str | None = None,
@@ -5521,7 +5521,9 @@ async def upsert_channel_model_override(
     """Insert or update the single override row for ``channel_id``.
 
     Loads (or creates) the row internally so no caller-owned object is mutated.
-    ``reasoning_level`` of ``None`` means "use the model's default level".
+    ``model_key`` of ``None`` keeps the server default model (budgets and
+    behaviour flags still apply); ``reasoning_level`` of ``None`` means "use
+    the model's default level".
     """
     record = await get_channel_model_override(session, guild_id, channel_id)
     if record is None:

--- a/smarter_dev/web/models.py
+++ b/smarter_dev/web/models.py
@@ -4557,7 +4557,9 @@ class ChannelModelOverride(Base):
     )
     guild_id: Mapped[str] = mapped_column(String(20), nullable=False)
     channel_id: Mapped[str] = mapped_column(String(20), nullable=False)
-    model_key: Mapped[str] = mapped_column(String(64), nullable=False)
+    # A stable catalog ``key``, or NULL to keep the server default model while
+    # the budgets/auto-respond/filter below still apply.
+    model_key: Mapped[str | None] = mapped_column(String(64), nullable=True)
     # A ReasoningLevel value (e.g. "high"), or NULL to use the model's default.
     # Resolved/clamped against the selected model at request time, so a level the
     # model no longer supports never needs a migration here.

--- a/tests/bot/agents/test_chat_agent_override.py
+++ b/tests/bot/agents/test_chat_agent_override.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import pytest
 
 import smarter_dev.bot.agents.chat_agent as chat_agent
-from smarter_dev.bot.agents.chat_agent import _model_identity_prompt
 from smarter_dev.bot.agents.chat_agent import get_chat_agent
 from smarter_dev.bot.agents.chat_agent import resolved_reasoning_level
 
@@ -68,56 +67,6 @@ def test_none_resolves_to_env_default_and_is_singleton_equivalent(monkeypatch):
     explicit_default = get_chat_agent(chat_agent.DEFAULT_MODEL)
     assert default_first is default_second
     assert default_first is explicit_default
-
-
-def test_model_identity_prompt_names_model_and_resolved_reasoning():
-    identity = _model_identity_prompt("gpt-5.4", "high")
-    assert "GPT-5.4" in identity
-    assert "`gpt-5.4`" in identity
-    assert "**high**" in identity
-
-
-def test_model_identity_prompt_reports_the_clamped_level():
-    # Gemini's thinking_level tops out at "high" — the identity must reflect
-    # what actually runs, not the raw stored choice.
-    identity = _model_identity_prompt("gemini-3.1-flash-lite", "max")
-    assert "**high**" in identity
-    assert "max" not in identity
-
-
-def test_model_identity_prompt_omits_reasoning_without_knob():
-    identity = _model_identity_prompt("kimi-k2.6", "high")
-    assert "Kimi K2.6" in identity
-    assert "at reasoning level" not in identity
-
-
-def test_model_identity_prompt_handles_adhoc_model_id():
-    identity = _model_identity_prompt("some-unlisted-model", None)
-    assert "`some-unlisted-model`" in identity
-    assert "at reasoning level" not in identity
-
-
-def test_model_identity_prompt_is_share_on_request_only():
-    identity = _model_identity_prompt("gpt-5.4", None)
-    assert "when someone asks" in identity
-    assert "never volunteer" in identity
-
-
-def test_agent_system_prompt_carries_its_model_identity():
-    _reset_cache()
-    agent = get_chat_agent("gpt-5.4", "high")
-    prompt = "".join(agent._system_prompts)
-    assert "## Your model" in prompt
-    assert "`gpt-5.4`" in prompt
-    assert "**high**" in prompt
-
-
-def test_default_agent_system_prompt_names_the_default_model(monkeypatch):
-    _reset_cache()
-    monkeypatch.delenv(chat_agent.MODEL_ENV_VAR, raising=False)
-    agent = get_chat_agent()
-    prompt = "".join(agent._system_prompts)
-    assert f"`{chat_agent.DEFAULT_MODEL}`" in prompt
 
 
 def test_resolved_reasoning_level_returns_supported_choice():

--- a/tests/bot/agents/test_chat_input_format.py
+++ b/tests/bot/agents/test_chat_input_format.py
@@ -1,0 +1,64 @@
+"""Tests for the per-turn ``<your-model>`` metadata tag in the agent input.
+
+The model identity rides in every turn's metadata block — NOT the system
+prompt — because pydantic-ai only applies the system prompt when the message
+history is empty, so a mid-engagement turn (or a mid-engagement model switch)
+would otherwise leave the agent not knowing what it runs on.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC
+from datetime import datetime
+
+from smarter_dev.bot.agents.chat_input_format import build_agent_call
+from smarter_dev.bot.agents.chat_models import Author
+from smarter_dev.bot.agents.chat_models import ChannelInfo
+from smarter_dev.bot.agents.chat_models import InitialAgentInput
+from smarter_dev.bot.agents.chat_models import Me
+from smarter_dev.bot.agents.chat_models import Message
+
+
+def _initial_input() -> InitialAgentInput:
+    return InitialAgentInput(
+        me=Me(user_id="999", username="bot"),
+        channel_history=[],
+        activation_message=Message(
+            message_id="101",
+            author_id="200",
+            body="@bot which model are you?",
+            mentions_bot=True,
+        ),
+        authors=[Author(user_id="200", username="alice")],
+        channel=ChannelInfo(channel_id="1", name="general"),
+        now_utc=datetime.now(UTC),
+    )
+
+
+def test_metadata_carries_model_identity_with_reasoning():
+    user_prompt, _ = build_agent_call(
+        _initial_input(), [], model_name="gpt-5.4", reasoning_level="high"
+    )
+    assert (
+        '<your-model id="gpt-5.4" name="GPT-5.4" reasoning-level="high"/>'
+        in user_prompt
+    )
+
+
+def test_metadata_model_without_reasoning_omits_the_attribute():
+    user_prompt, _ = build_agent_call(
+        _initial_input(), [], model_name="kimi-k2.6", reasoning_level=None
+    )
+    assert '<your-model id="kimi-k2.6" name="Kimi K2.6 (Moonshot)"/>' in user_prompt
+
+
+def test_metadata_adhoc_model_id_renders_without_label():
+    user_prompt, _ = build_agent_call(
+        _initial_input(), [], model_name="some-unlisted-model"
+    )
+    assert '<your-model id="some-unlisted-model"/>' in user_prompt
+
+
+def test_metadata_omits_your_model_when_name_unset():
+    user_prompt, _ = build_agent_call(_initial_input(), [])
+    assert "<your-model" not in user_prompt

--- a/tests/bot/agents/test_response_fitting.py
+++ b/tests/bot/agents/test_response_fitting.py
@@ -1,0 +1,186 @@
+"""Tests for fitting overlong chat replies into Discord's message cap."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+
+import pytest
+
+import smarter_dev.bot.agents.response_fitting as response_fitting
+from smarter_dev.bot.agents.response_fitting import DISCORD_MESSAGE_LIMIT
+from smarter_dev.bot.agents.response_fitting import SPLIT_TARGET
+from smarter_dev.bot.agents.response_fitting import SUMMARIZE_THRESHOLD
+from smarter_dev.bot.agents.response_fitting import _shorten_with_agent
+from smarter_dev.bot.agents.response_fitting import fit_overlong_response
+from smarter_dev.bot.agents.response_fitting import split_for_discord
+
+# --------------------------------------------------------------------------- #
+# split_for_discord
+# --------------------------------------------------------------------------- #
+
+
+def test_split_short_text_passes_through():
+    assert split_for_discord("hello") == ["hello"]
+
+
+def test_split_exactly_at_limit_passes_through():
+    text = "a" * DISCORD_MESSAGE_LIMIT
+    assert split_for_discord(text) == [text]
+
+
+def test_split_empty_text_returns_no_parts():
+    assert split_for_discord("   ") == []
+
+
+def test_split_breaks_on_last_newline_before_target():
+    lines = ["x" * 99] * 25  # 100-char lines -> newlines at 99, 199, ... 2499
+    text = "\n".join(lines)  # 2499 chars
+    parts = split_for_discord(text)
+    assert len(parts) == 2
+    # Last newline at or before index 1500 is after the 15th line.
+    assert parts[0] == "\n".join(lines[:15])
+    assert parts[1] == "\n".join(lines[15:])
+    assert all(len(part) <= DISCORD_MESSAGE_LIMIT for part in parts)
+
+
+def test_split_without_newline_breaks_on_space():
+    words = ("word " * 500).strip()  # 2499 chars, spaces only
+    parts = split_for_discord(words)
+    assert len(parts) == 2
+    assert all(len(part) <= DISCORD_MESSAGE_LIMIT for part in parts)
+    assert " ".join(parts) == words
+
+
+def test_split_without_any_break_point_cuts_hard():
+    text = "a" * 2500
+    parts = split_for_discord(text)
+    assert parts == ["a" * SPLIT_TARGET, "a" * 1000]
+
+
+def test_split_ignores_newlines_that_would_overflow_the_tail():
+    # Only newline is at index 100; splitting there would leave a 2399-char
+    # tail. The split must move past it so both parts fit the cap.
+    text = "a" * 100 + "\n" + "b" * 2399
+    parts = split_for_discord(text)
+    assert len(parts) == 2
+    assert all(len(part) <= DISCORD_MESSAGE_LIMIT for part in parts)
+
+
+def test_split_defensive_overlong_tail_is_truncated():
+    # >3000 input shouldn't reach here, but must never produce an unsendable part.
+    text = "a" * 5000
+    parts = split_for_discord(text)
+    assert all(len(part) <= DISCORD_MESSAGE_LIMIT for part in parts)
+    assert parts[1].endswith("…")
+
+
+# --------------------------------------------------------------------------- #
+# _shorten_with_agent
+# --------------------------------------------------------------------------- #
+
+
+def _agent_returning(message, *, input_tokens=10, output_tokens=5):
+    agent = MagicMock()
+    response = (
+        SimpleNamespace(message=message) if message is not None else None
+    )
+    agent.run = AsyncMock(
+        return_value=SimpleNamespace(
+            output=SimpleNamespace(response=response),
+            usage=lambda: SimpleNamespace(
+                input_tokens=input_tokens, output_tokens=output_tokens
+            ),
+        )
+    )
+    return agent
+
+
+@pytest.mark.asyncio
+async def test_shorten_returns_rewrite_and_usage():
+    agent = _agent_returning("short version")
+    text, input_tokens, output_tokens = await _shorten_with_agent(
+        "x" * 4000, agent, deps=None, message_history=[]
+    )
+    assert text == "short version"
+    assert (input_tokens, output_tokens) == (10, 5)
+    prompt = agent.run.await_args.kwargs["user_prompt"]
+    assert "4000" in prompt
+
+
+@pytest.mark.asyncio
+async def test_shorten_no_response_returns_none():
+    agent = _agent_returning(None)
+    text, _, _ = await _shorten_with_agent("x" * 4000, agent, None, [])
+    assert text is None
+
+
+@pytest.mark.asyncio
+async def test_shorten_run_failure_degrades_to_none():
+    agent = MagicMock()
+    agent.run = AsyncMock(side_effect=RuntimeError("model down"))
+    text, input_tokens, output_tokens = await _shorten_with_agent(
+        "x" * 4000, agent, None, []
+    )
+    assert (text, input_tokens, output_tokens) == (None, 0, 0)
+
+
+# --------------------------------------------------------------------------- #
+# fit_overlong_response tiers
+# --------------------------------------------------------------------------- #
+
+LONG = "z" * 4000
+
+
+@pytest.mark.asyncio
+async def test_fit_uses_agent_rewrite_when_it_fits(monkeypatch):
+    monkeypatch.setattr(
+        response_fitting,
+        "_shorten_with_agent",
+        AsyncMock(return_value=("rewritten", 11, 7)),
+    )
+    summarize = AsyncMock()
+    monkeypatch.setattr(response_fitting, "_summarize_with_flash_lite", summarize)
+
+    fit = await fit_overlong_response(LONG, agent=None, deps=None, message_history=[])
+
+    assert fit.text == "rewritten"
+    assert fit.method == "shortened"
+    assert (fit.extra_input_tokens, fit.extra_output_tokens) == (11, 7)
+    summarize.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_fit_falls_back_to_summarizer_when_rewrite_still_long(monkeypatch):
+    monkeypatch.setattr(
+        response_fitting,
+        "_shorten_with_agent",
+        AsyncMock(return_value=("y" * (SUMMARIZE_THRESHOLD + 1), 11, 7)),
+    )
+    summarize = AsyncMock(return_value="a tidy summary")
+    monkeypatch.setattr(response_fitting, "_summarize_with_flash_lite", summarize)
+
+    fit = await fit_overlong_response(LONG, agent=None, deps=None, message_history=[])
+
+    assert fit.text == "a tidy summary"
+    assert fit.method == "summarized"
+    # The failed rewrite still spent chat-model tokens — they must be metered.
+    assert (fit.extra_input_tokens, fit.extra_output_tokens) == (11, 7)
+    summarize.assert_awaited_once_with(LONG)
+
+
+@pytest.mark.asyncio
+async def test_fit_truncates_when_everything_fails(monkeypatch):
+    monkeypatch.setattr(
+        response_fitting, "_shorten_with_agent", AsyncMock(return_value=(None, 0, 0))
+    )
+    monkeypatch.setattr(
+        response_fitting, "_summarize_with_flash_lite", AsyncMock(return_value=None)
+    )
+
+    fit = await fit_overlong_response(LONG, agent=None, deps=None, message_history=[])
+
+    assert fit.method == "truncated"
+    assert fit.text.endswith("…")
+    assert len(fit.text) <= DISCORD_MESSAGE_LIMIT

--- a/tests/bot/services/test_chat_engine_length.py
+++ b/tests/bot/services/test_chat_engine_length.py
@@ -25,6 +25,7 @@ from smarter_dev.bot.agents.chat_models import Message
 from smarter_dev.bot.agents.chat_models import MessageScore
 from smarter_dev.bot.agents.chat_models import ResponseBody
 from smarter_dev.bot.agents.chat_models import TurnDecision
+from smarter_dev.bot.agents.chat_tools import GeneratedImage
 from smarter_dev.bot.agents.response_fitting import FitResult
 from smarter_dev.bot.services.chat_engine import ChannelEngine
 
@@ -243,4 +244,69 @@ async def test_reply_at_threshold_is_not_rewritten(fake_memory, fake_redis):
         await engine._run_once(first_activation=True)
 
     fit_mock.assert_not_called()
+    assert len(engine.bot.rest.create_message.await_args_list) == 2
+
+
+@pytest.mark.asyncio
+async def test_split_reply_puts_attachments_on_the_last_message(fake_redis):
+    """Images ride on the second message of a split reply so an attachment
+    never visually interrupts the text."""
+    engine = _make_engine(fake_redis)
+    image = GeneratedImage(
+        data=b"PNGDATA", mime_type="image/png", filename="diagram.png"
+    )
+
+    ok = await engine._send_text(
+        "A" * 1200 + "\n" + "B" * 1290, reply_to=101, images=[image]
+    )
+
+    assert ok is True
+    calls = engine.bot.rest.create_message.await_args_list
+    assert len(calls) == 2
+    first, second = (call.kwargs for call in calls)
+    assert first["content"] == "A" * 1200
+    assert first["reply"] == 101
+    assert "attachments" not in first
+    assert second["content"] == "B" * 1290
+    assert "reply" not in second
+    assert len(second["attachments"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_single_message_reply_keeps_attachments_on_it(fake_redis):
+    engine = _make_engine(fake_redis)
+    image = GeneratedImage(
+        data=b"PNGDATA", mime_type="image/png", filename="diagram.png"
+    )
+
+    ok = await engine._send_text("short reply", reply_to=None, images=[image])
+
+    assert ok is True
+    engine.bot.rest.create_message.assert_awaited_once()
+    kwargs = engine.bot.rest.create_message.await_args.kwargs
+    assert kwargs["content"] == "short reply"
+    assert len(kwargs["attachments"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_failed_lead_message_fails_the_send(fake_redis):
+    engine = _make_engine(fake_redis)
+    engine.bot.rest.create_message = AsyncMock(side_effect=RuntimeError("down"))
+
+    ok = await engine._send_text("A" * 1200 + "\n" + "B" * 1290, reply_to=None)
+
+    assert ok is False
+    engine.bot.rest.create_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_failed_continuation_still_counts_as_sent(fake_redis):
+    engine = _make_engine(fake_redis)
+    engine.bot.rest.create_message = AsyncMock(
+        side_effect=[None, RuntimeError("down")]
+    )
+
+    ok = await engine._send_text("A" * 1200 + "\n" + "B" * 1290, reply_to=None)
+
+    assert ok is True
     assert len(engine.bot.rest.create_message.await_args_list) == 2

--- a/tests/bot/services/test_chat_engine_length.py
+++ b/tests/bot/services/test_chat_engine_length.py
@@ -1,0 +1,246 @@
+"""Engine wiring tests for overlong-reply handling.
+
+The agent run, memory, and input builders are patched — these verify the
+engine splits a 2000–3000 char reply into two messages, and routes a >3000
+char reply through ``fit_overlong_response`` (metering the rewrite's extra
+tokens) before sending.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from smarter_dev.bot.agents.chat_models import Author
+from smarter_dev.bot.agents.chat_models import ChannelInfo
+from smarter_dev.bot.agents.chat_models import InitialAgentInput
+from smarter_dev.bot.agents.chat_models import Me
+from smarter_dev.bot.agents.chat_models import Message
+from smarter_dev.bot.agents.chat_models import MessageScore
+from smarter_dev.bot.agents.chat_models import ResponseBody
+from smarter_dev.bot.agents.chat_models import TurnDecision
+from smarter_dev.bot.agents.response_fitting import FitResult
+from smarter_dev.bot.services.chat_engine import ChannelEngine
+
+
+def _initial_input() -> InitialAgentInput:
+    return InitialAgentInput(
+        me=Me(user_id="999", username="bot"),
+        channel_history=[],
+        activation_message=Message(
+            message_id="101",
+            author_id="200",
+            body="@bot hi",
+            mentions_bot=True,
+        ),
+        authors=[Author(user_id="200", username="alice")],
+        channel=ChannelInfo(channel_id="1", name="general"),
+        now_utc=datetime.now(UTC),
+    )
+
+
+def _send(message: str) -> TurnDecision:
+    return TurnDecision(
+        rankings=[MessageScore(message_id="101", score=10, reasoning="direct")],
+        response=ResponseBody(
+            target_message_id="101",
+            reply_directly=False,
+            message=message,
+        ),
+        topic="t",
+        notes="n",
+        continue_watching=True,
+    )
+
+
+def _result(output, *, input_tokens=100, output_tokens=50):
+    usage = SimpleNamespace(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        requests=1,
+        model="test-model",
+    )
+    return SimpleNamespace(
+        output=output,
+        usage=lambda: usage,
+        all_messages=lambda: [],
+        new_messages=lambda: [],
+    )
+
+
+@pytest.fixture
+def fake_memory():
+    m = MagicMock()
+    m.reset_idle_counter = AsyncMock()
+    m.write_topic = AsyncMock()
+    m.write_notes = AsyncMock()
+    m.clear_notes = AsyncMock()
+    m.read_history = AsyncMock(return_value=[])
+    m.write_history = AsyncMock()
+    m.clear_history = AsyncMock()
+    return m
+
+
+@pytest.fixture
+def fake_redis():
+    r = MagicMock()
+    r.set = AsyncMock(return_value=True)
+    r.exists = AsyncMock(return_value=0)
+    r.delete = AsyncMock(return_value=0)
+    r.get = AsyncMock(return_value=None)
+    pipe = MagicMock()
+    pipe.execute = AsyncMock(return_value=[0, True])
+    pipe.__aenter__ = AsyncMock(return_value=pipe)
+    pipe.__aexit__ = AsyncMock(return_value=False)
+    r.pipeline = MagicMock(return_value=pipe)
+    return r
+
+
+def _make_engine(fake_redis) -> ChannelEngine:
+    bot = MagicMock()
+    bot.rest = MagicMock()
+    bot.rest.create_message = AsyncMock()
+    service = MagicMock()
+    service.get_override = AsyncMock(return_value=None)
+    bot.d = {
+        "model_override_service": service,
+        "chat_memory_redis": fake_redis,
+    }
+
+    async def _on_deactivate(channel_id: int) -> None:
+        pass
+
+    async def _noop_voice(channel_id, text, reply_to, instruction=None):
+        pass
+
+    engine = ChannelEngine(
+        bot=bot,
+        channel_id=42,
+        guild_id=99,
+        voice_send=_noop_voice,
+        on_deactivate=_on_deactivate,
+    )
+    engine.activation_message = SimpleNamespace(
+        id=101, author=SimpleNamespace(id=200, username="alice")
+    )
+    return engine
+
+
+def _patches(agent_mock, fake_memory):
+    return [
+        patch(
+            "smarter_dev.bot.services.chat_engine.get_chat_agent",
+            return_value=agent_mock,
+        ),
+        patch(
+            "smarter_dev.bot.services.chat_engine.get_chat_memory",
+            return_value=fake_memory,
+        ),
+        patch(
+            "smarter_dev.bot.services.chat_engine.build_initial_input",
+            new=AsyncMock(return_value=_initial_input()),
+        ),
+        patch("smarter_dev.bot.services.chat_engine.add_usage", new=AsyncMock()),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_reply_between_2k_and_3k_is_sent_as_two_messages(
+    fake_memory, fake_redis
+):
+    long_reply = "A" * 1200 + "\n" + "B" * 1290  # 2491 chars
+    agent_mock = MagicMock()
+    agent_mock.run = AsyncMock(return_value=_result(_send(long_reply)))
+    engine = _make_engine(fake_redis)
+
+    patches = _patches(agent_mock, fake_memory)
+    with patches[0], patches[1], patches[2], patches[3]:
+        await engine._run_once(first_activation=True)
+
+    calls = engine.bot.rest.create_message.await_args_list
+    assert len(calls) == 2
+    contents = [call.kwargs["content"] for call in calls]
+    assert contents[0] == "A" * 1200
+    assert contents[1] == "B" * 1290
+    assert all(len(content) <= 2000 for content in contents)
+
+
+@pytest.mark.asyncio
+async def test_reply_under_2k_is_sent_as_one_message(fake_memory, fake_redis):
+    agent_mock = MagicMock()
+    agent_mock.run = AsyncMock(return_value=_result(_send("short reply")))
+    engine = _make_engine(fake_redis)
+
+    patches = _patches(agent_mock, fake_memory)
+    with patches[0], patches[1], patches[2], patches[3]:
+        await engine._run_once(first_activation=True)
+
+    engine.bot.rest.create_message.assert_awaited_once()
+    assert (
+        engine.bot.rest.create_message.await_args.kwargs["content"]
+        == "short reply"
+    )
+
+
+@pytest.mark.asyncio
+async def test_overlong_reply_is_fitted_and_extra_tokens_metered(
+    fake_memory, fake_redis
+):
+    agent_mock = MagicMock()
+    agent_mock.run = AsyncMock(return_value=_result(_send("z" * 3500)))
+    engine = _make_engine(fake_redis)
+
+    fit_mock = AsyncMock(
+        return_value=FitResult("fitted reply", 20, 10, "summarized")
+    )
+    persist_turn = AsyncMock()
+    patches = _patches(agent_mock, fake_memory)
+    with patches[0], patches[1], patches[2], patch(
+        "smarter_dev.bot.services.chat_engine.add_usage", new=AsyncMock()
+    ) as add_usage_mock, patch(
+        "smarter_dev.bot.services.chat_engine.fit_overlong_response", new=fit_mock
+    ), patch(
+        "smarter_dev.bot.services.chat_engine.start_engagement",
+        new=AsyncMock(return_value="engagement-1"),
+    ), patch(
+        "smarter_dev.bot.services.chat_engine.persist_turn", new=persist_turn
+    ):
+        await engine._run_once(first_activation=True)
+
+    fit_mock.assert_awaited_once()
+    assert fit_mock.await_args.args[0] == "z" * 3500
+    # The fitted text is what gets sent, in one message.
+    engine.bot.rest.create_message.assert_awaited_once()
+    assert (
+        engine.bot.rest.create_message.await_args.kwargs["content"]
+        == "fitted reply"
+    )
+    # Rewrite spend is metered (100+50 base + 20+10 extra) and persisted.
+    add_usage_mock.assert_awaited_once_with(fake_redis, "42", 180)
+    assert persist_turn.await_args.kwargs["chat_tokens_input"] == 120
+    assert persist_turn.await_args.kwargs["chat_tokens_output"] == 60
+
+
+@pytest.mark.asyncio
+async def test_reply_at_threshold_is_not_rewritten(fake_memory, fake_redis):
+    # Exactly 3000 chars: split into two messages, no model rewrite.
+    reply = "C" * 1400 + "\n" + "D" * 1599  # 3000 chars
+    agent_mock = MagicMock()
+    agent_mock.run = AsyncMock(return_value=_result(_send(reply)))
+    engine = _make_engine(fake_redis)
+
+    fit_mock = AsyncMock()
+    patches = _patches(agent_mock, fake_memory)
+    with patches[0], patches[1], patches[2], patches[3], patch(
+        "smarter_dev.bot.services.chat_engine.fit_overlong_response", new=fit_mock
+    ):
+        await engine._run_once(first_activation=True)
+
+    fit_mock.assert_not_called()
+    assert len(engine.bot.rest.create_message.await_args_list) == 2

--- a/tests/bot/services/test_chat_engine_override.py
+++ b/tests/bot/services/test_chat_engine_override.py
@@ -313,6 +313,62 @@ async def test_no_override_uses_default_and_skips_enforcement_but_meters(
     add_usage_mock.assert_awaited_once_with(fake_redis, "42", 150)
 
 
+@pytest.mark.asyncio
+async def test_override_without_pinned_model_uses_default_but_enforces_budget(
+    fake_memory, fake_redis
+):
+    """A budgets-only override (model_key None = server default) runs the
+    default agent while its token budgets are still enforced."""
+    agent_mock = MagicMock()
+    agent_mock.run = AsyncMock(return_value=_result(_send()))
+    engine, _ = _make_engine(_override(None, hourly=100), fake_redis)
+
+    get_agent = patch(
+        "smarter_dev.bot.services.chat_engine.get_chat_agent",
+        return_value=agent_mock,
+    )
+    with get_agent as get_agent_mock, _patches(
+        agent_mock=agent_mock, fake_memory=fake_memory
+    )[1], _patches(agent_mock=agent_mock, fake_memory=fake_memory)[2], patch(
+        "smarter_dev.bot.services.chat_engine.over_budget_reset_epoch",
+        new=AsyncMock(return_value=None),
+    ) as over_budget_mock, patch(
+        "smarter_dev.bot.services.chat_engine.add_usage", new=AsyncMock()
+    ):
+        await engine._run_once(first_activation=True)
+
+    get_agent_mock.assert_called_once_with(None, None)
+    over_budget_mock.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_turn_prompt_carries_model_identity(fake_memory, fake_redis):
+    """The user prompt handed to the agent names the resolved model and
+    reasoning level in its ``<your-model>`` metadata tag."""
+    agent_mock = MagicMock()
+    agent_mock.run = AsyncMock(return_value=_result(_send()))
+    engine, _ = _make_engine(
+        _override("gpt-5-4", reasoning_level="high"), fake_redis
+    )
+
+    with patch(
+        "smarter_dev.bot.services.chat_engine.get_chat_agent",
+        return_value=agent_mock,
+    ), _patches(agent_mock=agent_mock, fake_memory=fake_memory)[1], _patches(
+        agent_mock=agent_mock, fake_memory=fake_memory
+    )[2], patch(
+        "smarter_dev.bot.services.chat_engine.over_budget_reset_epoch",
+        new=AsyncMock(return_value=None),
+    ), patch(
+        "smarter_dev.bot.services.chat_engine.add_usage", new=AsyncMock()
+    ):
+        await engine._run_once(first_activation=True)
+
+    user_prompt = agent_mock.run.await_args.kwargs["user_prompt"]
+    assert '<your-model id="gpt-5.4"' in user_prompt
+    assert 'reasoning-level="high"' in user_prompt
+
+
 def _temporary_default_payload(
     model_key: str = "gemini-3-6-flash", reasoning_level: str | None = "high"
 ) -> str:

--- a/tests/bot/test_model_override.py
+++ b/tests/bot/test_model_override.py
@@ -26,6 +26,7 @@ from smarter_dev.bot.views.model_override_views import MAX_TOKEN_BUDGET
 from smarter_dev.bot.views.model_override_views import MODAL_CUSTOM_ID_PREFIX
 from smarter_dev.bot.views.model_override_views import MODEL_NEXT_CUSTOM_ID_PREFIX
 from smarter_dev.bot.views.model_override_views import REASONING_SELECT_CUSTOM_ID_PREFIX
+from smarter_dev.bot.views.model_override_views import RESET_CUSTOM_ID
 from smarter_dev.bot.views.model_override_views import SAVE_CUSTOM_ID_PREFIX
 from smarter_dev.bot.views.model_override_views import SENTINEL_DEFAULT
 from smarter_dev.bot.views.model_override_views import SENTINEL_MODEL_DEFAULT
@@ -296,7 +297,7 @@ def test_create_settings_panel_no_reasoning_model_omits_reasoning_row():
     )
 
 
-def test_create_settings_panel_buttons_carry_auto_continue_and_save():
+def test_create_settings_panel_buttons_carry_auto_continue_save_and_reset():
     model = get_model(NO_REASONING_KEY)
     rows = create_settings_panel(model, None, False, None)
     buttons = rows[-1].components
@@ -304,7 +305,31 @@ def test_create_settings_panel_buttons_carry_auto_continue_and_save():
     assert AUTO_TOGGLE_CUSTOM_ID_PREFIX in button_prefixes
     assert CONTINUE_CUSTOM_ID_PREFIX in button_prefixes
     assert SAVE_CUSTOM_ID_PREFIX in button_prefixes
-    assert len(buttons) == 3
+    assert RESET_CUSTOM_ID in button_prefixes
+    assert len(buttons) == 4
+
+
+def test_create_settings_panel_server_default_omits_reasoning_row():
+    rows = create_settings_panel(None, None, False, None)
+    custom_ids = [component.custom_id for component in _row_components(rows)]
+    assert not any(
+        custom_id.startswith(REASONING_SELECT_CUSTOM_ID_PREFIX)
+        for custom_id in custom_ids
+    )
+    state = encode_panel_state(SENTINEL_DEFAULT, None, False, None)
+    assert f"{SAVE_CUSTOM_ID_PREFIX}:{state}" in custom_ids
+    assert RESET_CUSTOM_ID in custom_ids
+
+
+def test_create_settings_panel_server_default_offers_every_fallback():
+    rows = create_settings_panel(None, None, False, None)
+    fallback_menu = next(
+        component
+        for component in _row_components(rows)
+        if component.custom_id.startswith(FALLBACK_SELECT_CUSTOM_ID_PREFIX)
+    )
+    # The sentinel matches no catalog key, so no model is excluded as "primary".
+    assert len(fallback_menu.options) == 1 + len(MODEL_CATALOG)
 
 
 def test_create_settings_panel_auto_button_reflects_off_state():
@@ -336,6 +361,9 @@ def test_create_settings_panel_custom_ids_carry_state_and_stay_short():
     rows = create_settings_panel(model, "high", True, FALLBACK_KEY)
     state = encode_panel_state(REASONING_KEY, "high", True, FALLBACK_KEY)
     for component in _row_components(rows):
+        # The reset button is stateless — it deletes the row outright.
+        if component.custom_id == RESET_CUSTOM_ID:
+            continue
         assert component.custom_id.endswith(state)
         assert len(component.custom_id) < 100
 
@@ -594,29 +622,100 @@ def _component_event(
     return event
 
 
-async def test_select_sentinel_clears_override():
+async def test_select_sentinel_renders_default_panel_without_reasoning():
+    """Picking "Server default" opens the settings panel (budgets, auto-respond
+    etc. stay configurable) instead of clearing the override, and the panel
+    omits the reasoning select — the underlying default model can change."""
     service = AsyncMock()
+    service.get_override.return_value = None
     event = _component_event([SENTINEL_DEFAULT], service)
     with patch(PERMS_TARGET, return_value=ADMIN):
         await model_override.handle_model_override_select(event)
+
+    service.clear_override.assert_not_called()
+    event.interaction.create_initial_response.assert_awaited_once()
+    args, kwargs = event.interaction.create_initial_response.call_args
+    assert args[0] == hikari.ResponseType.MESSAGE_UPDATE
+    custom_ids = [c.custom_id for c in _row_components(kwargs["components"])]
+    assert not any(c.startswith(REASONING_SELECT_CUSTOM_ID_PREFIX) for c in custom_ids)
+    assert any(c.startswith(FALLBACK_SELECT_CUSTOM_ID_PREFIX) for c in custom_ids)
+    assert RESET_CUSTOM_ID in custom_ids
+
+
+async def test_select_sentinel_drops_stored_reasoning_from_panel_state():
+    """A stored override's reasoning level must not ride into the default
+    panel's state — the server default carries no pinned level."""
+    service = AsyncMock()
+    service.get_override.return_value = _override(
+        model_key=REASONING_KEY, reasoning_level="high", auto_respond=True
+    )
+    event = _component_event([SENTINEL_DEFAULT], service)
+    with patch(PERMS_TARGET, return_value=ADMIN):
+        await model_override.handle_model_override_select(event)
+
+    _, kwargs = event.interaction.create_initial_response.call_args
+    state = encode_panel_state(SENTINEL_DEFAULT, None, True, None)
+    save_ids = [
+        c.custom_id
+        for c in _row_components(kwargs["components"])
+        if c.custom_id.startswith(SAVE_CUSTOM_ID_PREFIX)
+    ]
+    assert save_ids == [f"{SAVE_CUSTOM_ID_PREFIX}:{state}"]
+
+
+async def test_save_sentinel_persists_null_model_key():
+    """Saving the server-default panel stores model_key=None so budgets and
+    behaviour apply while the channel keeps the default model."""
+    service = AsyncMock()
+    service.get_override.return_value = _override(daily=500, hourly=100)
+    state = encode_panel_state(SENTINEL_DEFAULT, None, True, None)
+    event = _component_event(
+        [], service, custom_id=f"{SAVE_CUSTOM_ID_PREFIX}:{state}"
+    )
+    with patch(PERMS_TARGET, return_value=ADMIN):
+        await model_override.handle_model_override_save(event)
+
+    service.set_override.assert_awaited_once()
+    args, kwargs = service.set_override.await_args
+    assert args[2] is None  # model_key
+    assert kwargs["auto_respond"] is True
+    _, response_kwargs = event.interaction.create_initial_response.call_args
+    assert "server default model" in response_kwargs["content"]
+
+
+async def test_reset_button_clears_override():
+    service = AsyncMock()
+    event = _component_event([], service, custom_id=RESET_CUSTOM_ID)
+    with patch(PERMS_TARGET, return_value=ADMIN):
+        await model_override.handle_model_override_reset(event)
 
     service.clear_override.assert_awaited_once_with("G", "C")
-    event.interaction.create_initial_response.assert_awaited_once()
-    event.interaction.create_modal_response.assert_not_called()
+    _, kwargs = event.interaction.create_initial_response.call_args
+    assert "Reset this channel's chat-bot settings" in kwargs["content"]
+    assert kwargs["components"] == []
 
 
-async def test_select_sentinel_clear_failure_reports_to_admin():
-    """An API failure clearing the override must answer the interaction with a
-    friendly error, not escape to the (broken) generic modal error responder."""
+async def test_reset_button_denies_non_admin():
+    service = AsyncMock()
+    event = _component_event([], service, custom_id=RESET_CUSTOM_ID)
+    with patch(PERMS_TARGET, return_value=NONE):
+        await model_override.handle_model_override_reset(event)
+
+    service.clear_override.assert_not_called()
+
+
+async def test_reset_failure_reports_to_admin():
+    """An API failure resetting must answer the interaction with a friendly
+    error, not escape to the (broken) generic error responder."""
     service = AsyncMock()
     service.clear_override.side_effect = APIError("boom", status_code=500)
-    event = _component_event([SENTINEL_DEFAULT], service)
+    event = _component_event([], service, custom_id=RESET_CUSTOM_ID)
     with patch(PERMS_TARGET, return_value=ADMIN):
-        await model_override.handle_model_override_select(event)
+        await model_override.handle_model_override_reset(event)
 
     event.interaction.create_initial_response.assert_awaited_once()
     _, kwargs = event.interaction.create_initial_response.call_args
-    assert "Couldn't remove the override" in kwargs["content"]
+    assert "Couldn't reset the settings" in kwargs["content"]
 
 
 async def test_select_no_reasoning_model_renders_panel():
@@ -778,6 +877,8 @@ async def test_auto_toggle_flips_state_off_to_on():
     assert args[0] == hikari.ResponseType.MESSAGE_UPDATE
     state = encode_panel_state(REASONING_KEY, "high", True, FALLBACK_KEY)
     for component in _row_components(kwargs["components"]):
+        if component.custom_id == RESET_CUSTOM_ID:
+            continue
         assert component.custom_id.endswith(state)
 
 

--- a/tests/web/test_api_native/test_model_overrides.py
+++ b/tests/web/test_api_native/test_model_overrides.py
@@ -110,6 +110,33 @@ class TestPutModelOverride:
         assert kwargs["fallback_model_key"] is None
         assert kwargs["response_filter"] is None
 
+    def test_upsert_accepts_null_model_key_for_server_default(
+        self, model_override_client: TestClient, model_override_crud_mock, session_mock
+    ):
+        """model_key null = keep the server default model; budgets and
+        behaviour flags still persist."""
+        model_override_crud_mock.upsert.return_value = _record(
+            model_key=None, daily_token_budget=1000, auto_respond=True
+        )
+
+        response = model_override_client.put(
+            _url(),
+            json={
+                "model_key": None,
+                "daily_token_budget": 1000,
+                "auto_respond": True,
+            },
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["model_key"] is None
+        assert body["daily_token_budget"] == 1000
+        assert body["auto_respond"] is True
+        _, kwargs = model_override_crud_mock.upsert.call_args
+        assert kwargs["model_key"] is None
+        session_mock.commit.assert_awaited_once()
+
     def test_new_settings_passed_through(
         self, model_override_client: TestClient, model_override_crud_mock
     ):


### PR DESCRIPTION
Three changes, one per commit:

## 1. `/chat-bot-settings` rework (291fb10)

- Picking **Server default** no longer clears the override and exits — it opens the settings panel with a NULL `model_key`, so **budgets, auto-respond, fallback model, and response filter** are configurable for default-model channels.
- The reasoning select is **omitted for the server default** (the underlying default model changes over time).
- New red **Reset all** button deletes the entire override row — replaces the old select-sentinel-to-clear behavior.
- Migration `f4a7d1c9e3b6` makes `channel_model_overrides.model_key` nullable; API schemas accept null; the engine treats a NULL pinned model as "run the default (or temporary default override) but still enforce budgets".

## 2. Model identity fix (dea826e + 291fb10)

The bot said it didn't know its model: the identity was in the system prompt, which pydantic-ai only applies when `message_history` is empty — mid-engagement turns never saw it. The identity now renders into **every turn's metadata block** as `<your-model id name reasoning-level/>`, staying truthful across engagements and mid-conversation model switches. Share-only-when-asked instruction lives in the static prompt file.

## 3. Overlong-reply fitting (de5d31b)

Replies over Discord's 2000-char cap were hard-truncated mid-sentence. New tiers in `response_fitting.py`:
- **≤ 2000** — sent unchanged.
- **2000–3000** — split into two messages at the last newline before the 1500-char mark (fallback: last space, then hard cut), constrained so both parts fit the cap. Reply anchor + images ride on the first message.
- **> 3000** — the chat agent rewrites its own draft (context-aware, `<length-notice>` follow-up run); still >3000 or failed → **Gemini 3.5 Flash Lite** summarizes; hard truncation backstops so a reply always lands.

The rewrite's chat-model tokens fold into the turn's budget metering and persisted totals; the Flash Lite summarizer's small spend is logged (mirrors compaction).

## Testing

Full bot suite green (856 passed) plus model-override API/model suites and migration ownership; single alembic head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ThsbEtkTfXyoSFCw9uu17w