### PR TITLE
Clarify chatbot web research workflow

### DIFF
--- a/smarter_dev/bot/agents/chat_tools.py
+++ b/smarter_dev/bot/agents/chat_tools.py
@@ -10,7 +10,8 @@ from __future__ import annotations
 import logging
 import mimetypes
 from contextlib import asynccontextmanager
-from dataclasses import dataclass, field
+from dataclasses import dataclass
+from dataclasses import field
 from typing import Any
 
 import hikari
@@ -132,10 +133,13 @@ async def _post_status(ctx: RunContext[ChatDeps], text: str) -> None:
 
 
 async def web_search(ctx: RunContext[ChatDeps], query: str) -> list[dict[str, str]]:
-    """Search the web via Brave Search and return up to 5 result snippets.
+    """Discover web sources via Brave Search and return up to 5 result snippets.
 
-    Use this when the user asks about current events, specific products,
-    niche technical topics, or anything that needs sources to back it up.
+    This is the first stage of web research. Snippets are enough for quick,
+    low-stakes answers and broad summaries. For accurate or deep answers,
+    precise technical guidance, nuanced comparisons, quotations, verification,
+    or source-specific claims, choose the best result URLs and call ``web_read``
+    before replying.
     """
     logger.info("web_search: %r (channel=%s)", query, ctx.deps.channel_id)
     await _post_status(ctx, f'Searching the web: "{query}"')
@@ -153,12 +157,14 @@ async def web_search(ctx: RunContext[ChatDeps], query: str) -> list[dict[str, st
 async def web_read(
     ctx: RunContext[ChatDeps], url: str, instruction: str
 ) -> dict[str, str]:
-    """Fetch a URL and return an instruction-guided summary of its content.
+    """Read a URL and return an instruction-guided summary of its content.
 
-    Handles web pages, PDFs, YouTube links, and image/audio files (e.g.
-    ``<attachment>`` URLs). A fast model condenses the content per
-    ``instruction`` — you get the summary back, never the raw file — so say
-    what to look for, what to ignore, quote-vs-paraphrase, and how much
+    This is the evidence stage after ``web_search`` when an answer must be
+    accurate, deep, precise, nuanced, verified, or grounded in a source. It
+    also handles direct URLs and ``<attachment>`` URLs for web pages, PDFs,
+    YouTube links, and image/audio files. A fast model condenses the content
+    per ``instruction`` — you get the summary back, never the raw file — so
+    say what to look for, what to ignore, quote-vs-paraphrase, and how much
     detail (keep it small; ~5 paragraphs max). If the page lacks what you
     asked for, the summary says so instead of guessing. Returns ``url``,
     ``title``, and ``summary`` (or ``error`` on fetch failure).

--- a/smarter_dev/bot/agents/prompts/chat_agent.md
+++ b/smarter_dev/bot/agents/prompts/chat_agent.md
@@ -211,6 +211,25 @@ your head — you will get it wrong. Use `run_code` (restricted sandbox;
 its description has the limits) with a short human `reason`, and use
 `web_read`/`web_search` for anything live.
 
+# Web research
+
+Treat `web_search` and `web_read` as stages of one research process:
+
+- `web_search` discovers sources and returns short result snippets. Those
+  snippets are enough for a quick, low-stakes answer or a broad summary when
+  the details do not need close verification.
+- For an accurate or deep answer, continue by calling `web_read` on the most
+  relevant result or results before replying. This includes precise technical
+  guidance, nuanced comparisons, quotations, source-specific claims, and
+  anything the user asks you to verify or explain in detail.
+- Choose what to read from the search results; don't guess a URL. If a read
+  fails, try another relevant result. If none can be read, be clear that your
+  answer is based only on search snippets and keep the claims appropriately
+  limited.
+
+Search is the discovery step. Reading is the evidence step when accuracy or
+depth matters.
+
 # Images
 
 You can attach a generated image to your reply with `generate_image(prompt)`.

--- a/tests/bot/agents/test_web_research_contract.py
+++ b/tests/bot/agents/test_web_research_contract.py
@@ -1,0 +1,26 @@
+"""Tests for the chat agent's search-to-read research contract."""
+
+from smarter_dev.bot.agents.chat_agent import SYSTEM_PROMPT
+from smarter_dev.bot.agents.chat_tools import web_read
+from smarter_dev.bot.agents.chat_tools import web_search
+
+
+def test_system_prompt_distinguishes_search_from_reading():
+    assert "Search is the discovery step" in SYSTEM_PROMPT
+    assert "Reading is the evidence step" in SYSTEM_PROMPT
+    assert "quick, low-stakes answer" in SYSTEM_PROMPT
+    assert "For an accurate or deep answer" in SYSTEM_PROMPT
+
+
+def test_web_search_description_requires_reading_for_deep_answers():
+    description = web_search.__doc__ or ""
+    assert "first stage of web research" in description
+    assert "Snippets are enough for quick" in description
+    assert "call ``web_read``" in description
+    assert "before replying" in description
+
+
+def test_web_read_description_identifies_evidence_stage():
+    description = web_read.__doc__ or ""
+    assert "evidence stage after ``web_search``" in description
+    assert "accurate, deep, precise, nuanced, verified" in description


### PR DESCRIPTION
## Summary

- define web search and web read as stages of one research process
- allow snippets for quick, low-stakes answers and broad summaries
- require source reads for accurate, deep, nuanced, or verified answers
- add regression tests for the prompt and tool-description contract

## Why

Some chat models stopped after search snippets because the existing prompt treated search and read as alternatives. The updated contract makes search the discovery stage and reading the evidence stage when accuracy or depth matters.

## Validation

- `uv run --group bot --group test pytest --no-cov -q tests/bot/agents/test_web_research_contract.py tests/bot/agents/test_chat_agent_override.py tests/bot/agents/test_web_read_summarize.py` (36 passed)
- `uv run ruff check smarter_dev/bot/agents/chat_tools.py tests/bot/agents/test_web_research_contract.py`
- `git diff --check`