### PR TITLE
Use GPT-5.6 Luna for internal Flash workloads

### DIFF
--- a/scripts/chat_eval_matrix.py
+++ b/scripts/chat_eval_matrix.py
@@ -50,7 +50,7 @@ from smarter_dev.bot.agents.chat_tools import ChatDeps  # noqa: E402
 MODELS = {
     "Gemini 3.1 Flash Lite": ("google", "gemini-3.1-flash-lite"),
     "Gemini 3 Flash": ("google", "gemini-3-flash-preview"),
-    "Gemini 3.6 Flash": ("google", "gemini-3.6-flash"),
+    "GPT 5.6 Luna": ("openai", "gpt-5.6-luna"),
     "GPT 5.4 Nano": ("openai", "gpt-5.4-nano"),
     "GPT 5.4 Mini": ("openai", "gpt-5.4-mini"),
 }

--- a/scripts/eval_prices.py
+++ b/scripts/eval_prices.py
@@ -1,8 +1,8 @@
 """Inject prices for models newer than the bundled genai-prices snapshot.
 
 The pip snapshot (and its remote refresh) lags new releases, so models like
-Gemini 3.5 Flash / 3.1 Flash Lite and GPT 5.4 nano/mini aren't priceable out
-of the box. We register them as a custom snapshot so calc_price() resolves.
+Gemini 3.1 Flash Lite and GPT 5.4 nano/mini or GPT 5.6 Luna aren't priceable
+out of the box. We register them as a custom snapshot so calc_price() resolves.
 
 Prices are list price per 1M tokens, sourced from each provider's published
 pricing. Update the table if list prices change.
@@ -39,6 +39,8 @@ CUSTOM_PRICES: dict[str, dict[str, tuple[str, str, str, str | None]]] = {
         "gpt-5.4-nano": ("GPT 5.4 Nano", "0.2", "1.25", "0.02"),
         # GPT-5.4 Mini — $0.75 in / $4.50 out / $0.075 cached.
         "gpt-5.4-mini": ("GPT 5.4 Mini", "0.75", "4.5", "0.075"),
+        # GPT-5.6 Luna — preview pricing, July 2026. $1.00 in / $6.00 out.
+        "gpt-5.6-luna": ("GPT 5.6 Luna", "1", "6", None),
     },
 }
 
@@ -90,7 +92,7 @@ if __name__ == "__main__":
     print("added:", install())
     pd = calc_price(
         Usage(input_tokens=1_000_000, output_tokens=1_000_000),
-        model_ref="gemini-3.5-flash",
-        provider_id="google",
+        model_ref="gpt-5.6-luna",
+        provider_id="openai",
     )
-    print(f"gemini-3.5-flash 1M/1M -> ${pd.total_price} (matched {pd.model.id})")
+    print(f"gpt-5.6-luna 1M/1M -> ${pd.total_price} (matched {pd.model.id})")

--- a/smarter_dev/bot/agents/response_fitting.py
+++ b/smarter_dev/bot/agents/response_fitting.py
@@ -10,14 +10,14 @@ Three tiers, cheapest first:
 3. ``len > 3000`` — :func:`fit_overlong_response` first asks the chat agent
    itself to rewrite the reply shorter (it has the full conversation context);
    if the rewrite is still over 3000 characters (or the run fails), a cheap
-   Gemini 3.5 Flash Lite summarizer condenses the original; if even that
-   overruns, the text is hard-truncated as a last resort. The result then
-   flows through tier 1/2 for sending.
+   GPT-5.6 Luna summarizer condenses the original; if even that overruns, the
+   text is hard-truncated as a last resort. The result then flows through tier
+   1/2 for sending.
 
 The shorten re-run uses the turn's own agent + history, so its tokens are the
 chat model's and are folded into the turn's metering/pricing by the engine.
-The Flash Lite summarizer runs its own model; like chat compaction, its
-(small) spend is logged but not metered against the channel budget.
+The Luna summarizer runs its own model; like chat compaction, its spend is
+logged but not metered against the channel budget.
 """
 
 from __future__ import annotations
@@ -44,7 +44,7 @@ SPLIT_TARGET = 1500
 SUMMARIZE_THRESHOLD = 3000
 
 # Catalog key of the model that summarizes as the second resort.
-LENGTH_SUMMARIZER_MODEL_KEY = "gemini-3-5-flash-lite"
+LENGTH_SUMMARIZER_MODEL_KEY = "gpt-5-6-luna"
 
 _SHORTEN_PROMPT_TEMPLATE = (
     "<length-notice>Your drafted reply could not be sent: it is {length} "
@@ -112,7 +112,7 @@ _length_summarizer: Agent | None = None
 
 
 def get_length_summarizer() -> Agent:
-    """The cached Flash Lite summarizer agent (plain-text output)."""
+    """The cached Luna summarizer agent (plain-text output)."""
     global _length_summarizer
     if _length_summarizer is None:
         catalog_model = get_model(LENGTH_SUMMARIZER_MODEL_KEY)
@@ -154,8 +154,8 @@ async def _shorten_with_agent(
     return text or None, input_tokens, output_tokens
 
 
-async def _summarize_with_flash_lite(message: str) -> str | None:
-    """Condense ``message`` with the Flash Lite summarizer (fail-soft)."""
+async def _summarize_with_luna(message: str) -> str | None:
+    """Condense ``message`` with the Luna summarizer (fail-soft)."""
     try:
         result = await get_length_summarizer().run(user_prompt=message)
     except Exception:
@@ -192,7 +192,7 @@ async def fit_overlong_response(
     if shortened is not None and len(shortened) <= SUMMARIZE_THRESHOLD:
         return FitResult(shortened, input_tokens, output_tokens, "shortened")
 
-    summary = await _summarize_with_flash_lite(message)
+    summary = await _summarize_with_luna(message)
     if summary is not None and len(summary) <= SUMMARIZE_THRESHOLD:
         return FitResult(summary, input_tokens, output_tokens, "summarized")
 

--- a/smarter_dev/bot/services/chat_engine.py
+++ b/smarter_dev/bot/services/chat_engine.py
@@ -686,7 +686,7 @@ class ChannelEngine:
             tokens = _extract_tokens(result.usage())
             # A reply too long to send in two messages gets rewritten before
             # dispatch: the agent shortens its own draft (context-aware),
-            # falling back to a Flash Lite summary, then truncation. The
+            # falling back to a Luna summary, then truncation. The
             # shorten re-run spends chat-model tokens, so they're folded into
             # this turn's metering and persisted totals.
             fit_extra_input = 0

--- a/smarter_dev/shared/config.py
+++ b/smarter_dev/shared/config.py
@@ -105,7 +105,7 @@ class Settings(BaseSettings):
         description="Model that reviews candidate handler scripts (Gemini 3 Flash)",
     )
     handler_admin_second_judge_model: str = Field(
-        default="gemini-3.6-flash",
+        default="gpt-5.6-luna",
         description="Second judge for ADMIN handlers — reviews in series with the "
         "primary judge and either rejection blocks install (their observed blind "
         "spots don't overlap). Empty string disables the second judge.",

--- a/tests/bot/agents/test_response_fitting.py
+++ b/tests/bot/agents/test_response_fitting.py
@@ -10,6 +10,7 @@ import pytest
 
 import smarter_dev.bot.agents.response_fitting as response_fitting
 from smarter_dev.bot.agents.response_fitting import DISCORD_MESSAGE_LIMIT
+from smarter_dev.bot.agents.response_fitting import LENGTH_SUMMARIZER_MODEL_KEY
 from smarter_dev.bot.agents.response_fitting import SPLIT_TARGET
 from smarter_dev.bot.agents.response_fitting import SUMMARIZE_THRESHOLD
 from smarter_dev.bot.agents.response_fitting import _shorten_with_agent
@@ -19,6 +20,10 @@ from smarter_dev.bot.agents.response_fitting import split_for_discord
 # --------------------------------------------------------------------------- #
 # split_for_discord
 # --------------------------------------------------------------------------- #
+
+
+def test_length_summarizer_uses_luna():
+    assert LENGTH_SUMMARIZER_MODEL_KEY == "gpt-5-6-luna"
 
 
 def test_split_short_text_passes_through():
@@ -141,7 +146,7 @@ async def test_fit_uses_agent_rewrite_when_it_fits(monkeypatch):
         AsyncMock(return_value=("rewritten", 11, 7)),
     )
     summarize = AsyncMock()
-    monkeypatch.setattr(response_fitting, "_summarize_with_flash_lite", summarize)
+    monkeypatch.setattr(response_fitting, "_summarize_with_luna", summarize)
 
     fit = await fit_overlong_response(LONG, agent=None, deps=None, message_history=[])
 
@@ -159,7 +164,7 @@ async def test_fit_falls_back_to_summarizer_when_rewrite_still_long(monkeypatch)
         AsyncMock(return_value=("y" * (SUMMARIZE_THRESHOLD + 1), 11, 7)),
     )
     summarize = AsyncMock(return_value="a tidy summary")
-    monkeypatch.setattr(response_fitting, "_summarize_with_flash_lite", summarize)
+    monkeypatch.setattr(response_fitting, "_summarize_with_luna", summarize)
 
     fit = await fit_overlong_response(LONG, agent=None, deps=None, message_history=[])
 
@@ -176,7 +181,7 @@ async def test_fit_truncates_when_everything_fails(monkeypatch):
         response_fitting, "_shorten_with_agent", AsyncMock(return_value=(None, 0, 0))
     )
     monkeypatch.setattr(
-        response_fitting, "_summarize_with_flash_lite", AsyncMock(return_value=None)
+        response_fitting, "_summarize_with_luna", AsyncMock(return_value=None)
     )
 
     fit = await fit_overlong_response(LONG, agent=None, deps=None, message_history=[])


### PR DESCRIPTION
## Summary

- switch the admin handler second judge from Gemini 3.6 Flash to GPT-5.6 Luna
- switch the overlong-response fallback summarizer from Gemini 3.5 Flash Lite to GPT-5.6 Luna
- replace Gemini 3.6 Flash in the chat evaluation matrix and update Luna pricing support
- preserve all model catalog entries and channel/default override behavior

## Validation

- 201 focused tests passed
- GPT-5.6 Luna eval pricing resolves to $7 per 1M input + 1M output tokens
- `git diff --check`
- Alembic head remains unchanged at `f4a7d1c9e3b6`