### PR TITLE
fix: widen admin_handlers.trigger_type to varchar(32)

### DIFF
--- a/alembic/main/versions/20260721_220000_d1e3f5a7c9b2_widen_admin_trigger_type.py
+++ b/alembic/main/versions/20260721_220000_d1e3f5a7c9b2_widen_admin_trigger_type.py
@@ -1,0 +1,44 @@
+"""Widen admin_handlers.trigger_type to varchar(32).
+
+The longest admin trigger, ``member_rules_accepted``, is 21 chars, but the
+column was varchar(20) — every insert of a handler on that trigger (e.g. the
+``onboard-and-promote`` extension) raised StringDataRightTruncationError. The
+value was never storable before, so widening cannot truncate existing data.
+``channel_handlers.trigger_type`` stays varchar(20): its check constraint only
+admits message/reaction/schedule/timer (all <= 8 chars).
+
+Revision ID: d1e3f5a7c9b2
+Revises: 7aa20a55c255
+Create Date: 2026-07-21 22:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "d1e3f5a7c9b2"
+down_revision: Union[str, None] = "7aa20a55c255"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "admin_handlers",
+        "trigger_type",
+        existing_type=sa.String(length=20),
+        type_=sa.String(length=32),
+        existing_nullable=False,
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "admin_handlers",
+        "trigger_type",
+        existing_type=sa.String(length=32),
+        type_=sa.String(length=20),
+        existing_nullable=False,
+    )

--- a/smarter_dev/web/models.py
+++ b/smarter_dev/web/models.py
@@ -4523,7 +4523,9 @@ class AdminHandler(Base):
     )
     guild_id: Mapped[str] = mapped_column(String(20), nullable=False)
     name: Mapped[str] = mapped_column(String(64), nullable=False)
-    trigger_type: Mapped[str] = mapped_column(String(20), nullable=False)
+    # 32, not 20: the longest admin trigger, "member_rules_accepted", is 21
+    # chars — a varchar(20) truncation-errored every insert of that handler.
+    trigger_type: Mapped[str] = mapped_column(String(32), nullable=False)
     settings: Mapped[dict] = mapped_column(
         JSON, nullable=False, default=dict, server_default="{}"
     )

--- a/tests/web/handler_models_test.py
+++ b/tests/web/handler_models_test.py
@@ -202,3 +202,24 @@ async def test_guild_handler_memory_unique_guild_key_upsert(db_session):
     db_session.add(GuildHandlerMemory(guild_id="G1", key="a", value={"v": 9}))
     with pytest.raises(IntegrityError):
         await db_session.commit()
+
+
+def test_trigger_type_columns_fit_their_vocabulary():
+    # The test DB is SQLite, which ignores VARCHAR(n) limits, so a too-narrow
+    # trigger_type column only surfaces in Postgres (prod): "member_rules_accepted"
+    # (21 chars) truncation-errored every insert against a varchar(20) column.
+    # This backend-independent invariant guards the column width directly.
+    admin_len = AdminHandler.__table__.c.trigger_type.type.length
+    longest_admin = max(len(t) for t in ADMIN_HANDLER_TRIGGER_TYPES)
+    assert admin_len >= longest_admin, (
+        f"admin_handlers.trigger_type varchar({admin_len}) cannot hold "
+        f"{longest_admin}-char triggers like "
+        f"{max(ADMIN_HANDLER_TRIGGER_TYPES, key=len)!r}"
+    )
+
+    channel_len = ChannelHandler.__table__.c.trigger_type.type.length
+    longest_channel = max(len(t) for t in HANDLER_TRIGGER_TYPES)
+    assert channel_len >= longest_channel, (
+        f"channel_handlers.trigger_type varchar({channel_len}) cannot hold "
+        f"{longest_channel}-char triggers"
+    )


### PR DESCRIPTION
## Problem
Installing the **onboard-and-promote** extension 500s in prod:
`asyncpg StringDataRightTruncationError: value too long for type character varying(20)`.

Its handler uses the `member_rules_accepted` trigger (21 chars), but `admin_handlers.trigger_type` is `varchar(20)`. Latent bug: the trigger type was added earlier but no admin-handler *row* with it had ever been inserted, and the test suite runs on **SQLite**, which silently ignores `VARCHAR(n)` limits — so nothing caught it.

## Fix
- Migration widens `admin_handlers.trigger_type` 20 → 32 (widening can't truncate — the value was never storable). `channel_handlers` stays 20 (its check constraint admits only message/reaction/schedule/timer).
- Model column bumped to `String(32)`.
- Backend-independent invariant test: asserts each `trigger_type` column is wide enough for its allowed vocabulary. Verified it fails at `varchar(20)` (`assert 20 >= 21`) and passes at 32 — catches the class of bug even on SQLite, where a row-insert test cannot.

## Test plan
- `handler_models_test.py`, `test_extension_install_service.py`, `test_migration_ownership.py` → 45 passed
- Single migration head `d1e3f5a7c9b2`; deploy runs migrations before rollout

🤖 Generated with [Claude Code](https://claude.com/claude-code)