### PR TITLE
fix(k8s): run sudo-sweep CronJob via PYTHONPATH=/app uv run

### DIFF
--- a/k8s/cron-sudo-sweep.yaml
+++ b/k8s/cron-sudo-sweep.yaml
@@ -37,9 +37,13 @@ spec:
                     containers:
                       - name: sweep
                         image: zzmmrmn/smarter-dev-website:<IMAGE_VERSION>
-                        command:
-                          - /app/.venv/bin/python
-                          - /app/scripts/sudo_daily_sweep.py
+                        # Invoke via a shell wrapper with PYTHONPATH=/app + uv
+                        # run so /app (and thus the smarter_dev package) is on
+                        # sys.path — matches the proven migrate-job.yaml pattern.
+                        # Running python against a bare script path instead puts
+                        # only /app/scripts on sys.path[0], so the script's
+                        # `from smarter_dev...` import fails with ModuleNotFoundError.
+                        command: ["sh", "-c", "PYTHONPATH=/app uv run --no-sync python scripts/sudo_daily_sweep.py"]
                         envFrom:
                           - configMapRef:
                               name: smarter-dev-config


### PR DESCRIPTION
## Problem

The production \`smarter-dev-sudo-sweep\` CronJob has never successfully run. Its container command invoked the daily Polar billing sweep as a bare script path:

\`\`\`yaml
command:
  - /app/.venv/bin/python
  - /app/scripts/sudo_daily_sweep.py
\`\`\`

Invoking \`python\` with a script PATH puts only the script's own directory (\`/app/scripts\`) on \`sys.path[0]\`, **not** \`/app\`. So \`sudo_daily_sweep.py:18\` — \`from smarter_dev.shared.database import get_db_session_context\` — raises \`ModuleNotFoundError: No module named 'smarter_dev'\`. The container crashes near-instantly, retries twice (\`backoffLimit: 2\`), then the Job fails with BackoffLimitExceeded. Confirmed live in prod by streaming a manually-triggered job's logs.

## Fix

Switch to the proven-working pattern already used by \`migrate-job.yaml\` in this same repo:

\`\`\`yaml
command: ["sh", "-c", "PYTHONPATH=/app uv run --no-sync python scripts/sudo_daily_sweep.py"]
\`\`\`

\`PYTHONPATH=/app\` puts \`/app\` on \`sys.path\` so \`smarter_dev\` resolves; \`uv run\` additionally resolves the project at cwd \`/app\`. Only the container \`command\` changed — schedule, env, resources, backoffLimit, etc. are byte-for-byte unchanged.

## Audit

Every other \`k8s/*.yaml\` was checked for the same antipattern; none had it. \`migrate-job.yaml\` already uses this pattern; \`deploy-*.yaml\` run via image CMD / \`uv run\`; \`init-guild-job.yaml\` uses \`python -c\` (cwd on path via \`WORKDIR /app\`), a different mechanism.

## Impact

No paying members currently, so no billing impact from missed runs. Safe to fix and redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)