### PR TITLE
Fix Disboard bump notifications

### DIFF
--- a/smarter_dev/extensions/catalog/disboard_bumping/__init__.py
+++ b/smarter_dev/extensions/catalog/disboard_bumping/__init__.py
@@ -24,11 +24,9 @@ rather than a separate polling schedule handler (see the module docstring notes)
 
 from __future__ import annotations
 
-from smarter_dev.extensions.schema import (
-    ConfigField,
-    ExtensionManifest,
-    HandlerTemplate,
-)
+from smarter_dev.extensions.schema import ConfigField
+from smarter_dev.extensions.schema import ExtensionManifest
+from smarter_dev.extensions.schema import HandlerTemplate
 
 MANIFEST = ExtensionManifest(
     slug="disboard-bumping",
@@ -38,7 +36,7 @@ MANIFEST = ExtensionManifest(
         "Bump King role, reminds the server every 2 hours, and answers !bumpers "
         "/ !bumps."
     ),
-    version=1,
+    version=2,
     config=[
         ConfigField(
             name="bump_channel_id",
@@ -61,6 +59,12 @@ MANIFEST = ExtensionManifest(
             ),
         ),
         ConfigField(
+            name="bump_king_announcement_channel_id",
+            type="channel_id",
+            label="Bump King announcement channel",
+            help="Where new Bump King announcements are posted.",
+        ),
+        ConfigField(
             name="commands_channel_id",
             type="channel_id",
             label="Bump commands channel",
@@ -71,13 +75,10 @@ MANIFEST = ExtensionManifest(
         ),
         ConfigField(
             name="reminder_ping_role_id",
-            type="string",
-            required=False,
-            default="",
-            label="Reminder ping role id (optional)",
+            type="role_id",
+            label="Reminder ping role",
             help=(
-                "A role id to ping on the 2-hour reminder (e.g. a bump-squad "
-                "role). Leave blank for a silent reminder."
+                "The role pinged on every 2-hour reminder, such as a bump-squad role."
             ),
         ),
     ],
@@ -116,5 +117,6 @@ MANIFEST = ExtensionManifest(
         "bump_king_role_id": "222222222222222222",
         "commands_channel_id": "333333333333333333",
         "reminder_ping_role_id": "444444444444444444",
+        "bump_king_announcement_channel_id": "555555555555555555",
     },
 )

--- a/smarter_dev/extensions/catalog/disboard_bumping/bump_tracker.monty
+++ b/smarter_dev/extensions/catalog/disboard_bumping/bump_tracker.monty
@@ -9,6 +9,7 @@
 import datetime
 
 BUMP_CHANNEL = {{cfg.bump_channel_id}}
+BUMP_KING_ANNOUNCEMENT_CHANNEL = {{cfg.bump_king_announcement_channel_id}}
 REMINDER_PING_ROLE = {{cfg.reminder_ping_role_id}}
 DISBOARD_ID = "302050872383242240"
 REMINDER_DELAY_SECONDS = 7200
@@ -41,9 +42,9 @@ def top_bumper(bumps):
 
 async def send_reminder():
     text = "It's been 2 hours since the last bump — run /bump to keep us at the top of Disboard!"
-    if REMINDER_PING_ROLE:
-        return await send_message(text, BUMP_CHANNEL, REMINDER_PING_ROLE)
-    return await send_message(text, BUMP_CHANNEL)
+    return await send_message(
+        f"<@&{REMINDER_PING_ROLE}> {text}", BUMP_CHANNEL, REMINDER_PING_ROLE
+    )
 
 
 async def run():
@@ -109,7 +110,10 @@ async def run():
             await remove_role(previous_king, {{cfg.bump_king_role_id}})
         await add_role(new_king, {{cfg.bump_king_role_id}})
         await guild_memory_set("disboard_king_id", new_king)
-        await send_message(f"👑 <@{new_king}> is the new Bump King!", BUMP_CHANNEL)
+        await send_message(
+            f"👑 <@{new_king}> is the new Bump King!",
+            BUMP_KING_ANNOUNCEMENT_CHANNEL,
+        )
 
     # Arm the one-shot reminder for 2 hours after this bump.
     await schedule_timer(REMINDER_DELAY_SECONDS, {"bump_at": now})

--- a/tests/test_disboard_bumping_extension.py
+++ b/tests/test_disboard_bumping_extension.py
@@ -18,15 +18,16 @@ mid-edit).
 from __future__ import annotations
 
 import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass
+from dataclasses import field
 from pathlib import Path
 
+import pytest
+
 from smarter_dev.extensions.catalog.disboard_bumping import MANIFEST
-from smarter_dev.extensions.rendering import (
-    extract_granted_role_literals,
-    render_bundle,
-)
-from smarter_dev.web.admin_actions import AdminActor
+from smarter_dev.extensions.rendering import RenderError
+from smarter_dev.extensions.rendering import extract_granted_role_literals
+from smarter_dev.extensions.rendering import render_bundle
 from smarter_dev.web.handler_budget import admin_budget
 from smarter_dev.web.handler_lint import lint_script
 from smarter_dev.web.handler_runtime import run_handler_script
@@ -36,6 +37,7 @@ _BUMP_CHANNEL = "111111111111111111"
 _CROWN_ROLE = "222222222222222222"
 _COMMANDS_CHANNEL = "333333333333333333"
 _PING_ROLE = "444444444444444444"
+_ANNOUNCEMENT_CHANNEL = "555555555555555555"
 
 _PACKAGE_DIR = Path(__file__).resolve().parents[1] / (
     "smarter_dev/extensions/catalog/disboard_bumping"
@@ -190,12 +192,11 @@ def test_commands_scoped_off_the_bump_channel():
     assert commands.channel_ids != [_BUMP_CHANNEL]
 
 
-def test_optional_ping_role_renders_empty_when_blank():
+def test_reminder_ping_role_is_required_and_typed():
     config = dict(MANIFEST.example_config)
     config["reminder_ping_role_id"] = ""
-    tracker = _rendered(config)["bump-tracker"]
-    assert 'REMINDER_PING_ROLE = ""' in tracker.script
-    assert lint_script(tracker.script) is None
+    with pytest.raises(RenderError, match="must be a Discord id"):
+        _rendered(config)
 
 
 # -- layer 2: tracker detection ------------------------------------------------
@@ -224,6 +225,10 @@ async def test_confirmed_bump_credits_ledger_crowns_and_arms_reminder():
     assert ("add_role", "USERA", _CROWN_ROLE) in actor.calls
     assert writes["disboard_king_id"] == "USERA"
     assert any("Bump King" in content for _, content in emitter.messages)
+    king_announcement = next(
+        message for message in emitter.messages if "Bump King" in message[1]
+    )
+    assert king_announcement[0] == _ANNOUNCEMENT_CHANNEL
     # No stray deletes (no prior reminder/confirmation), and the reminder armed.
     assert not any(call[0] == "delete" for call in actor.calls)
     assert len(timer.calls) == 1
@@ -363,25 +368,9 @@ async def test_timer_refire_posts_reminder_and_pings_role_when_configured():
     assert emitter.message_calls == [
         (_BUMP_CHANNEL, emitter.messages[0][1], _PING_ROLE)
     ]
+    assert f"<@&{_PING_ROLE}>" in emitter.messages[0][1]
     assert result.guild_memory_writes["disboard_reminded"] is True
     assert "disboard_reminder_message_id" in result.guild_memory_writes
-
-
-async def test_timer_refire_silent_reminder_when_no_ping_role():
-    now = int(time.time())
-    config = dict(MANIFEST.example_config)
-    config["reminder_ping_role_id"] = ""
-    seed = {"disboard_last_bump_at": now, "disboard_reminded": False}
-    context = {
-        "trigger_type": "timer",
-        "payload": {"bump_at": now},
-        "scheduled_at": "2026-07-21T00:00:00+00:00",
-    }
-    result, emitter, actor, timer = await _run_tracker(
-        context, guild_memory=seed, config=config
-    )
-    assert result.outcome == "ok", result.error
-    assert emitter.message_calls[0][2] is None  # no role pinged
 
 
 async def test_stale_timer_does_not_remind_when_a_newer_bump_arrived():


### PR DESCRIPTION
## Summary
- include the configured role mention in two-hour bump reminders
- route Bump King announcements to a dedicated configured channel
- require typed role/channel configuration and bump the extension to version 2

## Root cause
The reminder allowlisted a role mention without including the Discord role mention token, and Bump King announcements were hardcoded to the bump channel.

## Validation
- `uv run pytest tests/test_disboard_bumping_extension.py tests/test_extension_registry.py -q --no-cov`
- `uv run ruff check smarter_dev/extensions/catalog/disboard_bumping/__init__.py tests/test_disboard_bumping_extension.py`
- `uv run ruff format --check smarter_dev/extensions/catalog/disboard_bumping/__init__.py tests/test_disboard_bumping_extension.py`