### PR TITLE
Warm the LaTeX renderer before chatbot replies

### DIFF
--- a/latex_renderer/worker.mjs
+++ b/latex_renderer/worker.mjs
@@ -13,6 +13,8 @@ const jax = await mathjax.init({
   },
 });
 
+process.stdout.write(`${JSON.stringify({ ready: true })}\n`);
+
 async function render(source) {
   if (typeof source !== "string" || source.length === 0) {
     throw new Error("LaTeX source must not be empty");

--- a/smarter_dev/bot/client.py
+++ b/smarter_dev/bot/client.py
@@ -614,6 +614,15 @@ async def setup_bot_services(bot: lightbulb.BotApp) -> None:
         await model_override_service.initialize()
         logger.info("✓ Model override service initialized")
 
+        logger.info("Initializing LaTeX renderer...")
+        try:
+            await latex_renderer.initialize()
+            logger.info("✓ LaTeX renderer initialized")
+        except Exception:
+            logger.exception(
+                "LaTeX renderer warmup failed — fenced equations will retry lazily"
+            )
+
         # Verify service health
         logger.info("Verifying service health...")
         try:

--- a/smarter_dev/bot/services/latex_renderer.py
+++ b/smarter_dev/bot/services/latex_renderer.py
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 MAX_LATEX_SOURCE_CHARS = 1_800
 MAX_RENDERED_BYTES = 8 * 1024 * 1024
 RENDER_TIMEOUT_SECONDS = 5.0
+STARTUP_TIMEOUT_SECONDS = 30.0
 
 
 class LatexRenderError(RuntimeError):
@@ -38,15 +39,21 @@ class LatexRenderer:
         worker_path: Path | None = None,
         *,
         timeout_seconds: float = RENDER_TIMEOUT_SECONDS,
+        startup_timeout_seconds: float = STARTUP_TIMEOUT_SECONDS,
     ) -> None:
         repository_root = Path(__file__).resolve().parents[3]
         self.worker_path = worker_path or (
             repository_root / "latex_renderer" / "worker.mjs"
         )
         self.timeout_seconds = timeout_seconds
+        self.startup_timeout_seconds = startup_timeout_seconds
         self._process: asyncio.subprocess.Process | None = None
         self._lock = asyncio.Lock()
         self._next_id = 0
+
+    async def initialize(self) -> None:
+        """Start the worker and exercise the full render path before serving chat."""
+        await self.render("x")
 
     async def render(self, source: str) -> RenderedLatex:
         """Render ``source`` as PNG, restarting the worker after protocol errors."""
@@ -124,6 +131,23 @@ class LatexRenderer:
         except OSError as exc:
             raise LatexRenderError("LaTeX renderer could not start") from exc
         self._process = process
+        try:
+            assert process.stdout is not None
+            line = await asyncio.wait_for(
+                process.stdout.readline(),
+                timeout=self.startup_timeout_seconds,
+            )
+            response: dict[str, Any] = json.loads(line)
+        except TimeoutError as exc:
+            await self._stop_process()
+            raise LatexRenderError("LaTeX renderer startup timed out") from exc
+        except (EOFError, json.JSONDecodeError) as exc:
+            await self._stop_process()
+            raise LatexRenderError("LaTeX renderer failed during startup") from exc
+        if response != {"ready": True}:
+            await self._stop_process()
+            raise LatexRenderError("LaTeX renderer returned invalid startup data")
+        logger.info("LaTeX renderer worker is ready")
         return process
 
     async def _stop_process(self) -> None:

--- a/tests/bot/services/test_chat_engine_latex.py
+++ b/tests/bot/services/test_chat_engine_latex.py
@@ -186,3 +186,35 @@ async def test_real_worker_renders_png_when_node_dependencies_are_installed():
 
     assert result.mime_type == "image/png"
     assert result.data.startswith(b"\x89PNG\r\n\x1a\n")
+
+
+@pytest.mark.asyncio
+async def test_worker_startup_has_a_separate_readiness_timeout(tmp_path):
+    worker = tmp_path / "slow-worker.mjs"
+    worker.write_text(
+        """
+import { createInterface } from "node:readline";
+await new Promise(resolve => setTimeout(resolve, 75));
+process.stdout.write(JSON.stringify({ready: true}) + "\\n");
+const lines = createInterface({input: process.stdin, crlfDelay: Infinity});
+for await (const line of lines) {
+  const request = JSON.parse(line);
+  process.stdout.write(JSON.stringify({
+    id: request.id,
+    png: Buffer.from("PNG").toString("base64"),
+  }) + "\\n");
+}
+""",
+        encoding="utf-8",
+    )
+    renderer = LatexRenderer(
+        worker_path=worker,
+        timeout_seconds=0.05,
+        startup_timeout_seconds=1.0,
+    )
+    try:
+        result = await renderer.render("x")
+    finally:
+        await renderer.close()
+
+    assert result.data == b"PNG"


### PR DESCRIPTION
## Root cause

The production bot parsed `latex` fences correctly, but the first request included MathJax's cold startup time. On the production pod that exceeded the five-second per-render timeout, killed the worker, and triggered the raw-source fallback.

## Fix

- make the Node worker emit an explicit readiness message after MathJax initialization
- give worker startup its own 30-second timeout
- keep the five-second timeout for actual render requests after readiness
- perform a real warmup render during bot service initialization
- retry lazily if startup warmup fails instead of preventing the bot from starting

## Validation

- readiness-timeout regression test passes with a deliberately slow-starting worker
- real MathJax/Sharp worker render test passes
- full fenced-LaTeX feature suite passes
- Ruff, Node syntax check, `npm audit`, and `git diff --check` pass